### PR TITLE
feat: wire up power-user features (6 commits)

### DIFF
--- a/BetterCmdTab/App/AppDelegate.swift
+++ b/BetterCmdTab/App/AppDelegate.swift
@@ -26,6 +26,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         BetterShortcuts.installDisplayNames()
+        DirectActivation.installHandlers()
         #if DEBUG
         // In Debug builds always show the menu bar icon, regardless of the
         // saved preference — otherwise a hidden icon leaves no way to reach

--- a/BetterCmdTab/App/AppShortcuts.swift
+++ b/BetterCmdTab/App/AppShortcuts.swift
@@ -10,17 +10,33 @@ import BetterShortcuts
 extension BetterShortcuts.Name {
     static let switchApps = Self("switchApps", default: .init(.tab, modifiers: .command))
     static let switchWindows = Self("switchWindows", default: .init(.backtick, modifiers: .command))
+
+    /// Number of direct-activation slots. Mirrors `Preferences.directActivationSlotCount`.
+    static let directActivateSlotCount = 9
+
+    /// "Jump straight to this app" hotkeys, slot 1…N. No defaults — these are
+    /// live Carbon hotkeys (unlike the switcher triggers): a handler registered
+    /// via `BetterShortcuts.onKeyDown` fires them, so the user assigns the combo.
+    static let directActivate: [Self] = (1...directActivateSlotCount).map { Self("directActivate\($0)") }
+
+    /// The raw-value prefix shared by every `directActivate` slot name.
+    static let directActivatePrefix = "directActivate"
 }
 
 extension BetterShortcuts.Name: @retroactive CaseIterable {
-    public static var allCases: [Self] { [.switchApps, .switchWindows] }
+    public static var allCases: [Self] { [.switchApps, .switchWindows] + directActivate }
 
     /// Human-readable label used by the recorder's conflict alert.
     var displayName: String {
         switch self {
         case .switchApps: return "Switch apps"
         case .switchWindows: return "Switch windows"
-        default: return rawValue
+        default:
+            if rawValue.hasPrefix(Self.directActivatePrefix) {
+                let slot = rawValue.dropFirst(Self.directActivatePrefix.count)
+                return "Direct activation \(slot)"
+            }
+            return rawValue
         }
     }
 }

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -58,6 +58,10 @@ enum SwitcherAccent: String, CaseIterable {
     case yellow
     case green
     case graphite
+    /// User-supplied color; the actual value lives in `Preferences.customAccentHex`.
+    /// Resolve via `Preferences.shared.resolvedAccent`, not `resolved`, so the hex
+    /// is read on the main actor.
+    case custom
 
     var displayName: String {
         switch self {
@@ -70,13 +74,14 @@ enum SwitcherAccent: String, CaseIterable {
         case .yellow: return "Yellow"
         case .green: return "Green"
         case .graphite: return "Graphite"
+        case .custom: return "Custom…"
         }
     }
 
-    /// Fixed color, or `nil` when the choice tracks the system accent.
+    /// Fixed color, or `nil` when the choice tracks the system accent or is custom.
     var color: NSColor? {
         switch self {
-        case .system: return nil
+        case .system, .custom: return nil
         case .blue: return .systemBlue
         case .purple: return .systemPurple
         case .pink: return .systemPink
@@ -89,8 +94,92 @@ enum SwitcherAccent: String, CaseIterable {
     }
 
     /// The concrete color to draw with right now. Resolving `.system` lazily
-    /// keeps it appearance-reactive (light/dark) like the rest of AppKit.
+    /// keeps it appearance-reactive (light/dark) like the rest of AppKit. For
+    /// `.custom` this falls back to the system accent — use
+    /// `Preferences.shared.resolvedAccent` to honor the stored hex.
     var resolved: NSColor { color ?? .controlAccentColor }
+}
+
+/// Background material for the switcher panel (the blur behind the rows). Maps to
+/// an `NSVisualEffectView.Material`; the macOS 26 glass backdrop ignores it.
+enum BackdropMaterial: String, CaseIterable {
+    case hud
+    case sidebar
+    case menu
+    case popover
+    case fullScreen
+    case underWindow
+
+    var displayName: String {
+        switch self {
+        case .hud: return "HUD (default)"
+        case .sidebar: return "Sidebar"
+        case .menu: return "Menu"
+        case .popover: return "Popover"
+        case .fullScreen: return "Full Screen"
+        case .underWindow: return "Under Window"
+        }
+    }
+
+    var material: NSVisualEffectView.Material {
+        switch self {
+        case .hud: return .hudWindow
+        case .sidebar: return .sidebar
+        case .menu: return .menu
+        case .popover: return .popover
+        case .fullScreen: return .fullScreenUI
+        case .underWindow: return .underWindowBackground
+        }
+    }
+}
+
+extension NSColor {
+    /// Parses `#RRGGBB` / `RRGGBB` (and the 8-digit `#RRGGBBAA` form). Returns
+    /// `nil` for malformed input so callers can fall back to a default.
+    convenience init?(hexString: String) {
+        var hex = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") { hex.removeFirst() }
+        guard hex.count == 6 || hex.count == 8,
+              let value = UInt64(hex, radix: 16) else { return nil }
+        let r, g, b, a: CGFloat
+        if hex.count == 8 {
+            r = CGFloat((value >> 24) & 0xFF) / 255
+            g = CGFloat((value >> 16) & 0xFF) / 255
+            b = CGFloat((value >> 8) & 0xFF) / 255
+            a = CGFloat(value & 0xFF) / 255
+        } else {
+            r = CGFloat((value >> 16) & 0xFF) / 255
+            g = CGFloat((value >> 8) & 0xFF) / 255
+            b = CGFloat(value & 0xFF) / 255
+            a = 1
+        }
+        self.init(srgbRed: r, green: g, blue: b, alpha: a)
+    }
+
+    /// `#RRGGBB` string in the sRGB space; nil if the color can't be converted.
+    var hexString: String? {
+        guard let rgb = usingColorSpace(.sRGB) else { return nil }
+        let r = Int(round(rgb.redComponent * 255))
+        let g = Int(round(rgb.greenComponent * 255))
+        let b = Int(round(rgb.blueComponent * 255))
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}
+
+/// What a three-finger horizontal trackpad swipe does (when the experimental
+/// swipe trigger is enabled).
+enum SwipeMode: String, CaseIterable {
+    /// Open the switcher and scrub through apps (the original behavior).
+    case openSwitcher
+    /// Switch to the Space on the left/right, one per swipe step.
+    case switchSpaces
+
+    var displayName: String {
+        switch self {
+        case .openSwitcher: return "Open switcher"
+        case .switchSpaces: return "Switch Spaces"
+        }
+    }
 }
 
 /// Overall size multiplier applied to the switcher panel (icons, text, spacing).
@@ -129,6 +218,15 @@ final class Preferences: ObservableObject {
     static let defaultSwipeSensitivity = 5
     static let swipeSensitivityRange: ClosedRange<Int> = 1...10
 
+    static let panelOpacityRange: ClosedRange<Int> = 30...100
+    /// `0` means "automatic" (track the size-derived metric); above that the
+    /// user pins an explicit radius in points.
+    static let panelCornerRadiusRange: ClosedRange<Int> = 0...40
+
+    /// Number of direct-activation hotkey slots. Each slot binds a recorded
+    /// shortcut (stored by BetterShortcuts) to a target app bundle ID.
+    static let directActivationSlotCount = 9
+
     // Internal (not private): `CatalogFilter` reads the catalog-related keys
     // directly from `UserDefaults` off the main actor, so the key strings must
     // be shared rather than duplicated.
@@ -153,6 +251,7 @@ final class Preferences: ObservableObject {
         static let accentChoice = "Switcher.accentChoice"
         static let hideMenuBarIcon = "Switcher.hideMenuBarIcon"
         static let experimentalSwipeTrigger = "Switcher.experimentalSwipeTrigger"
+        static let swipeMode = "Switcher.swipeMode"
         static let swipeReverseDirection = "Switcher.swipeReverseDirection"
         static let swipeCommitOnRelease = "Switcher.swipeCommitOnRelease"
         static let swipeSensitivity = "Switcher.swipeSensitivity"
@@ -163,6 +262,20 @@ final class Preferences: ObservableObject {
         /// Pre-graduation key (badges used to live behind the Experimental tab);
         /// read once at launch to carry a user's earlier choice over to the new key.
         static let legacyUnreadBadges = "Switcher.experimentalUnreadBadges"
+        static let showWindowTitleLabel = "Switcher.showWindowTitleLabel"
+        static let panelOpacity = "Switcher.panelOpacity"
+        static let panelCornerRadius = "Switcher.panelCornerRadius"
+        static let customAccentHex = "Switcher.customAccentHex"
+        static let backdropMaterial = "Switcher.backdropMaterial"
+        static let currentSpaceOnly = "Switcher.currentSpaceOnly"
+        static let experimentalMoveToSpace = "Switcher.experimentalMoveToSpace"
+        static let directActivationBindings = "Switcher.directActivationBindings"
+        static let hoverActionsEnabled = "Switcher.hoverActionsEnabled"
+        static let hoverShowClose = "Switcher.hoverShowClose"
+        static let hoverShowMinimize = "Switcher.hoverShowMinimize"
+        static let hoverShowMaximize = "Switcher.hoverShowMaximize"
+        static let hoverShowHide = "Switcher.hoverShowHide"
+        static let hoverShowQuit = "Switcher.hoverShowQuit"
     }
 
     @Published var switcherLayoutMode: SwitcherLayoutMode {
@@ -339,6 +452,15 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// What the three-finger swipe does: open the switcher (default) or switch
+    /// Spaces left/right. Only meaningful while `experimentalSwipeTrigger` is on.
+    @Published var swipeMode: SwipeMode {
+        didSet {
+            guard oldValue != swipeMode else { return }
+            UserDefaults.standard.set(swipeMode.rawValue, forKey: Keys.swipeMode)
+        }
+    }
+
     /// When false (default), sliding fingers right moves the selection right;
     /// when true the axis is flipped. Only affects the three-finger swipe.
     @Published var swipeReverseDirection: Bool {
@@ -411,12 +533,157 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Show the per-window title label under the icon in Grid and Previews
+    /// layouts. Default on. (No effect on the List layout, which always shows it.)
+    @Published var showWindowTitleLabel: Bool {
+        didSet {
+            guard oldValue != showWindowTitleLabel else { return }
+            UserDefaults.standard.set(showWindowTitleLabel, forKey: Keys.showWindowTitleLabel)
+        }
+    }
+
+    /// Panel opacity as a 30–100 percentage. Default 100 (fully opaque).
+    @Published var panelOpacity: Int {
+        didSet {
+            let clamped = Self.clampOpacity(panelOpacity)
+            if clamped != panelOpacity { panelOpacity = clamped; return }
+            guard oldValue != panelOpacity else { return }
+            UserDefaults.standard.set(panelOpacity, forKey: Keys.panelOpacity)
+        }
+    }
+
+    /// Explicit panel corner radius in points; `0` = automatic (size-derived).
+    @Published var panelCornerRadius: Int {
+        didSet {
+            let clamped = Self.clampCornerRadius(panelCornerRadius)
+            if clamped != panelCornerRadius { panelCornerRadius = clamped; return }
+            guard oldValue != panelCornerRadius else { return }
+            UserDefaults.standard.set(panelCornerRadius, forKey: Keys.panelCornerRadius)
+        }
+    }
+
+    /// `#RRGGBB` used when `accentChoice == .custom`. `nil` until the user picks one.
+    @Published var customAccentHex: String? {
+        didSet {
+            guard oldValue != customAccentHex else { return }
+            UserDefaults.standard.set(customAccentHex, forKey: Keys.customAccentHex)
+        }
+    }
+
+    /// Background blur material for the panel (NSVisualEffectView fallback path).
+    @Published var backdropMaterial: BackdropMaterial {
+        didSet {
+            guard oldValue != backdropMaterial else { return }
+            UserDefaults.standard.set(backdropMaterial.rawValue, forKey: Keys.backdropMaterial)
+        }
+    }
+
+    /// Show only windows that live on the currently active Space. Default off.
+    /// Reads window Space membership via the same private APIs as instant Space
+    /// switching; degrades to showing everything when those are unavailable.
+    @Published var currentSpaceOnly: Bool {
+        didSet {
+            guard oldValue != currentSpaceOnly else { return }
+            UserDefaults.standard.set(currentSpaceOnly, forKey: Keys.currentSpaceOnly)
+        }
+    }
+
+    /// Experimental: allow ⌘⇧← / ⌘⇧→ to move the highlighted window to the
+    /// adjacent Space (private SkyLight APIs). Off by default — fragile.
+    /// Display moves (⌘⇧↑ / ⌘⇧↓ and across monitors) use stable AX APIs and are
+    /// always available. [[experimental-features]]
+    @Published var experimentalMoveToSpace: Bool {
+        didSet {
+            guard oldValue != experimentalMoveToSpace else { return }
+            UserDefaults.standard.set(experimentalMoveToSpace, forKey: Keys.experimentalMoveToSpace)
+        }
+    }
+
+    /// Target app bundle IDs for the direct-activation hotkey slots. Index maps
+    /// to the slot number (0 = slot 1). An empty string means the slot is unset.
+    /// Always normalized to `directActivationSlotCount` entries.
+    @Published var directActivationBindings: [String] {
+        didSet {
+            let normalized = Self.normalizeBindings(directActivationBindings)
+            if normalized != directActivationBindings { directActivationBindings = normalized; return }
+            guard oldValue != directActivationBindings else { return }
+            UserDefaults.standard.set(directActivationBindings, forKey: Keys.directActivationBindings)
+        }
+    }
+
+    /// Master switch for the hover action buttons shown on each switcher row.
+    /// Default off. Per-button visibility lives in `hoverShow*`.
+    @Published var hoverActionsEnabled: Bool {
+        didSet {
+            guard oldValue != hoverActionsEnabled else { return }
+            UserDefaults.standard.set(hoverActionsEnabled, forKey: Keys.hoverActionsEnabled)
+        }
+    }
+
+    @Published var hoverShowClose: Bool {
+        didSet {
+            guard oldValue != hoverShowClose else { return }
+            UserDefaults.standard.set(hoverShowClose, forKey: Keys.hoverShowClose)
+        }
+    }
+
+    @Published var hoverShowMinimize: Bool {
+        didSet {
+            guard oldValue != hoverShowMinimize else { return }
+            UserDefaults.standard.set(hoverShowMinimize, forKey: Keys.hoverShowMinimize)
+        }
+    }
+
+    @Published var hoverShowMaximize: Bool {
+        didSet {
+            guard oldValue != hoverShowMaximize else { return }
+            UserDefaults.standard.set(hoverShowMaximize, forKey: Keys.hoverShowMaximize)
+        }
+    }
+
+    @Published var hoverShowHide: Bool {
+        didSet {
+            guard oldValue != hoverShowHide else { return }
+            UserDefaults.standard.set(hoverShowHide, forKey: Keys.hoverShowHide)
+        }
+    }
+
+    @Published var hoverShowQuit: Bool {
+        didSet {
+            guard oldValue != hoverShowQuit else { return }
+            UserDefaults.standard.set(hoverShowQuit, forKey: Keys.hoverShowQuit)
+        }
+    }
+
+    /// Concrete accent color honoring the `.custom` choice (reads `customAccentHex`).
+    var resolvedAccent: NSColor {
+        if accentChoice == .custom, let hex = customAccentHex, let color = NSColor(hexString: hex) {
+            return color
+        }
+        return accentChoice.resolved
+    }
+
     static func clampDelay(_ value: Int) -> Int {
         min(revealDelayRange.upperBound, max(revealDelayRange.lowerBound, value))
     }
 
     static func clampSwipeSensitivity(_ value: Int) -> Int {
         min(swipeSensitivityRange.upperBound, max(swipeSensitivityRange.lowerBound, value))
+    }
+
+    static func clampOpacity(_ value: Int) -> Int {
+        min(panelOpacityRange.upperBound, max(panelOpacityRange.lowerBound, value))
+    }
+
+    static func clampCornerRadius(_ value: Int) -> Int {
+        min(panelCornerRadiusRange.upperBound, max(panelCornerRadiusRange.lowerBound, value))
+    }
+
+    /// Pads/truncates to exactly `directActivationSlotCount` entries.
+    static func normalizeBindings(_ value: [String]) -> [String] {
+        var out = Array(value.prefix(directActivationSlotCount))
+        while out.count < directActivationSlotCount { out.append("") }
+        return out
     }
 
     private init() {
@@ -457,6 +724,8 @@ final class Preferences: ObservableObject {
         self.hideMenuBarIcon = defaults.object(forKey: Keys.hideMenuBarIcon) as? Bool ?? false
 
         self.experimentalSwipeTrigger = defaults.object(forKey: Keys.experimentalSwipeTrigger) as? Bool ?? false
+        let swipeModeRaw = defaults.string(forKey: Keys.swipeMode)
+        self.swipeMode = swipeModeRaw.flatMap(SwipeMode.init(rawValue:)) ?? .openSwitcher
         self.swipeReverseDirection = defaults.object(forKey: Keys.swipeReverseDirection) as? Bool ?? false
         self.swipeCommitOnRelease = defaults.object(forKey: Keys.swipeCommitOnRelease) as? Bool ?? false
         let sensitivity = defaults.object(forKey: Keys.swipeSensitivity) as? Int ?? Self.defaultSwipeSensitivity
@@ -474,5 +743,23 @@ final class Preferences: ObservableObject {
         } else {
             self.showUnreadBadges = true
         }
+
+        self.showWindowTitleLabel = defaults.object(forKey: Keys.showWindowTitleLabel) as? Bool ?? true
+        let opacity = defaults.object(forKey: Keys.panelOpacity) as? Int ?? 100
+        self.panelOpacity = Self.clampOpacity(opacity)
+        let radius = defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0
+        self.panelCornerRadius = Self.clampCornerRadius(radius)
+        self.customAccentHex = defaults.string(forKey: Keys.customAccentHex)
+        let materialRaw = defaults.string(forKey: Keys.backdropMaterial)
+        self.backdropMaterial = materialRaw.flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
+        self.currentSpaceOnly = defaults.object(forKey: Keys.currentSpaceOnly) as? Bool ?? false
+        self.experimentalMoveToSpace = defaults.object(forKey: Keys.experimentalMoveToSpace) as? Bool ?? false
+        self.directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
+        self.hoverActionsEnabled = defaults.object(forKey: Keys.hoverActionsEnabled) as? Bool ?? false
+        self.hoverShowClose = defaults.object(forKey: Keys.hoverShowClose) as? Bool ?? true
+        self.hoverShowMinimize = defaults.object(forKey: Keys.hoverShowMinimize) as? Bool ?? true
+        self.hoverShowMaximize = defaults.object(forKey: Keys.hoverShowMaximize) as? Bool ?? true
+        self.hoverShowHide = defaults.object(forKey: Keys.hoverShowHide) as? Bool ?? true
+        self.hoverShowQuit = defaults.object(forKey: Keys.hoverShowQuit) as? Bool ?? true
     }
 }

--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -15,10 +15,11 @@ enum CatalogFilter {
         let showMinimized: Bool
         let showHidden: Bool
         let showWindowless: Bool
+        let currentSpaceOnly: Bool
 
         /// No filtering and no reordering — lets callers skip work entirely.
         var isIdentity: Bool {
-            excluded.isEmpty && pinned.isEmpty && showMinimized && showHidden && showWindowless
+            excluded.isEmpty && pinned.isEmpty && showMinimized && showHidden && showWindowless && !currentSpaceOnly
         }
     }
 
@@ -29,7 +30,8 @@ enum CatalogFilter {
             pinned: defaults.stringArray(forKey: Preferences.Keys.pinnedBundleIDs) ?? [],
             showMinimized: defaults.object(forKey: Preferences.Keys.showMinimizedWindows) as? Bool ?? true,
             showHidden: defaults.object(forKey: Preferences.Keys.showHiddenApps) as? Bool ?? true,
-            showWindowless: defaults.object(forKey: Preferences.Keys.showWindowlessApps) as? Bool ?? true
+            showWindowless: defaults.object(forKey: Preferences.Keys.showWindowlessApps) as? Bool ?? true,
+            currentSpaceOnly: defaults.object(forKey: Preferences.Keys.currentSpaceOnly) as? Bool ?? false
         )
     }
 
@@ -38,13 +40,41 @@ enum CatalogFilter {
     /// are never filtered or reordered.
     static func filteredRows(_ rows: [SwitcherRow], _ cfg: Config) -> [SwitcherRow] {
         if cfg.isIdentity { return rows }
-        let filtered = rows.filter {
+        var filtered = rows.filter {
             includes(bundleID: $0.bundleIdentifier, isPlaceholder: $0.isPlaceholder, isMinimized: $0.isMinimized, appHidden: $0.isHidden, hasWindow: $0.window != nil, cfg)
         }
-        guard !cfg.pinned.isEmpty else { return filtered }
-        return stablePartition(filtered) { row in
-            row.isPlaceholder ? nil : row.bundleIdentifier.flatMap { cfg.pinned.firstIndex(of: $0) }
+        if !cfg.pinned.isEmpty {
+            filtered = stablePartition(filtered) { row in
+                row.isPlaceholder ? nil : row.bundleIdentifier.flatMap { cfg.pinned.firstIndex(of: $0) }
+            }
         }
+        if cfg.currentSpaceOnly {
+            filtered = filterToCurrentSpace(filtered)
+        }
+        return filtered
+    }
+
+    /// Drop windows that live on a Space other than the one in focus. Rows
+    /// without a real window (windowless apps, launchables, recents) and any
+    /// window whose Space can't be resolved are kept, so the filter only ever
+    /// hides windows it's certain are elsewhere. Degrades to a no-op when the
+    /// private Space APIs are unavailable.
+    private static func filterToCurrentSpace(_ rows: [SwitcherRow]) -> [SwitcherRow] {
+        guard let active = PrivateAPI.activeSpace() else { return rows }
+        let widByOffset: [(offset: Int, wid: CGWindowID)] = rows.enumerated().compactMap { idx, row in
+            guard let window = row.window else { return nil }
+            let wid = PrivateAPI.cgWindowId(of: window)
+            return wid == 0 ? nil : (idx, wid)
+        }
+        guard !widByOffset.isEmpty else { return rows }
+        let spaceByWindow = PrivateAPI.spaces(forWindows: widByOffset.map(\.wid))
+        guard !spaceByWindow.isEmpty else { return rows }
+        var dropOffsets = Set<Int>()
+        for (offset, wid) in widByOffset {
+            if let space = spaceByWindow[wid], space != active { dropOffsets.insert(offset) }
+        }
+        if dropOffsets.isEmpty { return rows }
+        return rows.enumerated().filter { !dropOffsets.contains($0.offset) }.map(\.element)
     }
 
     /// Row-level inclusion test split out so it can be unit-tested without

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -12,6 +12,10 @@ final class HotkeyTap {
         case prevRow
         case spatialLeft
         case spatialRight
+        case moveWindowLeft
+        case moveWindowRight
+        case moveWindowUp
+        case moveWindowDown
         case releaseCmd
         case commit
         case escape
@@ -317,6 +321,11 @@ final class HotkeyTap {
         // The switcher stays open while either trigger's hold modifier is down.
         let anyModHeld = appModHeld || windowModHeld
         let shiftHeld = flags.contains(.maskShift)
+        // Option + arrow (while the switcher is open) moves the highlighted
+        // window between displays/Spaces instead of moving the selection. Option
+        // is used rather than Shift because Shift already steps the selection
+        // backwards (see the flagsChanged handler below).
+        let optionHeld = flags.contains(.maskAlternate)
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
 
         if type == .keyDown {
@@ -369,13 +378,13 @@ final class HotkeyTap {
                 } else {
                     switch keyCode {
                     case Self.leftArrow:
-                        deliver(.spatialLeft); return nil
+                        deliver(optionHeld ? .moveWindowLeft : .spatialLeft); return nil
                     case Self.rightArrow:
-                        deliver(.spatialRight); return nil
+                        deliver(optionHeld ? .moveWindowRight : .spatialRight); return nil
                     case Self.upArrow:
-                        deliver(.prevRow); return nil
+                        deliver(optionHeld ? .moveWindowUp : .prevRow); return nil
                     case Self.downArrow:
-                        deliver(.nextRow); return nil
+                        deliver(optionHeld ? .moveWindowDown : .nextRow); return nil
                     case Self.returnKey, Self.keypadEnterKey, Self.spaceKey:
                         deliver(.commit); return nil
                     case Self.escKey:

--- a/BetterCmdTab/Input/SwipeTrigger.swift
+++ b/BetterCmdTab/Input/SwipeTrigger.swift
@@ -58,6 +58,12 @@ final class SwipeTrigger {
         MTGesture.stepDistance = MTGesture.stepDistance(forLevel: level)
     }
 
+    func setOneShot(_ oneShot: Bool) {
+        MTGesture.oneShot = oneShot
+        MTGesture.fired = false
+        MTGesture.accumulator = 0
+    }
+
     private func install() {
         guard devices.isEmpty else { return }
         guard let api = MultitouchAPI.shared else {
@@ -214,10 +220,18 @@ private enum MTGesture {
     nonisolated(unsafe) static var reverse = false
     nonisolated(unsafe) static var commitOnRelease = false
 
+    nonisolated(unsafe) static var oneShot = false
+    /// Set once a one-shot gesture has fired; cleared only when all fingers lift,
+    /// so a single swipe switches exactly one Space.
+    nonisolated(unsafe) static var fired = false
+    /// Normalized horizontal travel needed to trigger a one-shot Space switch.
+    static let oneShotThreshold: Float = 0.08
+
     static func reset() {
         active = false
         tracking = false
         accumulator = 0
+        fired = false
     }
 }
 
@@ -274,9 +288,25 @@ private func multitouchSwipeCallback(
         MTGesture.accumulator += avgX - MTGesture.lastX
         MTGesture.lastX = avgX
 
-        let step = MTGesture.stepDistance
         // Default: moving right (+x) advances the selection right (+1).
         let rightward = MTGesture.reverse ? -1 : 1
+
+        if MTGesture.oneShot {
+            // One Space jump per swipe: fire once past the fixed threshold, then
+            // latch until all fingers lift (handled below). Sensitivity ignored.
+            if !MTGesture.fired {
+                if MTGesture.accumulator >= MTGesture.oneShotThreshold {
+                    MTGesture.fired = true
+                    mtEmitStep(rightward)
+                } else if MTGesture.accumulator <= -MTGesture.oneShotThreshold {
+                    MTGesture.fired = true
+                    mtEmitStep(-rightward)
+                }
+            }
+            return 0
+        }
+
+        let step = MTGesture.stepDistance
         while MTGesture.accumulator >= step {
             MTGesture.accumulator -= step
             mtEmitStep(rightward)
@@ -297,6 +327,8 @@ private func multitouchSwipeCallback(
         }
         MTGesture.active = false
         MTGesture.accumulator = 0
+        // Re-arm one-shot mode so the next swipe can switch another Space.
+        MTGesture.fired = false
     }
     return 0
 }

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -11,6 +11,11 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     private let accentPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let delaySlider = NSSlider()
     private let delayValueLabel = NSTextField(labelWithString: "")
+    private let windowTitleSwitch = NSSwitch()
+    private let opacitySlider = NSSlider()
+    private let opacityValueLabel = NSTextField(labelWithString: "")
+    private let radiusSlider = NSSlider()
+    private let radiusValueLabel = NSTextField(labelWithString: "")
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -66,6 +71,61 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         addRow(to: section, title: "Quick-switch delay",
                subtitle: "Tap to switch instantly; hold longer to open the switcher.",
                accessory: sliderStack, searchItemID: SearchID.quickSwitchDelay)
+
+        configureSwitch(windowTitleSwitch, action: #selector(toggleWindowTitle(_:)))
+        addRow(to: section, title: "Show window title",
+               subtitle: "Show each window's title under the icon in the Grid and Previews layouts.",
+               accessory: windowTitleSwitch, searchItemID: SearchID.windowTitle)
+
+        let opacityStack = makeSliderControl(
+            opacitySlider, valueLabel: opacityValueLabel,
+            range: Preferences.panelOpacityRange, action: #selector(opacityChanged(_:))
+        )
+        addRow(to: section, title: "Panel opacity",
+               subtitle: "Translucency of the switcher panel.",
+               accessory: opacityStack, searchItemID: SearchID.opacity)
+
+        let radiusStack = makeSliderControl(
+            radiusSlider, valueLabel: radiusValueLabel,
+            range: Preferences.panelCornerRadiusRange, action: #selector(radiusChanged(_:))
+        )
+        addRow(to: section, title: "Corner radius",
+               subtitle: "Rounding of the panel's corners. Automatic follows the panel size.",
+               accessory: radiusStack, searchItemID: SearchID.cornerRadius)
+    }
+
+    private func configureSwitch(_ toggle: NSSwitch, action: Selector) {
+        toggle.controlSize = .small
+        toggle.target = self
+        toggle.action = action
+    }
+
+    /// Builds a horizontal slider + right-aligned monospaced value label, matching
+    /// the quick-switch delay control. The caller wires `viewWillAppear` sync.
+    private func makeSliderControl(_ slider: NSSlider, valueLabel: NSTextField, range: ClosedRange<Int>, action: Selector) -> NSView {
+        slider.minValue = Double(range.lowerBound)
+        slider.maxValue = Double(range.upperBound)
+        slider.isContinuous = true
+        slider.controlSize = .small
+        slider.target = self
+        slider.action = action
+        slider.translatesAutoresizingMaskIntoConstraints = false
+
+        valueLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        valueLabel.textColor = .secondaryLabelColor
+        valueLabel.alignment = .right
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        let stack = NSStackView(views: [slider, valueLabel])
+        stack.orientation = .horizontal
+        stack.spacing = 8
+        stack.alignment = .centerY
+        NSLayoutConstraint.activate([
+            slider.widthAnchor.constraint(equalToConstant: 140),
+            valueLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 52),
+        ])
+        return stack
     }
 
     /// Small filled-circle swatch shown beside each accent menu item. The
@@ -78,7 +138,15 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         image.lockFocus()
         let rect = NSRect(origin: .zero, size: size).insetBy(dx: 0.5, dy: 0.5)
         let path = NSBezierPath(ovalIn: rect)
-        accent.resolved.setFill()
+        // The custom choice previews the stored hex so its swatch tracks the
+        // user's pick instead of the system accent fallback in `resolved`.
+        let fill: NSColor
+        if accent == .custom {
+            fill = Preferences.shared.customAccentHex.flatMap(NSColor.init(hexString:)) ?? .controlAccentColor
+        } else {
+            fill = accent.resolved
+        }
+        fill.setFill()
         path.fill()
         NSColor.black.withAlphaComponent(0.15).setStroke()
         path.lineWidth = 1
@@ -146,6 +214,22 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.selectAccent($0) }
             .store(in: &cancellables)
+        prefs.$customAccentHex
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.refreshCustomSwatch() }
+            .store(in: &cancellables)
+        prefs.$showWindowTitleLabel
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.windowTitleSwitch.state = $0 ? .on : .off }
+            .store(in: &cancellables)
+        prefs.$panelOpacity
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.applyOpacity($0) }
+            .store(in: &cancellables)
+        prefs.$panelCornerRadius
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.applyRadius($0) }
+            .store(in: &cancellables)
     }
 
     override func viewWillDisappear() {
@@ -160,6 +244,10 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         selectGrid(prefs.gridMaxColumns)
         applyDelay(prefs.revealDelayMs)
         selectAccent(prefs.accentChoice)
+        windowTitleSwitch.state = prefs.showWindowTitleLabel ? .on : .off
+        applyOpacity(prefs.panelOpacity)
+        applyRadius(prefs.panelCornerRadius)
+        refreshCustomSwatch()
     }
 
     private func selectLayout(_ mode: SwitcherLayoutMode) {
@@ -188,10 +276,60 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     }
 
     @objc private func accentChanged() {
-        Preferences.shared.accentChoice = accents[accentPopup.indexOfSelectedItem]
+        let choice = accents[accentPopup.indexOfSelectedItem]
+        Preferences.shared.accentChoice = choice
+        if choice == .custom { presentColorPanel() }
     }
 
     @objc private func delayChanged(_ sender: NSSlider) {
         Preferences.shared.revealDelayMs = sender.integerValue
+    }
+
+    @objc private func toggleWindowTitle(_ sender: NSSwitch) {
+        Preferences.shared.showWindowTitleLabel = (sender.state == .on)
+    }
+
+    @objc private func opacityChanged(_ sender: NSSlider) {
+        Preferences.shared.panelOpacity = sender.integerValue
+        opacityValueLabel.stringValue = "\(sender.integerValue)%"
+    }
+
+    @objc private func radiusChanged(_ sender: NSSlider) {
+        Preferences.shared.panelCornerRadius = sender.integerValue
+        radiusValueLabel.stringValue = sender.integerValue == 0 ? "Auto" : "\(sender.integerValue) pt"
+    }
+
+    private func applyOpacity(_ value: Int) {
+        if opacitySlider.integerValue != value { opacitySlider.integerValue = value }
+        opacityValueLabel.stringValue = "\(value)%"
+    }
+
+    private func applyRadius(_ value: Int) {
+        if radiusSlider.integerValue != value { radiusSlider.integerValue = value }
+        radiusValueLabel.stringValue = value == 0 ? "Auto" : "\(value) pt"
+    }
+
+    /// Repaints the custom accent menu item's swatch from the stored hex.
+    private func refreshCustomSwatch() {
+        guard let i = accents.firstIndex(of: .custom) else { return }
+        accentPopup.item(at: i)?.image = Self.swatch(for: .custom)
+    }
+
+    // MARK: - Custom accent color
+
+    private func presentColorPanel() {
+        let panel = NSColorPanel.shared
+        panel.showsAlpha = false
+        if let hex = Preferences.shared.customAccentHex, let color = NSColor(hexString: hex) {
+            panel.color = color
+        }
+        panel.setTarget(self)
+        panel.setAction(#selector(customColorChanged(_:)))
+        panel.orderFront(nil)
+    }
+
+    @objc private func customColorChanged(_ sender: NSColorPanel) {
+        Preferences.shared.customAccentHex = sender.color.hexString
+        refreshCustomSwatch()
     }
 }

--- a/BetterCmdTab/Settings/AppsPickerSheet.swift
+++ b/BetterCmdTab/Settings/AppsPickerSheet.swift
@@ -14,8 +14,8 @@ final class AppsPickerSheetWindowController: NSWindowController {
     /// can drop its reference.
     var onDidDismiss: (() -> Void)?
 
-    init(title: String, prompt: String, selectedBundleIDs: Set<String>, onDone: @escaping (Set<String>) -> Void) {
-        content = AppsPickerSheetViewController(prompt: prompt, selectedBundleIDs: selectedBundleIDs, onDone: onDone)
+    init(title: String, prompt: String, selectedBundleIDs: Set<String>, singleSelection: Bool = false, onDone: @escaping (Set<String>) -> Void) {
+        content = AppsPickerSheetViewController(prompt: prompt, selectedBundleIDs: selectedBundleIDs, singleSelection: singleSelection, onDone: onDone)
         let window = NSWindow(contentViewController: content)
         window.styleMask = [.titled, .closable]
         window.title = title
@@ -56,6 +56,9 @@ final class AppsPickerSheetViewController: NSViewController, NSTableViewDataSour
 
     private var selected: Set<String>
     private let prompt: String
+    /// When true, only one app can be chosen (radio behavior) and the search /
+    /// filter row is hidden — used by the direct-activation slot picker.
+    private let singleSelection: Bool
     private let onDone: (Set<String>) -> Void
     var onClose: (() -> Void)?
 
@@ -77,9 +80,10 @@ final class AppsPickerSheetViewController: NSViewController, NSTableViewDataSour
 
     private static let cellIdentifier = NSUserInterfaceItemIdentifier("AppsPickerCell")
 
-    init(prompt: String, selectedBundleIDs: Set<String>, onDone: @escaping (Set<String>) -> Void) {
+    init(prompt: String, selectedBundleIDs: Set<String>, singleSelection: Bool = false, onDone: @escaping (Set<String>) -> Void) {
         self.prompt = prompt
         self.selected = selectedBundleIDs
+        self.singleSelection = singleSelection
         self.onDone = onDone
         super.init(nibName: nil, bundle: nil)
     }
@@ -107,7 +111,10 @@ final class AppsPickerSheetViewController: NSViewController, NSTableViewDataSour
         filterPopup.target = self
         filterPopup.action = #selector(filterChanged)
 
-        let topRow = NSStackView(views: [searchField, filterPopup])
+        // Single-selection mode keeps the search field but drops the
+        // All/Checked/Unchecked filter (there's only ever one checked app).
+        let topRowViews: [NSView] = singleSelection ? [searchField] : [searchField, filterPopup]
+        let topRow = NSStackView(views: topRowViews)
         topRow.orientation = .horizontal
         topRow.spacing = 8
         topRow.alignment = .centerY
@@ -288,6 +295,12 @@ final class AppsPickerSheetViewController: NSViewController, NSTableViewDataSour
     }
 
     private func toggle(bundleID: String, on: Bool) {
+        if singleSelection {
+            // Radio: enabling one clears the others; disabling clears all.
+            selected = on ? [bundleID] : []
+            tableView.reloadData()
+            return
+        }
         if on { selected.insert(bundleID) } else { selected.remove(bundleID) }
         // In a filtered view, re-apply after a short delay so a just-toggled row
         // slides out of "Checked"/"Unchecked" instead of vanishing under the

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -8,11 +8,14 @@ import Combine
 final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     private let swipeSwitch = NSSwitch()
+    private let swipeModePopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let swipeModes: [SwipeMode] = SwipeMode.allCases
     private let reverseSwitch = NSSwitch()
     private let commitSwitch = NSSwitch()
     private let sensitivitySlider = NSSlider()
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
+    private let moveToSpaceSwitch = NSSwitch()
 
     override func setupContent() {
         // Experimental section — off by default, clearly flagged as unstable.
@@ -23,9 +26,21 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addDivider(to: experimental)
 
         configureSwitch(swipeSwitch, action: #selector(toggleSwipe(_:)))
-        addRow(to: experimental, title: "Open with three-finger swipe",
-               subtitle: "Slide three fingers across the trackpad to open the switcher and scrub through apps — keep sliding to move further. Pick with Return or a click, Esc to cancel. Reads the trackpad directly, so no system setting is needed.",
+        addRow(to: experimental, title: "Three-finger swipe",
+               subtitle: "Slide three fingers horizontally across the trackpad. Reads the trackpad directly, so no system setting is needed.",
                accessory: swipeSwitch, searchItemID: SearchID.swipe)
+
+        swipeModePopup.controlSize = .small
+        swipeModePopup.translatesAutoresizingMaskIntoConstraints = false
+        swipeModePopup.setContentHuggingPriority(.required, for: .horizontal)
+        swipeModePopup.removeAllItems()
+        swipeModePopup.addItems(withTitles: swipeModes.map(\.displayName))
+        swipeModePopup.target = self
+        swipeModePopup.action = #selector(swipeModeChanged)
+        addRow(to: experimental, title: "Swipe action",
+               subtitle: "Open switcher: scrub through apps (commit with Return/click, Esc to cancel). Switch Spaces: jump to the Space on that side, one per step.",
+               accessory: swipeModePopup, searchItemID: SearchID.swipeMode)
+
         configureSwitch(reverseSwitch, action: #selector(toggleReverse(_:)))
         addRow(to: experimental, title: "Reverse swipe direction",
                subtitle: "Slide right to move left and left to move right.",
@@ -44,6 +59,11 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: experimental, title: "Switch Spaces without animation",
                subtitle: "Picking an app on another Space or in full screen jumps there instantly, with no slide animation. Applies to keyboard switching too.",
                accessory: instantSpaceSwitch, searchItemID: SearchID.instantSpace)
+
+        configureSwitch(moveToSpaceSwitch, action: #selector(toggleMoveToSpace(_:)))
+        addRow(to: experimental, title: "Move window to adjacent Space",
+               subtitle: "While the switcher is open, ⌘⌥← / ⌘⌥→ move the highlighted window to the Space on that side and follow it there. (⌘⌥↑ / ⌘⌥↓ always move it to the next display.) Uses private APIs.",
+               accessory: moveToSpaceSwitch, searchItemID: SearchID.moveToSpace)
     }
 
     private func configureSwitch(_ toggle: NSSwitch, action: Selector) {
@@ -85,10 +105,12 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         super.viewWillAppear()
         let prefs = Preferences.shared
         swipeSwitch.state = prefs.experimentalSwipeTrigger ? .on : .off
+        if let i = swipeModes.firstIndex(of: prefs.swipeMode) { swipeModePopup.selectItem(at: i) }
         reverseSwitch.state = prefs.swipeReverseDirection ? .on : .off
         commitSwitch.state = prefs.swipeCommitOnRelease ? .on : .off
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
+        moveToSpaceSwitch.state = prefs.experimentalMoveToSpace ? .on : .off
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -96,6 +118,13 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         let on = (sender.state == .on)
         Preferences.shared.experimentalSwipeTrigger = on
         setSwipeSubOptionsEnabled(on)
+    }
+
+    @objc private func swipeModeChanged() {
+        let idx = swipeModePopup.indexOfSelectedItem
+        guard swipeModes.indices.contains(idx) else { return }
+        Preferences.shared.swipeMode = swipeModes[idx]
+        setSwipeSubOptionsEnabled(Preferences.shared.experimentalSwipeTrigger)
     }
 
     @objc private func toggleReverse(_ sender: NSSwitch) {
@@ -120,11 +149,17 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         Preferences.shared.experimentalInstantSpaceSwitch = (sender.state == .on)
     }
 
+    @objc private func toggleMoveToSpace(_ sender: NSSwitch) {
+        Preferences.shared.experimentalMoveToSpace = (sender.state == .on)
+    }
+
     /// The reverse/commit/sensitivity controls only make sense while the swipe
     /// is enabled.
     private func setSwipeSubOptionsEnabled(_ enabled: Bool) {
+        let spaces = Preferences.shared.swipeMode == .switchSpaces
+        swipeModePopup.isEnabled = enabled
         reverseSwitch.isEnabled = enabled
-        commitSwitch.isEnabled = enabled
-        sensitivitySlider.isEnabled = enabled
+        commitSwitch.isEnabled = enabled && !spaces
+        sensitivitySlider.isEnabled = enabled && !spaces
     }
 }

--- a/BetterCmdTab/Settings/GeneralSettingsViewController.swift
+++ b/BetterCmdTab/Settings/GeneralSettingsViewController.swift
@@ -20,6 +20,10 @@ final class GeneralSettingsViewController: SettingsTabViewController {
     private let appRecorder = BetterShortcuts.RecorderCocoa(for: .switchApps)
     private let windowRecorder = BetterShortcuts.RecorderCocoa(for: .switchWindows)
 
+    // Direct-activation slots: a "choose app" button + shortcut recorder per slot.
+    private var directButtons: [NSButton] = []
+    private var directSlotSheet: AppsPickerSheetWindowController?
+
     private var cancellables = Set<AnyCancellable>()
     private var axTimer: Timer?
 
@@ -58,6 +62,29 @@ final class GeneralSettingsViewController: SettingsTabViewController {
             accessory: windowRecorder,
             searchItemID: SearchID.switchWindows
         )
+
+        // Direct activation section — global shortcuts that jump straight to a
+        // chosen app, bypassing the switcher.
+        let direct = addSection(title: "Direct activation", anchor: SettingsAnchor.directActivation)
+        addRow(
+            to: direct,
+            title: "Jump straight to an app",
+            subtitle: "Assign a shortcut to focus a specific app, launching it if it isn't running.",
+            searchItemID: SearchID.directActivation
+        )
+        for (index, name) in BetterShortcuts.Name.directActivate.enumerated() {
+            let recorder = BetterShortcuts.RecorderCocoa(for: name)
+            let button = NSButton(title: "Choose…", target: self, action: #selector(chooseDirectApp(_:)))
+            button.bezelStyle = .rounded
+            button.controlSize = .small
+            button.tag = index
+            let stack = NSStackView(views: [button, recorder])
+            stack.orientation = .horizontal
+            stack.spacing = 8
+            stack.alignment = .centerY
+            addRow(to: direct, title: "Slot \(index + 1)", accessory: stack)
+            directButtons.append(button)
+        }
 
         // Feedback section — confirmation cues on commit.
         let feedback = addSection(title: "Feedback", anchor: SettingsAnchor.feedback)
@@ -156,6 +183,8 @@ final class GeneralSettingsViewController: SettingsTabViewController {
         hapticSwitch.state = prefs.hapticOnCommit ? .on : .off
         soundSwitch.state = prefs.soundOnCommit ? .on : .off
 
+        refreshDirectSlots()
+
         let updater = GitHubUpdater.shared
         betaSwitch.state = updater.includePreReleases ? .on : .off
 
@@ -220,6 +249,60 @@ final class GeneralSettingsViewController: SettingsTabViewController {
     @objc private func openSystemSettings() {
         AccessibilityCheck.promptIfNeeded()
         AccessibilityCheck.openSystemSettings()
+    }
+
+    // MARK: - Direct activation slots
+
+    /// Sync each slot's "choose app" button to its stored bundle ID.
+    private func refreshDirectSlots() {
+        let bindings = Preferences.shared.directActivationBindings
+        for (index, button) in directButtons.enumerated() {
+            let bundleID = bindings.indices.contains(index) ? bindings[index] : ""
+            if bundleID.isEmpty {
+                button.title = "Choose…"
+                button.image = nil
+            } else {
+                button.title = Self.appName(forBundleID: bundleID) ?? bundleID
+                button.image = Self.appIcon(forBundleID: bundleID)
+                button.imagePosition = .imageLeading
+            }
+        }
+    }
+
+    @objc private func chooseDirectApp(_ sender: NSButton) {
+        let slot = sender.tag
+        guard let window = view.window, directSlotSheet == nil else { return }
+        let current = Preferences.shared.directActivationBindings
+        let selected: Set<String> = (current.indices.contains(slot) && !current[slot].isEmpty) ? [current[slot]] : []
+        let controller = AppsPickerSheetWindowController(
+            title: "Activate App",
+            prompt: "Choose the app this shortcut focuses.",
+            selectedBundleIDs: selected,
+            singleSelection: true
+        ) { selection in
+            var bindings = Preferences.shared.directActivationBindings
+            while bindings.count <= slot { bindings.append("") }
+            bindings[slot] = selection.sorted().first ?? ""
+            Preferences.shared.directActivationBindings = bindings
+        }
+        controller.onDidDismiss = { [weak self] in
+            self?.directSlotSheet = nil
+            self?.refreshDirectSlots()
+        }
+        directSlotSheet = controller
+        controller.present(asSheetFor: window)
+    }
+
+    private static func appName(forBundleID bundleID: String) -> String? {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return nil }
+        return FileManager.default.displayName(atPath: url.path)
+    }
+
+    private static func appIcon(forBundleID bundleID: String) -> NSImage? {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return nil }
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        icon.size = NSSize(width: 16, height: 16)
+        return icon
     }
 
     private func refreshAccessibilityStatus() {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -21,6 +21,7 @@ enum SettingsAnchor {
     // General
     static let startup = "general.startup"
     static let shortcuts = "general.shortcuts"
+    static let directActivation = "general.directActivation"
     static let feedback = "general.feedback"
     static let permissions = "general.permissions"
     static let updates = "general.updates"
@@ -28,6 +29,7 @@ enum SettingsAnchor {
     static let contents = "switcher.contents"
     static let search = "switcher.search"
     static let navigation = "switcher.navigation"
+    static let actions = "switcher.actions"
     static let apps = "switcher.apps"
     // Appearance
     static let appearance = "appearance.switcher"
@@ -50,11 +52,13 @@ enum SearchID {
     static let accessibility = "general.accessibility"
     static let updateInterval = "general.updateInterval"
     static let beta = "general.beta"
+    static let directActivation = "general.directActivation"
     // Switcher
     static let showMinimized = "switcher.showMinimized"
     static let showHidden = "switcher.showHidden"
     static let showWindowless = "switcher.showWindowless"
     static let showBadges = "switcher.showBadges"
+    static let currentSpaceOnly = "switcher.currentSpaceOnly"
     static let showRecentlyClosed = "switcher.showRecentlyClosed"
     static let recentlyClosedLimit = "switcher.recentlyClosedLimit"
     static let letterHints = "switcher.letterHints"
@@ -63,6 +67,7 @@ enum SearchID {
     static let searchMode = "switcher.searchMode"
     static let scroll = "switcher.scroll"
     static let scrollReverse = "switcher.scrollReverse"
+    static let hoverActions = "switcher.hoverActions"
     static let excludedApps = "switcher.excludedApps"
     static let pinnedApps = "switcher.pinnedApps"
     // Appearance
@@ -71,12 +76,17 @@ enum SearchID {
     static let gridColumns = "appearance.gridColumns"
     static let accent = "appearance.accent"
     static let quickSwitchDelay = "appearance.quickSwitchDelay"
+    static let windowTitle = "appearance.windowTitle"
+    static let opacity = "appearance.opacity"
+    static let cornerRadius = "appearance.cornerRadius"
     // Experimental
     static let swipe = "experimental.swipe"
+    static let swipeMode = "experimental.swipeMode"
     static let reverseSwipe = "experimental.reverseSwipe"
     static let switchOnRelease = "experimental.switchOnRelease"
     static let sensitivity = "experimental.sensitivity"
     static let instantSpace = "experimental.instantSpace"
+    static let moveToSpace = "experimental.moveToSpace"
 }
 
 @MainActor
@@ -166,6 +176,9 @@ enum SettingsCatalog {
              "Check for updates", ["update", "upgrade", "interval", "cadence"]),
         item(SearchID.beta, .general, SettingsAnchor.updates, "General", "Updates",
              "Include beta releases", ["beta", "prerelease", "pre-release", "channel"]),
+        // General · Direct activation
+        item(SearchID.directActivation, .general, SettingsAnchor.directActivation, "General", "Direct activation",
+             "Direct activation hotkeys", ["direct", "hotkey", "shortcut", "activate", "focus app", "jump to app"]),
 
         // Switcher · Contents
         item(SearchID.showMinimized, .switcher, SettingsAnchor.contents, "Switcher", "Contents",
@@ -176,6 +189,8 @@ enum SettingsCatalog {
              "Show apps without windows", ["windowless", "no windows", "background apps"]),
         item(SearchID.showBadges, .switcher, SettingsAnchor.contents, "Switcher", "Contents",
              "Show unread badges", ["badge", "unread", "dock badge", "count"]),
+        item(SearchID.currentSpaceOnly, .switcher, SettingsAnchor.contents, "Switcher", "Contents",
+             "Only current Space", ["space", "current space", "desktop", "filter"]),
         item(SearchID.showRecentlyClosed, .switcher, SettingsAnchor.contents, "Switcher", "Contents",
              "Show recently closed apps", ["recently closed", "reopen", "recent"]),
         item(SearchID.recentlyClosedLimit, .switcher, SettingsAnchor.contents, "Switcher", "Contents",
@@ -194,6 +209,9 @@ enum SettingsCatalog {
              "Switch with mouse scroll", ["scroll", "wheel", "mouse"]),
         item(SearchID.scrollReverse, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
              "Reverse scroll direction", ["scroll", "reverse", "invert"]),
+        // Switcher · Actions
+        item(SearchID.hoverActions, .switcher, SettingsAnchor.actions, "Switcher", "Hover actions",
+             "Action buttons on hover", ["hover", "buttons", "close", "minimize", "maximize", "hide", "quit", "actions"]),
         // Switcher · Apps
         item(SearchID.excludedApps, .switcher, SettingsAnchor.apps, "Switcher", "Apps",
              "Excluded apps", ["excluded", "exclude", "hide app", "blacklist"]),
@@ -211,10 +229,18 @@ enum SettingsCatalog {
              "Accent color", ["accent", "color", "highlight", "tint"]),
         item(SearchID.quickSwitchDelay, .appearance, SettingsAnchor.appearance, "Appearance", "Switcher",
              "Quick-switch delay", ["delay", "reveal", "hold", "quick switch"]),
+        item(SearchID.windowTitle, .appearance, SettingsAnchor.appearance, "Appearance", "Switcher",
+             "Show window title", ["window title", "title", "label", "name"]),
+        item(SearchID.opacity, .appearance, SettingsAnchor.appearance, "Appearance", "Switcher",
+             "Panel opacity", ["opacity", "transparency", "alpha", "translucent"]),
+        item(SearchID.cornerRadius, .appearance, SettingsAnchor.appearance, "Appearance", "Switcher",
+             "Corner radius", ["corner", "radius", "rounded", "rounding"]),
 
         // Experimental
         item(SearchID.swipe, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
-             "Open with three-finger swipe", ["swipe", "trackpad", "gesture", "three finger"]),
+             "Three-finger swipe", ["swipe", "trackpad", "gesture", "three finger"]),
+        item(SearchID.swipeMode, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
+             "Swipe action", ["swipe", "spaces", "switch spaces", "open switcher", "gesture action"]),
         item(SearchID.reverseSwipe, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
              "Reverse swipe direction", ["swipe", "reverse", "invert"]),
         item(SearchID.switchOnRelease, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
@@ -223,6 +249,8 @@ enum SettingsCatalog {
              "Swipe sensitivity", ["sensitivity", "swipe", "distance"]),
         item(SearchID.instantSpace, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
              "Switch Spaces without animation", ["spaces", "space", "animation", "instant", "full screen"]),
+        item(SearchID.moveToSpace, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
+             "Move window to Space", ["move", "window", "space", "send to space"]),
     ]
 
     private static func item(

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -13,6 +13,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let hiddenSwitch = NSSwitch()
     private let windowlessSwitch = NSSwitch()
     private let badgesSwitch = NSSwitch()
+    private let currentSpaceSwitch = NSSwitch()
     private let recentlyClosedSwitch = NSSwitch()
     private let recentlyClosedLimitPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let recentlyClosedLimits: [Int] = [3, 5, 10, 15, 20]
@@ -27,6 +28,14 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     // Navigation
     private let scrollSwitch = NSSwitch()
     private let scrollReverseSwitch = NSSwitch()
+
+    // Hover actions
+    private let hoverSwitch = NSSwitch()
+    private let hoverCloseSwitch = NSSwitch()
+    private let hoverMinimizeSwitch = NSSwitch()
+    private let hoverMaximizeSwitch = NSSwitch()
+    private let hoverHideSwitch = NSSwitch()
+    private let hoverQuitSwitch = NSSwitch()
 
     // Apps
     private let excludedButton = NSButton(title: "Manage apps", target: nil, action: nil)
@@ -54,6 +63,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         addRow(to: contents, title: "Show unread badges",
                subtitle: "Show each app's Dock badge count (e.g. Mail's unread mail) on its row.",
                accessory: badgesSwitch, searchItemID: SearchID.showBadges)
+        configureSwitch(currentSpaceSwitch, action: #selector(toggleCurrentSpace(_:)))
+        addRow(to: contents, title: "Only current Space",
+               subtitle: "Show only windows on the Space you're currently viewing.",
+               accessory: currentSpaceSwitch, searchItemID: SearchID.currentSpaceOnly)
         configureSwitch(recentlyClosedSwitch, action: #selector(toggleRecentlyClosed(_:)))
         addRow(to: contents, title: "Show recently closed apps",
                subtitle: "Lists apps and windows you just closed so you can reopen them.",
@@ -107,6 +120,23 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
                subtitle: "Scroll up to move forward instead of down.",
                accessory: scrollReverseSwitch, searchItemID: SearchID.scrollReverse)
 
+        // Hover actions section — buttons revealed on a row under the pointer.
+        let actions = addSection(title: "Hover actions", anchor: SettingsAnchor.actions)
+        configureSwitch(hoverSwitch, action: #selector(toggleHover(_:)))
+        addRow(to: actions, title: "Action buttons on hover",
+               subtitle: "Reveal quick buttons on the row your pointer is over.",
+               accessory: hoverSwitch, searchItemID: SearchID.hoverActions)
+        configureSwitch(hoverCloseSwitch, action: #selector(toggleHoverClose(_:)))
+        addRow(to: actions, title: "Close window", accessory: hoverCloseSwitch)
+        configureSwitch(hoverMinimizeSwitch, action: #selector(toggleHoverMinimize(_:)))
+        addRow(to: actions, title: "Minimize window", accessory: hoverMinimizeSwitch)
+        configureSwitch(hoverMaximizeSwitch, action: #selector(toggleHoverMaximize(_:)))
+        addRow(to: actions, title: "Zoom window", accessory: hoverMaximizeSwitch)
+        configureSwitch(hoverHideSwitch, action: #selector(toggleHoverHide(_:)))
+        addRow(to: actions, title: "Hide app", accessory: hoverHideSwitch)
+        configureSwitch(hoverQuitSwitch, action: #selector(toggleHoverQuit(_:)))
+        addRow(to: actions, title: "Quit app", accessory: hoverQuitSwitch)
+
         // App lists section — exclusion and pinning, each via a picker sheet.
         let appLists = addSection(title: "Apps", anchor: SettingsAnchor.apps)
         configureManageButton(excludedButton, action: #selector(manageExcluded))
@@ -140,6 +170,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         hiddenSwitch.state = prefs.showHiddenApps ? .on : .off
         windowlessSwitch.state = prefs.showWindowlessApps ? .on : .off
         badgesSwitch.state = prefs.showUnreadBadges ? .on : .off
+        currentSpaceSwitch.state = prefs.currentSpaceOnly ? .on : .off
         letterHintsSwitch.state = prefs.letterHintsEnabled ? .on : .off
         fuzzySwitch.state = prefs.fuzzySearchEnabled ? .on : .off
         launcherSwitch.state = prefs.searchIncludesLaunchableApps ? .on : .off
@@ -150,6 +181,13 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         scrollSwitch.state = prefs.scrollToSwitch ? .on : .off
         scrollReverseSwitch.state = prefs.scrollReverseDirection ? .on : .off
         scrollReverseSwitch.isEnabled = prefs.scrollToSwitch
+        hoverSwitch.state = prefs.hoverActionsEnabled ? .on : .off
+        hoverCloseSwitch.state = prefs.hoverShowClose ? .on : .off
+        hoverMinimizeSwitch.state = prefs.hoverShowMinimize ? .on : .off
+        hoverMaximizeSwitch.state = prefs.hoverShowMaximize ? .on : .off
+        hoverHideSwitch.state = prefs.hoverShowHide ? .on : .off
+        hoverQuitSwitch.state = prefs.hoverShowQuit ? .on : .off
+        setHoverSubOptionsEnabled(prefs.hoverActionsEnabled)
         updateAppListCounts()
 
         prefs.$searchDismissMode
@@ -188,6 +226,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         Preferences.shared.showUnreadBadges = (sender.state == .on)
     }
 
+    @objc private func toggleCurrentSpace(_ sender: NSSwitch) {
+        Preferences.shared.currentSpaceOnly = (sender.state == .on)
+    }
+
     @objc private func toggleLetterHints(_ sender: NSSwitch) {
         Preferences.shared.letterHintsEnabled = (sender.state == .on)
     }
@@ -208,6 +250,41 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleScrollReverse(_ sender: NSSwitch) {
         Preferences.shared.scrollReverseDirection = (sender.state == .on)
+    }
+
+    @objc private func toggleHover(_ sender: NSSwitch) {
+        let on = (sender.state == .on)
+        Preferences.shared.hoverActionsEnabled = on
+        setHoverSubOptionsEnabled(on)
+    }
+
+    @objc private func toggleHoverClose(_ sender: NSSwitch) {
+        Preferences.shared.hoverShowClose = (sender.state == .on)
+    }
+
+    @objc private func toggleHoverMinimize(_ sender: NSSwitch) {
+        Preferences.shared.hoverShowMinimize = (sender.state == .on)
+    }
+
+    @objc private func toggleHoverMaximize(_ sender: NSSwitch) {
+        Preferences.shared.hoverShowMaximize = (sender.state == .on)
+    }
+
+    @objc private func toggleHoverHide(_ sender: NSSwitch) {
+        Preferences.shared.hoverShowHide = (sender.state == .on)
+    }
+
+    @objc private func toggleHoverQuit(_ sender: NSSwitch) {
+        Preferences.shared.hoverShowQuit = (sender.state == .on)
+    }
+
+    /// The per-button toggles only matter while hover actions are enabled.
+    private func setHoverSubOptionsEnabled(_ enabled: Bool) {
+        hoverCloseSwitch.isEnabled = enabled
+        hoverMinimizeSwitch.isEnabled = enabled
+        hoverMaximizeSwitch.isEnabled = enabled
+        hoverHideSwitch.isEnabled = enabled
+        hoverQuitSwitch.isEnabled = enabled
     }
 
     @objc private func toggleRecentlyClosed(_ sender: NSSwitch) {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -231,6 +231,7 @@ final class SwitcherController: SwitcherViewDelegate {
         swipeTrigger.setReverseDirection(Preferences.shared.swipeReverseDirection)
         swipeTrigger.setCommitOnRelease(Preferences.shared.swipeCommitOnRelease)
         swipeTrigger.setSensitivity(Preferences.shared.swipeSensitivity)
+        swipeTrigger.setOneShot(Preferences.shared.swipeMode == .switchSpaces)
         swipeTrigger.setEnabled(Preferences.shared.experimentalSwipeTrigger)
         // The swipe takes over three-finger horizontal Spaces navigation, so
         // suppress the system Space-swipe whenever the swipe is enabled.
@@ -253,6 +254,10 @@ final class SwitcherController: SwitcherViewDelegate {
         Preferences.shared.$swipeSensitivity
             .receive(on: DispatchQueue.main)
             .sink { [weak self] level in self?.swipeTrigger.setSensitivity(level) }
+            .store(in: &cancellables)
+        Preferences.shared.$swipeMode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mode in self?.swipeTrigger.setOneShot(mode == .switchSpaces) }
             .store(in: &cancellables)
 
         // Mouse scroll-to-switch: stepped by the hotkey tap (it sees scroll
@@ -278,6 +283,12 @@ final class SwitcherController: SwitcherViewDelegate {
     /// stray modifier release won't commit; the user commits with Return or a
     /// click, or dismisses with Esc, exactly like stay-open search.
     private func triggerFromGesture(delta: Int) {
+        // In "switch Spaces" mode the swipe never opens the switcher — each step
+        // jumps to the adjacent Space instead.
+        if Preferences.shared.swipeMode == .switchSpaces {
+            PrivateAPI.switchSpaceWrapping(rightward: delta > 0)
+            return
+        }
         switch phase {
         case .visible:
             advanceLinearVisible(by: delta, wrap: true)
@@ -373,6 +384,32 @@ final class SwitcherController: SwitcherViewDelegate {
         commit()
     }
 
+    /// A hover action button on a specific row was clicked. Point the current
+    /// index at that row, then run the same path as the keyboard W/M/H/Q actions
+    /// (plus zoom, which has no keyboard binding).
+    func switcherViewDidInvokeAction(_ action: RowAction, atIndex index: Int) {
+        guard phase == .visible, rows.indices.contains(index) else { return }
+        self.index = index
+        view.setSelectedIndex(index)
+        // The user is now interacting with the mouse: detach from the held
+        // modifier so releasing ⌘ no longer commits (which would switch to the
+        // app instead of running the clicked action). Commit stays available via
+        // a tile click, Return, or Esc to dismiss.
+        stickyOpen = true
+        switch action {
+        case .close:
+            performCloseAction()
+        case .minimize:
+            performOnVisibleTarget { Activator.minimizeWindow($0) }
+        case .maximize:
+            performOnVisibleTarget { Activator.zoomWindow($0) }
+        case .hide:
+            performOnVisibleTarget { Activator.hideApp($0) }
+        case .quit:
+            performQuitAction()
+        }
+    }
+
     private func handle(_ event: HotkeyTap.Event) {
         switch event {
         case .nextApp:
@@ -391,6 +428,14 @@ final class SwitcherController: SwitcherViewDelegate {
             advanceHorizontal(by: 1)
         case .spatialLeft:
             advanceHorizontal(by: -1)
+        case .moveWindowLeft:
+            performMove(.left)
+        case .moveWindowRight:
+            performMove(.right)
+        case .moveWindowUp:
+            performMove(.up)
+        case .moveWindowDown:
+            performMove(.down)
         case .releaseCmd:
             handleModifierRelease()
         case .commit:
@@ -410,20 +455,7 @@ final class SwitcherController: SwitcherViewDelegate {
         case .hideApp:
             performOnVisibleTarget { Activator.hideApp($0) }
         case .quitApp:
-            performOnVisibleTarget { row in
-                // Record an app-level entry (no document) so a quit app can be
-                // relaunched from recently-closed search. Regular apps only —
-                // system dialog hosts shouldn't be reopenable.
-                if row.app?.activationPolicy == .regular, let bundleID = row.bundleIdentifier {
-                    RecentlyClosedStore.shared.record(
-                        bundleID: bundleID,
-                        appName: row.appName,
-                        title: "",
-                        documentPath: nil
-                    )
-                }
-                Activator.quitApp(row)
-            }
+            performQuitAction()
         case .letterInput(let ch):
             handleLetter(ch)
         }
@@ -960,6 +992,43 @@ final class SwitcherController: SwitcherViewDelegate {
         guard !rows[index].isSystemDialog else { return }
         action(rows[index])
         scheduleVisibleRefresh(after: 0.25)
+    }
+
+    /// Move the highlighted window. Horizontal moves go to the adjacent Space
+    /// when the experimental toggle is on (following the window there and
+    /// closing the switcher); otherwise — and for vertical moves — the window
+    /// hops to the adjacent display and the switcher stays open.
+    private func performMove(_ direction: MoveDirection) {
+        guard phase == .visible, rows.indices.contains(index) else { return }
+        let row = rows[index]
+        guard !row.isSystemDialog, row.app != nil, row.window != nil else { return }
+
+        let horizontal = (direction == .left || direction == .right)
+        if horizontal && Preferences.shared.experimentalMoveToSpace {
+            Activator.moveWindowToSpace(row, direction: direction)
+            // We followed the window onto its new Space; dismiss the switcher.
+            cancel()
+        } else {
+            Activator.moveWindowToDisplay(row, direction: direction)
+            scheduleVisibleRefresh(after: 0.2)
+        }
+    }
+
+    private func performQuitAction() {
+        performOnVisibleTarget { row in
+            // Record an app-level entry (no document) so a quit app can be
+            // relaunched from recently-closed search. Regular apps only —
+            // system dialog hosts shouldn't be reopenable.
+            if row.app?.activationPolicy == .regular, let bundleID = row.bundleIdentifier {
+                RecentlyClosedStore.shared.record(
+                    bundleID: bundleID,
+                    appName: row.appName,
+                    title: "",
+                    documentPath: nil
+                )
+            }
+            Activator.quitApp(row)
+        }
     }
 
     private func performCloseAction() {

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -3,6 +3,15 @@ import AppKit
 @MainActor
 protocol SwitcherItemViewProtocol: NSView {
     var isSelected: Bool { get set }
+    /// True while the mouse is directly over this row — drives the hover action
+    /// buttons (independent of keyboard selection).
+    var isHovered: Bool { get set }
+    /// The hover-action this row's button bar exposes at `point` (window coords),
+    /// or nil. `SwitcherView` calls this on mouseDown to route clicks (the dots
+    /// can't receive events themselves through the glass-hosted subtree).
+    func hoverAction(atWindowPoint point: NSPoint) -> RowAction?
+    /// Highlight the button under `point` (window coords); nil clears it.
+    func setHotDot(atWindowPoint point: NSPoint?)
     func configure(with row: SwitcherRow, label: String, prefixLength: Int, selected: Bool, metrics: SwitcherMetrics, accent: NSColor)
 }
 
@@ -30,9 +39,20 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         }
     }
 
+    private let actionBar = HoverActionBar(frame: .zero)
+    private var actionsAvailable = false
+    var isHovered: Bool = false {
+        didSet {
+            guard oldValue != isHovered else { return }
+            updateHoverBar()
+        }
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+
+        actionBar.isHidden = true
 
         selectionBackdrop.wantsLayer = true
         selectionBackdrop.layer?.cornerCurve = .continuous
@@ -103,6 +123,9 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         titleLabel.cell?.usesSingleLineMode = true
         addSubview(titleLabel)
 
+        // Last, so the hover bar floats above the icon and labels.
+        addSubview(actionBar)
+
         updateSelectionAppearance()
         applyMetrics(metrics)
     }
@@ -112,6 +135,29 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         updateSelectionAppearance()
+    }
+
+    /// Show the hover bar only over a hovered, actionable row when the feature
+    /// (and at least one button) is enabled.
+    private func updateHoverBar() {
+        let show = isHovered
+            && Preferences.shared.hoverActionsEnabled
+            && actionsAvailable
+            && actionBar.hasAnyEnabledButton
+        if !show { actionBar.setHotAction(nil) }
+        if actionBar.isHidden == !show { return }
+        actionBar.isHidden = !show
+        needsLayout = true
+    }
+
+    func hoverAction(atWindowPoint point: NSPoint) -> RowAction? {
+        guard !actionBar.isHidden else { return nil }
+        return actionBar.action(atWindowPoint: point)
+    }
+
+    func setHotDot(atWindowPoint point: NSPoint?) {
+        guard !actionBar.isHidden else { actionBar.setHotAction(nil); return }
+        actionBar.setHotAction(point.flatMap { actionBar.action(atWindowPoint: $0) })
     }
 
     private func updateSelectionAppearance() {
@@ -159,7 +205,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         // window). Launch/reopen rows return their single cue, never a stacked
         // no-window glyph.
         let indicators = isDialog ? [] : Self.indicators(for: row)
-        let secondary = isDialog ? "" : Self.secondaryText(for: row)
+        let secondary = isDialog ? "" : Self.secondaryText(for: row, showTitle: Preferences.shared.showWindowTitleLabel)
         if indicators.isEmpty, secondary.isEmpty {
             titleLabel.attributedStringValue = NSAttributedString(string: "")
             titleLabel.isHidden = true
@@ -178,6 +224,11 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         } else {
             badgePill.isHidden = true
         }
+
+        // Hover action buttons apply to a real window of a running app.
+        actionsAvailable = !isDialog && row.app != nil && row.window != nil
+        actionBar.applyEnabledButtons()
+        updateHoverBar()
 
         // Run `applySelection` exactly once: the `isSelected` setter already does
         // so via `didSet` when the value flips, so call it explicitly only when
@@ -207,11 +258,14 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         return result
     }
 
-    private static func secondaryText(for row: SwitcherRow) -> String {
+    /// `showTitle == false` blanks the window-title text (the "Window title under
+    /// icon" preference) while leaving launch/reopen cues — which aren't window
+    /// titles — intact so those rows still read clearly.
+    private static func secondaryText(for row: SwitcherRow, showTitle: Bool) -> String {
         if row.isLaunchable { return "Launch" }
-        if row.isRecentlyClosed { return row.windowTitle.isEmpty ? "Reopen" : row.windowTitle }
+        if row.isRecentlyClosed { return (showTitle && !row.windowTitle.isEmpty) ? row.windowTitle : "Reopen" }
         if row.isPlaceholder || row.window == nil { return "" }
-        return row.windowTitle
+        return showTitle ? row.windowTitle : ""
     }
 
     /// Builds the secondary line: leading status glyphs (each tinted to its
@@ -386,6 +440,17 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         let titleH = ceil(titleLabel.font?.pointSize ?? m.tileTitleFontSize) + 2
         nameLabel.frame = NSRect(x: 0, y: labelAreaH - nameH, width: w, height: nameH)
         titleLabel.frame = NSRect(x: 0, y: labelAreaH - nameH - titleH, width: w, height: titleH)
+
+        if !actionBar.isHidden {
+            // Centered horizontally just below the icon's top edge.
+            let size = actionBar.contentSize
+            actionBar.frame = NSRect(
+                x: round(iconArea.midX - size.width / 2),
+                y: round(iconArea.maxY - size.height - 2),
+                width: size.width,
+                height: size.height
+            )
+        }
     }
 }
 

--- a/BetterCmdTab/Switcher/SwitcherItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherItemView.swift
@@ -35,9 +35,20 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         }
     }
 
+    private let actionBar = HoverActionBar(frame: .zero)
+    private var actionsAvailable = false
+    var isHovered: Bool = false {
+        didSet {
+            guard oldValue != isHovered else { return }
+            updateHoverBar()
+        }
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+
+        actionBar.isHidden = true
 
         highlight.wantsLayer = true
         highlight.layer?.cornerCurve = .continuous
@@ -110,10 +121,36 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
             addSubview(iv)
         }
 
+        // Last, so the hover bar floats above the row content.
+        addSubview(actionBar)
+
         applyMetrics(metrics)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    /// Show the hover bar only over a hovered, actionable row when the feature
+    /// (and at least one button) is enabled.
+    private func updateHoverBar() {
+        let show = isHovered
+            && Preferences.shared.hoverActionsEnabled
+            && actionsAvailable
+            && actionBar.hasAnyEnabledButton
+        if !show { actionBar.setHotAction(nil) }
+        if actionBar.isHidden == !show { return }
+        actionBar.isHidden = !show
+        needsLayout = true
+    }
+
+    func hoverAction(atWindowPoint point: NSPoint) -> RowAction? {
+        guard !actionBar.isHidden else { return nil }
+        return actionBar.action(atWindowPoint: point)
+    }
+
+    func setHotDot(atWindowPoint point: NSPoint?) {
+        guard !actionBar.isHidden else { actionBar.setHotAction(nil); return }
+        actionBar.setHotAction(point.flatMap { actionBar.action(atWindowPoint: $0) })
+    }
 
     private var currentLabel: String = ""
     private var currentPrefixLength: Int = 0
@@ -189,6 +226,11 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         // it exactly once: the `isSelected` setter already does so via `didSet`
         // when the value flips, so only call it explicitly when the value is
         // unchanged but other inputs (accent, metrics, label) still need it.
+        // Hover action buttons apply to a real window of a running app.
+        actionsAvailable = !isDialog && row.app != nil && row.window != nil
+        actionBar.applyEnabledButtons()
+        updateHoverBar()
+
         if isSelected == selected {
             applySelection()
         } else {
@@ -349,5 +391,16 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
 
         let titleW = max(0, rightLimit - titleX)
         titleLabel.frame = NSRect(x: titleX, y: labelY, width: titleW, height: labelH)
+
+        if !actionBar.isHidden {
+            // Right-aligned, vertically centered — floats over the status column.
+            let size = actionBar.contentSize
+            actionBar.frame = NSRect(
+                x: bounds.width - m.horizontalInset - size.width,
+                y: round((h - size.height) / 2),
+                width: size.width,
+                height: size.height
+            )
+        }
     }
 }

--- a/BetterCmdTab/Switcher/SwitcherPanel.swift
+++ b/BetterCmdTab/Switcher/SwitcherPanel.swift
@@ -73,6 +73,15 @@ final class SwitcherPanel: NSPanel {
             super.resignKey()
             return
         }
+        // Swallow `super.resignKey()` to suppress the glass dim animation's
+        // notification — but the internal `_isKey` has already flipped to false,
+        // so without reclaiming, the panel stops being key: its controls (hover
+        // action buttons) stop receiving clicks and keyboard focus drifts. Re-key
+        // on the next runloop so the panel stays interactive while it's on screen.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isVisible, !self.isKeyWindow else { return }
+            self.makeKeyAndOrderFront(nil)
+        }
     }
 
     func present() {
@@ -92,9 +101,12 @@ final class SwitcherPanel: NSPanel {
             setFrame(newFrame, display: true)
         }
         // Restore opacity that `dismiss()` zeroed to mask the glass-layer
-        // teardown ghost. Reset before ordering on screen so the first frame
-        // is fully opaque (no fade — `animationBehavior` is `.none`).
-        alphaValue = 1
+        // teardown ghost, and un-hide the content `dismiss()` hid to drop the
+        // glass sample. Reset before ordering on screen so the first frame is
+        // shown at the user's chosen opacity (no fade — `animationBehavior` is
+        // `.none`).
+        content.isHidden = false
+        alphaValue = CGFloat(Preferences.shared.panelOpacity) / 100
         makeKeyAndOrderFront(nil)
         CATransaction.commit()
     }
@@ -113,6 +125,11 @@ final class SwitcherPanel: NSPanel {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         alphaValue = 0
+        // Hiding the content view tears the glass/visual-effect layer out of the
+        // compositor in the same transaction as `orderOut`, so the window server
+        // has no last-sampled backdrop left to flash as a ghost after we vanish.
+        // `present()` un-hides it.
+        contentView?.isHidden = true
         orderOut(nil)
         CATransaction.commit()
     }

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -31,9 +31,20 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         }
     }
 
+    private let actionBar = HoverActionBar(frame: .zero)
+    private var actionsAvailable = false
+    var isHovered: Bool = false {
+        didSet {
+            guard oldValue != isHovered else { return }
+            updateHoverBar()
+        }
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+
+        actionBar.isHidden = true
 
         selectionBackdrop.wantsLayer = true
         selectionBackdrop.layer?.cornerCurve = .continuous
@@ -75,6 +86,9 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         nameLabel.isSelectable = false
         addSubview(nameLabel)
 
+        // Last, so the hover bar floats above the thumbnail.
+        addSubview(actionBar)
+
         updateThumbBackground()
         updateSelectionAppearance()
         applyMetrics(metrics)
@@ -86,6 +100,29 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         super.viewDidChangeEffectiveAppearance()
         updateSelectionAppearance()
         updateThumbBackground()
+    }
+
+    /// Show the hover bar only over a hovered, actionable row when the feature
+    /// (and at least one button) is enabled.
+    private func updateHoverBar() {
+        let show = isHovered
+            && Preferences.shared.hoverActionsEnabled
+            && actionsAvailable
+            && actionBar.hasAnyEnabledButton
+        if !show { actionBar.setHotAction(nil) }
+        if actionBar.isHidden == !show { return }
+        actionBar.isHidden = !show
+        needsLayout = true
+    }
+
+    func hoverAction(atWindowPoint point: NSPoint) -> RowAction? {
+        guard !actionBar.isHidden else { return nil }
+        return actionBar.action(atWindowPoint: point)
+    }
+
+    func setHotDot(atWindowPoint point: NSPoint?) {
+        guard !actionBar.isHidden else { actionBar.setHotAction(nil); return }
+        actionBar.setHotAction(point.flatMap { actionBar.action(atWindowPoint: $0) })
     }
 
     private func updateSelectionAppearance() {
@@ -128,7 +165,9 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         let icon = isDialog ? SystemSettingsIcon.image : IconCache.icon(for: row)
         placeholderIcon = icon
         iconView.image = icon
-        nameLabel.stringValue = row.displayTitle
+        // "Window title under icon" preference: when off, keep the app icon but
+        // drop the title text so the tile is just the thumbnail + icon.
+        nameLabel.stringValue = Preferences.shared.showWindowTitleLabel ? row.displayTitle : ""
 
         // Resolve the window id and ask for (or reuse) its live thumbnail. Rows
         // without a real window (windowless apps, launchables, recents) keep the
@@ -142,6 +181,11 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
             imageView.image = icon
         }
         applyImageScaling()
+
+        // Hover action buttons apply to a real window of a running app.
+        actionsAvailable = !isDialog && row.app != nil && row.window != nil
+        actionBar.applyEnabledButtons()
+        updateHoverBar()
 
         if isSelected == selected {
             applySelection()
@@ -256,5 +300,16 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
             width: max(0, nameW),
             height: nameH
         )
+
+        if !actionBar.isHidden {
+            // Top-right corner of the thumbnail, inset slightly.
+            let size = actionBar.contentSize
+            actionBar.frame = NSRect(
+                x: round(thumbRect.maxX - size.width - 4),
+                y: round(thumbRect.maxY - size.height - 4),
+                width: size.width,
+                height: size.height
+            )
+        }
     }
 }

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -1,10 +1,21 @@
 import AppKit
 import os
 
+/// A window/app action invoked from a row's hover buttons. Raw values double as
+/// `NSButton.tag`s in `HoverActionBar`.
+enum RowAction: Int {
+    case close
+    case minimize
+    case maximize
+    case hide
+    case quit
+}
+
 @MainActor
 protocol SwitcherViewDelegate: AnyObject {
     func switcherViewDidHover(index: Int)
     func switcherViewDidClick(index: Int)
+    func switcherViewDidInvokeAction(_ action: RowAction, atIndex index: Int)
 }
 
 @MainActor
@@ -20,6 +31,10 @@ final class SwitcherView: NSView {
     private var rows: [SwitcherRow] = []
     private(set) var labels: [String] = []
     private var selectedIndex: Int = 0
+    /// Row the mouse is directly over (-1 = none). Separate from `selectedIndex`
+    /// so hover action buttons appear only under the pointer, not on a
+    /// keyboard-selected row.
+    private var hoveredIndex: Int = -1
     private var cachedLayout: ListLayout?
     private var trackingArea: NSTrackingArea?
 
@@ -90,7 +105,7 @@ final class SwitcherView: NSView {
         self.labels = labels
         self.highlightPrefix = highlightPrefix
         self.searchActive = searchActive
-        self.accent = Preferences.shared.accentChoice.resolved
+        self.accent = Preferences.shared.resolvedAccent
         self.selectedIndex = selectedIndex
         searchBar.update(query: searchQuery)
         searchBar.isHidden = !searchActive
@@ -98,8 +113,12 @@ final class SwitcherView: NSView {
         let layoutModeChanged = metrics.layoutMode != self.metrics.layoutMode
         if metrics != self.metrics {
             self.metrics = metrics
-            updateBackdropCornerRadius(metrics.cornerRadius)
         }
+        // Corner radius and blur material are user-tunable theme settings, so
+        // apply them on every reveal (a cheap property set) rather than only when
+        // the size-derived metrics change.
+        updateBackdropCornerRadius(effectiveCornerRadius(metrics))
+        applyBackdropMaterial()
         if layoutModeChanged {
             // Different item view class — clear the pool so rebuild picks the right type.
             for v in itemViews { v.removeFromSuperview() }
@@ -156,6 +175,19 @@ final class SwitcherView: NSView {
         } else {
             glassBackdrop.layer?.cornerRadius = radius
         }
+    }
+
+    /// User-pinned corner radius when set (> 0), otherwise the size-derived metric.
+    private func effectiveCornerRadius(_ metrics: SwitcherMetrics) -> CGFloat {
+        let pref = Preferences.shared.panelCornerRadius
+        return pref > 0 ? CGFloat(pref) : metrics.cornerRadius
+    }
+
+    /// Apply the chosen blur material to the fallback backdrop. The macOS 26
+    /// glass backdrop has no material knob, so it's left untouched there.
+    private func applyBackdropMaterial() {
+        if #available(macOS 26.0, *), glassBackdrop is NSGlassEffectView { return }
+        (glassBackdrop as? NSVisualEffectView)?.material = Preferences.shared.backdropMaterial.material
     }
 
     var columnCount: Int {
@@ -231,15 +263,39 @@ final class SwitcherView: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        if let idx = indexAtWindowPoint(event.locationInWindow) {
+        let idx = indexAtWindowPoint(event.locationInWindow)
+        setHoveredIndex(idx ?? -1)
+        if let idx {
             delegate?.switcherViewDidHover(index: idx)
+            // Highlight the hover-action dot under the pointer, if any.
+            itemViews[idx].setHotDot(atWindowPoint: event.locationInWindow)
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        setHoveredIndex(-1)
+    }
+
+    /// Track which row the mouse is directly over so only that row shows its
+    /// hover action buttons (distinct from the keyboard selection).
+    private func setHoveredIndex(_ index: Int) {
+        guard index != hoveredIndex else { return }
+        hoveredIndex = index
+        for (i, view) in itemViews.enumerated() {
+            view.isHovered = (i == index)
         }
     }
 
     override func mouseDown(with event: NSEvent) {
-        if let idx = indexAtWindowPoint(event.locationInWindow) {
-            delegate?.switcherViewDidClick(index: idx)
+        guard let idx = indexAtWindowPoint(event.locationInWindow), itemViews.indices.contains(idx) else { return }
+        // A click on a hover-action dot runs that action instead of committing.
+        // The dots can't receive events themselves (glass-hosted subtree), so
+        // hit-test them here against the hovered row.
+        if let action = itemViews[idx].hoverAction(atWindowPoint: event.locationInWindow) {
+            delegate?.switcherViewDidInvokeAction(action, atIndex: idx)
+            return
         }
+        delegate?.switcherViewDidClick(index: idx)
     }
 
 
@@ -297,6 +353,7 @@ final class SwitcherView: NSView {
                 metrics: metrics,
                 accent: accent
             )
+            itemViews[i].isHovered = (i == hoveredIndex)
             itemViews[i].isHidden = false
         }
     }

--- a/BetterCmdTab/System/PrivateAPIs.swift
+++ b/BetterCmdTab/System/PrivateAPIs.swift
@@ -80,6 +80,79 @@ enum PrivateAPI {
     // swipe will move, so we only post one for jumps within that display.
     private static let getActiveSpaceFn: (@convention(c) (Int32) -> UInt64)? =
         sym("CGSGetActiveSpace", in: skyLight)
+    // (cid, CFArray<window ids>, CGSSpaceID) -> Void. Moves the given windows to
+    // a Space. Backs the experimental "move window to adjacent Space" action.
+    private static let moveWindowsToSpaceFn: (@convention(c) (Int32, CFArray, UInt64) -> Void)? =
+        sym("CGSMoveWindowsToManagedSpace", in: skyLight)
+
+    // MARK: - SkyLight: current-Space queries (read-only)
+
+    /// The id of the currently focused Space, or nil when the private API is
+    /// unavailable. Used by the "only current Space" switcher filter.
+    static func activeSpace() -> UInt64? {
+        guard let mainConnection = mainConnectionFn, let getActive = getActiveSpaceFn else { return nil }
+        let space = getActive(mainConnection())
+        return space == 0 ? nil : space
+    }
+
+    /// Maps each window id to the first Space it belongs to. Windows whose Space
+    /// can't be resolved are omitted; the result is empty when the private API is
+    /// unavailable (callers should then degrade to showing every window).
+    static func spaces(forWindows wids: [CGWindowID]) -> [CGWindowID: UInt64] {
+        guard !wids.isEmpty,
+              let mainConnection = mainConnectionFn,
+              let copySpaces = copySpacesForWindowsFn else { return [:] }
+        let cid = mainConnection()
+        var result: [CGWindowID: UInt64] = [:]
+        result.reserveCapacity(wids.count)
+        for wid in wids where wid != 0 {
+            // Query one window at a time: `CGSCopySpacesForWindows` returns the
+            // union of Spaces for the whole input array, so a single call can't
+            // be attributed back to individual windows.
+            let list = [NSNumber(value: wid)] as CFArray
+            guard let spaces = copySpaces(cid, 0x7, list)?.takeRetainedValue(),
+                  CFArrayGetCount(spaces) > 0,
+                  let raw = CFArrayGetValueAtIndex(spaces, 0) else { continue }
+            let number = Unmanaged<CFNumber>.fromOpaque(raw).takeUnretainedValue()
+            var space: UInt64 = 0
+            if CFNumberGetValue(number, .sInt64Type, &space), space != 0 {
+                result[wid] = space
+            }
+        }
+        return result
+    }
+
+    /// The Space adjacent to `space` by `step` (-1 = left, +1 = right) within the
+    /// same display's ordered Space list. nil at the ends or when unresolved.
+    /// Backs the experimental move-window-to-adjacent-Space action.
+    static func adjacentSpace(toSpace space: UInt64, step: Int) -> UInt64? {
+        guard space != 0, step != 0,
+              let mainConnection = mainConnectionFn,
+              let copyDisplays = copyManagedDisplaySpacesFn else { return nil }
+        let cid = mainConnection()
+        guard let cf = copyDisplays(cid)?.takeRetainedValue() else { return nil }
+        let displays = (cf as NSArray).compactMap { $0 as? [String: Any] }
+        for display in displays {
+            guard let spaceArray = display["Spaces"] as? [Any] else { continue }
+            let ids = spaceArray.compactMap { ($0 as? [String: Any]).flatMap(spaceId) }
+            guard let idx = ids.firstIndex(of: space) else { continue }
+            let target = idx + step
+            return ids.indices.contains(target) ? ids[target] : nil
+        }
+        return nil
+    }
+
+    /// Move a single window to `space`. Returns false when the private API is
+    /// unavailable. Does not switch the user to that Space — call `switchToSpace`
+    /// afterwards to follow the window.
+    @discardableResult
+    static func moveWindow(_ wid: CGWindowID, toSpace space: UInt64) -> Bool {
+        guard wid != 0, space != 0,
+              let mainConnection = mainConnectionFn,
+              let move = moveWindowsToSpaceFn else { return false }
+        move(mainConnection(), [NSNumber(value: wid)] as CFArray, space)
+        return true
+    }
 
     /// One-shot startup diagnostic. Returns the list of dlsym symbols that
     /// failed to resolve, so AppDelegate can surface a single warning instead
@@ -95,6 +168,7 @@ enum PrivateAPI {
         if copySpacesForWindowsFn == nil { missing.append("CGSCopySpacesForWindows") }
         if copyManagedDisplaySpacesFn == nil { missing.append("CGSCopyManagedDisplaySpaces") }
         if getActiveSpaceFn == nil { missing.append("CGSGetActiveSpace") }
+        if moveWindowsToSpaceFn == nil { missing.append("CGSMoveWindowsToManagedSpace") }
         return missing
     }
 
@@ -156,6 +230,56 @@ enum PrivateAPI {
             postDockSwipe(rightward: steps > 0, velocity: velocity)
         }
         return true
+    }
+
+    /// Switch to the Space on the left (`rightward == false`) or right by posting
+    /// one synthetic horizontal Dock-swipe — the same instant path as
+    /// `switchToSpace`, but direction-driven rather than window-driven. Backs the
+    /// "three-finger swipe switches Spaces" mode.
+    static func switchSpace(rightward: Bool) {
+        postDockSwipe(rightward: rightward, velocity: dockSwipeVelocity)
+    }
+
+    /// Switch one Space left/right, wrapping at the ends: swiping left off the
+    /// first Space lands on the last, and vice versa. At an edge it reaches the
+    /// far Space by posting `count - 1` swipes the other way (one synthetic swipe
+    /// = one Space step, same as the instant Space switch). Falls back to a
+    /// single non-wrapping swipe when the Space layout can't be resolved.
+    static func switchSpaceWrapping(rightward: Bool) {
+        guard let layout = activeDisplaySpaces(), layout.count > 1 else {
+            switchSpace(rightward: rightward)
+            return
+        }
+        let target = layout.index + (rightward ? 1 : -1)
+        if target >= 0 && target < layout.count {
+            postDockSwipe(rightward: rightward, velocity: dockSwipeVelocity)
+        } else {
+            // Wrap to the opposite end.
+            let steps = layout.count - 1
+            let velocity = dockSwipeVelocity * Double(steps)
+            for _ in 0..<steps {
+                postDockSwipe(rightward: !rightward, velocity: velocity)
+            }
+        }
+    }
+
+    /// Ordered Space count and the active Space's index on the display that owns
+    /// the focused Space (the one a swipe moves). nil when unavailable.
+    private static func activeDisplaySpaces() -> (count: Int, index: Int)? {
+        guard let mainConnection = mainConnectionFn,
+              let getActiveSpace = getActiveSpaceFn,
+              let copyDisplays = copyManagedDisplaySpacesFn else { return nil }
+        let cid = mainConnection()
+        let active = getActiveSpace(cid)
+        guard active != 0, let cf = copyDisplays(cid)?.takeRetainedValue() else { return nil }
+        let displays = (cf as NSArray).compactMap { $0 as? [String: Any] }
+        for display in displays {
+            guard let spaceArray = display["Spaces"] as? [Any] else { continue }
+            let ids = spaceArray.compactMap { ($0 as? [String: Any]).flatMap(spaceId) }
+            guard let idx = ids.firstIndex(of: active) else { continue }
+            return (ids.count, idx)
+        }
+        return nil
     }
 
     /// On the display that owns `activeSpace` (the one a swipe would move),

--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -1,8 +1,27 @@
 import AppKit
 import ApplicationServices
 
+/// Direction for moving a window between displays or Spaces.
+enum MoveDirection {
+    case left, right, up, down
+}
+
 enum Activator {
     private static let finderBundleID = "com.apple.finder"
+
+    /// Focus the app with the given bundle ID, launching it if it isn't running.
+    /// Backs the direct-activation hotkeys (jump straight to a chosen app).
+    static func activateOrLaunch(bundleID: String) {
+        if let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first {
+            activateApp(running)
+            return
+        }
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return }
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        config.createsNewApplicationInstance = false
+        NSWorkspace.shared.openApplication(at: url, configuration: config) { _, _ in }
+    }
 
     static func activateApp(_ app: NSRunningApplication) {
         if app.isHidden {
@@ -285,6 +304,25 @@ enum Activator {
         up.postToPid(pid)
     }
 
+    /// Zoom (green-button maximize) the row's window by pressing its AX zoom
+    /// button. Apps without a zoom button (some dialogs/utilities) are no-ops.
+    static func zoomWindow(_ row: SwitcherRow) {
+        guard let window = row.window, let app = row.app else { return }
+        let apply = {
+            var buttonValue: AnyObject?
+            let err = AXUIElementCopyAttributeValue(window, kAXZoomButtonAttribute as CFString, &buttonValue)
+            guard err == .success, CFGetTypeID(buttonValue as CFTypeRef) == AXUIElementGetTypeID() else { return }
+            AXUIElementPerformAction(buttonValue as! AXUIElement, kAXPressAction as CFString)
+        }
+        // Our own window must mutate on the main thread (window-management
+        // constraint, same as close/minimize); other apps stay off-main.
+        if app.processIdentifier == getpid() {
+            DispatchQueue.main.async(execute: apply)
+        } else {
+            DispatchQueue.global(qos: .userInitiated).async(execute: apply)
+        }
+    }
+
     static func hideApp(_ row: SwitcherRow) {
         guard let app = row.app else { return }
         if app.isHidden {
@@ -305,5 +343,119 @@ enum Activator {
             return
         }
         app.terminate()
+    }
+
+    // MARK: - Move window between displays / Spaces
+
+    /// Move the row's window to the adjacent display in `direction`, preserving
+    /// its relative position within the screen and clamping it to fit. Uses the
+    /// stable Accessibility position API — no private symbols.
+    static func moveWindowToDisplay(_ row: SwitcherRow, direction: MoveDirection) {
+        guard let window = row.window, let app = row.app else { return }
+        let apply = { Self.repositionToAdjacentDisplay(window: window, direction: direction) }
+        // Our own window must mutate on the main thread (window-management
+        // constraint, as with close/minimize); other apps stay off-main.
+        if app.processIdentifier == getpid() {
+            DispatchQueue.main.async(execute: apply)
+        } else {
+            DispatchQueue.global(qos: .userInitiated).async(execute: apply)
+        }
+    }
+
+    private static func repositionToAdjacentDisplay(window: AXUIElement, direction: MoveDirection) {
+        guard !NSScreen.screens.isEmpty else { return }
+        // AX coordinates are top-left origin (y down) anchored at the main screen;
+        // Cocoa screen frames are bottom-left origin. `mainHeight` bridges them.
+        let mainHeight = NSScreen.screens[0].frame.maxY
+
+        var posRef: AnyObject?
+        var sizeRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &posRef) == .success,
+              AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRef) == .success,
+              CFGetTypeID(posRef as CFTypeRef) == AXValueGetTypeID(),
+              CFGetTypeID(sizeRef as CFTypeRef) == AXValueGetTypeID() else { return }
+        var axPos = CGPoint.zero
+        var axSize = CGSize.zero
+        AXValueGetValue(posRef as! AXValue, .cgPoint, &axPos)
+        AXValueGetValue(sizeRef as! AXValue, .cgSize, &axSize)
+
+        let cocoaRect = CGRect(
+            x: axPos.x,
+            y: mainHeight - axPos.y - axSize.height,
+            width: axSize.width,
+            height: axSize.height
+        )
+        guard let current = screenContaining(rect: cocoaRect),
+              let target = adjacentScreen(to: current, direction: direction) else { return }
+
+        let cv = current.visibleFrame
+        let tv = target.visibleFrame
+        let relX = cv.width > 0 ? (cocoaRect.minX - cv.minX) / cv.width : 0
+        let relY = cv.height > 0 ? (cocoaRect.minY - cv.minY) / cv.height : 0
+        var newX = tv.minX + relX * tv.width
+        var newY = tv.minY + relY * tv.height
+        // Clamp so the window stays on-screen (no resize).
+        newX = min(max(newX, tv.minX), max(tv.minX, tv.maxX - axSize.width))
+        newY = min(max(newY, tv.minY), max(tv.minY, tv.maxY - axSize.height))
+
+        var newAXPos = CGPoint(x: newX, y: mainHeight - (newY + axSize.height))
+        guard let value = AXValueCreate(.cgPoint, &newAXPos) else { return }
+        AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, value)
+    }
+
+    private static func screenContaining(rect: CGRect) -> NSScreen? {
+        NSScreen.screens.max { a, b in
+            intersectionArea(a.frame, rect) < intersectionArea(b.frame, rect)
+        }
+    }
+
+    private static func intersectionArea(_ a: CGRect, _ b: CGRect) -> CGFloat {
+        let i = a.intersection(b)
+        guard !i.isNull else { return 0 }
+        return max(0, i.width) * max(0, i.height)
+    }
+
+    private static func adjacentScreen(to current: NSScreen, direction: MoveDirection) -> NSScreen? {
+        let c = CGPoint(x: current.frame.midX, y: current.frame.midY)
+        let candidates = NSScreen.screens.filter { $0 != current }.filter { s in
+            let p = CGPoint(x: s.frame.midX, y: s.frame.midY)
+            switch direction {
+            case .left: return p.x < c.x
+            case .right: return p.x > c.x
+            case .up: return p.y > c.y     // Cocoa y increases upward
+            case .down: return p.y < c.y
+            }
+        }
+        return candidates.min { a, b in
+            let pa = CGPoint(x: a.frame.midX, y: a.frame.midY)
+            let pb = CGPoint(x: b.frame.midX, y: b.frame.midY)
+            switch direction {
+            case .left, .right: return abs(pa.x - c.x) < abs(pb.x - c.x)
+            case .up, .down: return abs(pa.y - c.y) < abs(pb.y - c.y)
+            }
+        }
+    }
+
+    /// Experimental: move the row's window to the adjacent Space in `direction`
+    /// (private SkyLight APIs), then follow it there with an instant Space switch
+    /// and raise it. Horizontal directions step Spaces; vertical falls back to
+    /// the caller's display move. No-op when the private APIs are unavailable.
+    static func moveWindowToSpace(_ row: SwitcherRow, direction: MoveDirection) {
+        guard let window = row.window else { return }
+        let step: Int
+        switch direction {
+        case .left, .up: step = -1
+        case .right, .down: step = 1
+        }
+        let wid = PrivateAPI.cgWindowId(of: window)
+        guard wid != 0,
+              let current = PrivateAPI.spaces(forWindows: [wid])[wid],
+              let target = PrivateAPI.adjacentSpace(toSpace: current, step: step),
+              PrivateAPI.moveWindow(wid, toSpace: target) else { return }
+        // Follow the window to its new Space (instant, no slide) and raise it.
+        PrivateAPI.switchToSpace(ofWindow: wid)
+        if let pid = row.pid {
+            PrivateAPI.raiseWindow(pid: pid, wid: wid)
+        }
     }
 }

--- a/BetterCmdTabTests/CatalogFilterTests.swift
+++ b/BetterCmdTabTests/CatalogFilterTests.swift
@@ -9,9 +9,10 @@ struct CatalogFilterTests {
         pinned: [String] = [],
         showMinimized: Bool = true,
         showHidden: Bool = true,
-        showWindowless: Bool = true
+        showWindowless: Bool = true,
+        currentSpaceOnly: Bool = false
     ) -> CatalogFilter.Config {
-        CatalogFilter.Config(excluded: excluded, pinned: pinned, showMinimized: showMinimized, showHidden: showHidden, showWindowless: showWindowless)
+        CatalogFilter.Config(excluded: excluded, pinned: pinned, showMinimized: showMinimized, showHidden: showHidden, showWindowless: showWindowless, currentSpaceOnly: currentSpaceOnly)
     }
 
     // MARK: - isIdentity

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -48,10 +48,12 @@ struct BetterShortcutsIntegrationTests {
     }
 
     @MainActor
-    @Test("allCases lists exactly the two switcher triggers")
+    @Test("allCases lists the switcher triggers plus the direct-activation slots")
     func allCases() {
-        #expect(BetterShortcuts.Name.allCases.count == 2)
-        #expect(BetterShortcuts.Name.allCases.contains(.switchApps))
-        #expect(BetterShortcuts.Name.allCases.contains(.switchWindows))
+        let names = BetterShortcuts.Name.allCases
+        #expect(names.contains(.switchApps))
+        #expect(names.contains(.switchWindows))
+        #expect(BetterShortcuts.Name.directActivate.count == BetterShortcuts.Name.directActivateSlotCount)
+        #expect(names.count == 2 + BetterShortcuts.Name.directActivateSlotCount)
     }
 }


### PR DESCRIPTION
Completes the feature set started in #3, which merged only the two new files (`HoverActionBar.swift`, `DirectActivation.swift`) and left `main` non-compiling. This adds the 22 supporting edits, split into six feature-grouped commits:

1. `feat(prefs)` — preferences + shortcut names
2. `feat(windows)` — window-move actions + Space private APIs
3. `feat(catalog)` — current-Space-only filter
4. `feat(switcher)` — hover buttons, window-title toggle, theming
5. `feat(input)` — hotkey dispatch, swipe-spaces, direct-activation wiring
6. `feat(settings)` — settings UI

## Testing
- `xcodebuild build` — BUILD SUCCEEDED
- `xcodebuild test -only-testing:BetterCmdTabTests` — 63/63 passed
- GUI behaviors (hover clicks, focus, swipe-spaces, move-to-space) need live-hardware verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)