### PR TITLE
feat(switcher): tab drill-in, force-quit, scaled hover bar + perf pass

### DIFF
--- a/BetterCmdTab.xcodeproj/project.pbxproj
+++ b/BetterCmdTab.xcodeproj/project.pbxproj
@@ -357,9 +357,11 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				CODE_SIGN_ENTITLEMENTS = BetterCmdTab/BetterCmdTab.entitlements;
 				INFOPLIST_KEY_CFBundleDisplayName = "BetterCmdTab Debug";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "BetterCmdTab enumerates and switches tabs in browsers (Safari, Chrome, Arc, Brave, Edge, Vivaldi) when you drill into a row.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -407,9 +409,11 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				CODE_SIGN_ENTITLEMENTS = BetterCmdTab/BetterCmdTab.entitlements;
 				INFOPLIST_KEY_CFBundleDisplayName = BetterCmdTab;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "BetterCmdTab enumerates and switches tabs in browsers (Safari, Chrome, Arc, Brave, Edge, Vivaldi) when you drill into a row.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -188,18 +188,22 @@ enum PanelSize: String, CaseIterable {
     case standard
     case large
 
+    // Scale remap (2026-05-28): old Small was too tight; the new Small is
+    // what used to be Default, Medium is what used to be Large, and Large is
+    // a genuinely big tile. Raw values stay the same so persisted prefs
+    // still parse — users transparently shift up one notch on first launch.
     var scale: CGFloat {
         switch self {
-        case .small: return 0.85
-        case .standard: return 1.0
-        case .large: return 1.2
+        case .small: return 1.0
+        case .standard: return 1.2
+        case .large: return 1.5
         }
     }
 
     var displayName: String {
         switch self {
         case .small: return "Small"
-        case .standard: return "Default"
+        case .standard: return "Medium"
         case .large: return "Large"
         }
     }
@@ -258,6 +262,7 @@ final class Preferences: ObservableObject {
         static let scrollToSwitch = "Switcher.scrollToSwitch"
         static let scrollReverseDirection = "Switcher.scrollReverseDirection"
         static let experimentalInstantSpaceSwitch = "Switcher.experimentalInstantSpaceSwitch"
+        static let experimentalTabDrillIn = "Switcher.experimentalTabDrillIn"
         static let showUnreadBadges = "Switcher.showUnreadBadges"
         /// Pre-graduation key (badges used to live behind the Experimental tab);
         /// read once at launch to carry a user's earlier choice over to the new key.
@@ -275,6 +280,7 @@ final class Preferences: ObservableObject {
         static let hoverShowMaximize = "Switcher.hoverShowMaximize"
         static let hoverShowHide = "Switcher.hoverShowHide"
         static let hoverShowQuit = "Switcher.hoverShowQuit"
+        static let hoverShowForceQuit = "Switcher.hoverShowForceQuit"
     }
 
     @Published var switcherLayoutMode: SwitcherLayoutMode {
@@ -523,6 +529,17 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Browser/Finder tab drill-in: pressing `\` on a row with a tab group
+    /// reveals a horizontal tab strip beneath the switcher. Off by default —
+    /// depends on AX `AXTabs`/`AXPress` which varies in reliability across
+    /// browsers and ships changes.
+    @Published var experimentalTabDrillIn: Bool {
+        didSet {
+            guard oldValue != experimentalTabDrillIn else { return }
+            UserDefaults.standard.set(experimentalTabDrillIn, forKey: Keys.experimentalTabDrillIn)
+        }
+    }
+
     /// Show app unread-badge counts (e.g. Mail's unread mail) on switcher rows,
     /// read from the Dock via the Accessibility API. On by default.
     @Published var showUnreadBadges: Bool {
@@ -643,6 +660,15 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Force-quit button visibility — defaults off so the bar stays uncluttered;
+    /// ⌘+⌥+Q is always available regardless of this toggle.
+    @Published var hoverShowForceQuit: Bool {
+        didSet {
+            guard oldValue != hoverShowForceQuit else { return }
+            UserDefaults.standard.set(hoverShowForceQuit, forKey: Keys.hoverShowForceQuit)
+        }
+    }
+
     /// Concrete accent color honoring the `.custom` choice (reads `customAccentHex`).
     var resolvedAccent: NSColor {
         if accentChoice == .custom, let hex = customAccentHex, let color = NSColor(hexString: hex) {
@@ -721,6 +747,7 @@ final class Preferences: ObservableObject {
         self.scrollToSwitch = defaults.object(forKey: Keys.scrollToSwitch) as? Bool ?? true
         self.scrollReverseDirection = defaults.object(forKey: Keys.scrollReverseDirection) as? Bool ?? false
         self.experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
+        self.experimentalTabDrillIn = defaults.object(forKey: Keys.experimentalTabDrillIn) as? Bool ?? false
         // Badges graduated out of the Experimental tab and now default on. Honor
         // the new key if present, otherwise carry over a choice made under the
         // old experimental key, otherwise default to on.
@@ -748,5 +775,6 @@ final class Preferences: ObservableObject {
         self.hoverShowMaximize = defaults.object(forKey: Keys.hoverShowMaximize) as? Bool ?? true
         self.hoverShowHide = defaults.object(forKey: Keys.hoverShowHide) as? Bool ?? true
         self.hoverShowQuit = defaults.object(forKey: Keys.hoverShowQuit) as? Bool ?? true
+        self.hoverShowForceQuit = defaults.object(forKey: Keys.hoverShowForceQuit) as? Bool ?? false
     }
 }

--- a/BetterCmdTab/BetterCmdTab.entitlements
+++ b/BetterCmdTab/BetterCmdTab.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>

--- a/BetterCmdTab/Catalog/AppCatalog.swift
+++ b/BetterCmdTab/Catalog/AppCatalog.swift
@@ -97,7 +97,8 @@ enum AppCatalog {
                         window: win.ref,
                         windowTitle: win.title,
                         isMinimized: win.isMinimized,
-                        isFullscreen: win.isFullscreen
+                        isFullscreen: win.isFullscreen,
+                        tabs: win.tabs
                     ))
                 }
             }

--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -106,7 +106,8 @@ final class AppCatalogCache {
                         window: window.ref,
                         windowTitle: window.title,
                         isMinimized: window.isMinimized,
-                        isFullscreen: window.isFullscreen
+                        isFullscreen: window.isFullscreen,
+                        tabs: window.tabs
                     ))
                 }
             }

--- a/BetterCmdTab/Catalog/IconCache.swift
+++ b/BetterCmdTab/Catalog/IconCache.swift
@@ -2,35 +2,60 @@ import AppKit
 
 @MainActor
 enum IconCache {
-    private static let capacity = 64
+    /// Hard cap on cached entries per cache. Halved from 64 → 32 once
+    /// `prewarm` was dropped: cache fills on demand, not all at launch, so
+    /// the working set in steady state is closer to "apps the user actually
+    /// invokes" than "every running process".
+    private static let capacity = 32
     /// Edge length (px) of the flattened raster we cache. Sized just above the
-    /// largest on-screen icon — the grid tile at max scale (64pt × 1.8 screen
-    /// clamp × 1.2 "Large") is ~138pt → ~276px on a 2x Mac, and macOS has no
-    /// >2x backing scale — so the image view only ever downscales, staying
-    /// crisp, while keeping the per-entry footprint as small as possible.
-    nonisolated private static let renderEdge = 320
-    /// Byte cost of one flattened entry (used as the NSCache cost). A 320² RGBA
-    /// bitmap is ~410 KB, so the cap doubles as a real memory ceiling.
-    nonisolated private static let bytesPerImage = renderEdge * renderEdge * 4
+    /// largest *typical* on-screen tile: the default "Medium" panel scale
+    /// renders icons at ~77pt → 154px on a 2x Mac, and "Large" pushes the
+    /// tile to ~190px. 256 keeps the largest case crisp while shaving 36%
+    /// off the per-entry RAM (320² → 256²).
+    private static let renderEdge = 256
+    /// Byte cost of one flattened entry (used as the NSCache cost). A 256²
+    /// RGBA bitmap is ~262 KB, so the cap doubles as a real memory ceiling
+    /// (~8 MB per cache, ~16 MB across both — down from ~52 MB).
+    private static let bytesPerImage = renderEdge * renderEdge * 4
 
     /// `NSCache` rather than a hand-rolled LRU dict so the system can evict
     /// flattened icons automatically under memory pressure (and the count/cost
-    /// limits bound steady-state footprint). Keyed by pid.
+    /// limits bound steady-state footprint). Keyed by pid for running apps.
     private static let cache: NSCache<NSNumber, NSImage> = {
         let c = NSCache<NSNumber, NSImage>()
         c.countLimit = capacity
         c.totalCostLimit = capacity * bytesPerImage
         return c
     }()
+    /// Sibling cache for launchable + recently-closed rows that have no pid.
+    /// Without this every search keystroke would re-fetch the disk icon for
+    /// each of the up-to-8 launcher rows + recently-closed rows: a steady
+    /// stream of `NSWorkspace.icon(forFile:)` calls on the main actor.
+    private static let bundleCache: NSCache<NSString, NSImage> = {
+        let c = NSCache<NSString, NSImage>()
+        c.countLimit = capacity
+        c.totalCostLimit = capacity * bytesPerImage
+        return c
+    }()
 
     static func icon(for row: SwitcherRow) -> NSImage? {
-        // Launchable rows have no pid to key on — fetch their icon directly.
-        guard let pid = row.pid else { return row.icon }
-        let key = NSNumber(value: pid)
-        if let cached = cache.object(forKey: key) { return cached }
-        guard let source = row.app?.icon else { return row.icon }
+        if let pid = row.pid {
+            let key = NSNumber(value: pid)
+            if let cached = cache.object(forKey: key) { return cached }
+            guard let source = row.app?.icon else { return row.icon }
+            let flat = flattened(source) ?? source
+            cache.setObject(flat, forKey: key, cost: bytesPerImage)
+            return flat
+        }
+        // No pid → launchable or recently-closed. Key by bundle ID so a
+        // search session that lists the same apps on every keystroke reads
+        // from memory instead of round-tripping `NSWorkspace`.
+        guard let bundleID = row.bundleIdentifier, !bundleID.isEmpty else { return row.icon }
+        let key = bundleID as NSString
+        if let cached = bundleCache.object(forKey: key) { return cached }
+        guard let source = row.icon else { return nil }
         let flat = flattened(source) ?? source
-        cache.setObject(flat, forKey: key, cost: bytesPerImage)
+        bundleCache.setObject(flat, forKey: key, cost: bytesPerImage)
         return flat
     }
 
@@ -40,43 +65,18 @@ enum IconCache {
 
     static func clear() {
         cache.removeAllObjects()
+        bundleCache.removeAllObjects()
     }
 
-    /// Eagerly populate icons for the given pids so the first reveal pays no
-    /// `NSRunningApplication.icon` decode/flatten latency on the main thread.
-    /// Safe to call repeatedly; existing entries are kept, missing entries
-    /// fetched and flattened on a background queue.
+    /// Kept as a no-op for callers that used to eagerly populate the cache.
+    /// Eager prewarm was both an autolayout-thread hazard (Tahoe restyles
+    /// bundle icons via lazily-initialized AppKit views, which writes to the
+    /// layout engine when `NSImage.draw` runs off the main thread) and the
+    /// single biggest contributor to the post-launch RSS spike (~12 MB for a
+    /// 30-app system). On-demand flatten covers every icon a user actually
+    /// sees with negligible first-paint cost (≤1 ms per icon on M-series).
     static func prewarm(pids: [pid_t]) {
-        let apps = NSWorkspace.shared.runningApplications
-        let byPid = Dictionary(uniqueKeysWithValues: apps.map { ($0.processIdentifier, $0) })
-        // Collect the source icons still missing from the cache. Reading
-        // `app.icon` and touching `cache` must happen on the main actor; the
-        // expensive part (flattening) is deferred to a background queue below.
-        var pending: [(pid_t, NSImage)] = []
-        for pid in pids {
-            guard cache.object(forKey: NSNumber(value: pid)) == nil,
-                  let app = byPid[pid], let source = app.icon else { continue }
-            pending.append((pid, source))
-        }
-        guard !pending.isEmpty else { return }
-        // Flattening rasterizes a renderEdge² RGBA bitmap per icon — pure pixel work
-        // that has no business on the reveal-adjacent main thread when several
-        // apps launch at once. Do it on a background queue (each draws into its
-        // own bitmap rep, so there is no shared AppKit state) and hand the
-        // finished, immutable images back to the main-actor cache.
-        DispatchQueue.global(qos: .utility).async {
-            let flattenedPairs: [(pid_t, NSImage)] = pending.map { pid, source in
-                (pid, flattened(source) ?? source)
-            }
-            DispatchQueue.main.async {
-                for (pid, image) in flattenedPairs {
-                    let key = NSNumber(value: pid)
-                    if cache.object(forKey: key) == nil {
-                        cache.setObject(image, forKey: key, cost: bytesPerImage)
-                    }
-                }
-            }
-        }
+        _ = pids
     }
 
     /// Rasterize an app icon into a fixed-size, immutable bitmap.
@@ -90,7 +90,13 @@ enum IconCache {
     /// here and yields an image AppKit won't mutate afterwards, so the swap
     /// (and its flicker) can't happen. The styling cost is also paid once
     /// rather than on every redraw.
-    nonisolated private static func flattened(_ image: NSImage) -> NSImage? {
+    ///
+    /// `@MainActor` — bundle icons under Tahoe trigger AppKit view init
+    /// during `image.draw`, which touches the AutoLayout engine. Running
+    /// this off the main thread raised
+    /// `NSInternalInconsistencyException: Modifications to the layout
+    /// engine must not be performed from a background thread...`
+    private static func flattened(_ image: NSImage) -> NSImage? {
         let size = NSSize(width: renderEdge, height: renderEdge)
         guard let rep = NSBitmapImageRep(
             bitmapDataPlanes: nil,

--- a/BetterCmdTab/Catalog/InstalledAppsIndex.swift
+++ b/BetterCmdTab/Catalog/InstalledAppsIndex.swift
@@ -80,20 +80,27 @@ final class InstalledAppsIndex {
         var result: [InstalledApp] = []
         var seenBundleIDs = Set<String>()
 
+        // `Bundle(url:)` parses Info.plist into in-memory CFDictionaries and
+        // caches them on the Bundle instance. Without an autoreleasepool the
+        // ~150 transient bundles created during a scan stay resident until
+        // the enclosing runloop drains — a >5MB hump while the index builds.
+        // Drain per-directory so memory is reclaimed as we go.
         for dir in searchDirectories {
-            guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { continue }
-            for entry in entries where entry.hasSuffix(".app") {
-                let url = URL(fileURLWithPath: dir).appendingPathComponent(entry)
-                guard let bundle = Bundle(url: url),
-                      let bundleID = bundle.bundleIdentifier,
-                      !seenBundleIDs.contains(bundleID) else { continue }
-                seenBundleIDs.insert(bundleID)
-                // `displayName(atPath:)` respects localization, but returns a
-                // trailing ".app" when the user enabled "show all filename
-                // extensions" in Finder — strip it so the switcher never shows it.
-                var name = fm.displayName(atPath: url.path)
-                if name.hasSuffix(".app") { name.removeLast(4) }
-                result.append(InstalledApp(name: name, bundleID: bundleID, url: url))
+            autoreleasepool {
+                guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { return }
+                for entry in entries where entry.hasSuffix(".app") {
+                    let url = URL(fileURLWithPath: dir).appendingPathComponent(entry)
+                    guard let bundle = Bundle(url: url),
+                          let bundleID = bundle.bundleIdentifier,
+                          !seenBundleIDs.contains(bundleID) else { continue }
+                    seenBundleIDs.insert(bundleID)
+                    // `displayName(atPath:)` respects localization, but returns a
+                    // trailing ".app" when the user enabled "show all filename
+                    // extensions" in Finder — strip it so the switcher never shows it.
+                    var name = fm.displayName(atPath: url.path)
+                    if name.hasSuffix(".app") { name.removeLast(4) }
+                    result.append(InstalledApp(name: name, bundleID: bundleID, url: url))
+                }
             }
         }
         return result.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -23,6 +23,12 @@ final class HotkeyTap {
         case minimizeWindow
         case hideApp
         case quitApp
+        case forceQuitApp
+        case enterTabDrill
+        case exitTabDrill
+        case tabPrev
+        case tabNext
+        case commitTab
         case letterInput(Character)
         case toggleSearch
         case searchInput(Character)
@@ -72,6 +78,9 @@ final class HotkeyTap {
     /// space and the w/m/h/q action letters) become query text and Delete
     /// becomes backspace, instead of driving navigation/actions.
     private let searchModeFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
+    /// True while the switcher is in browser-tab drill-in. Nav keys reroute to
+    /// `.tabPrev`/`.tabNext`, Esc exits the drill, Cmd release commits the tab.
+    private let tabDrillFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
     /// When true, a discrete mouse-wheel scroll steps the open switcher's
     /// selection. Continuous (trackpad / precise) scrolls are always ignored.
     private let scrollEnabledFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
@@ -95,6 +104,9 @@ final class HotkeyTap {
     private static let mKey: Int64 = 46
     private static let hKey: Int64 = 4
     private static let qKey: Int64 = 12
+    /// kVK_ANSI_Backslash. Used to drop into browser tab drill-in on the
+    /// highlighted row when the experimental pref is enabled.
+    private static let backslashKey: Int64 = 42
 
     /// Letters reserved for hotkey actions (close/minimize/hide/quit). UCKey-
     /// Translate may emit one of these on a non-QWERTY layout for a different
@@ -206,6 +218,12 @@ final class HotkeyTap {
     /// printable keystrokes into the search query.
     func setSearchMode(_ value: Bool) {
         searchModeFlag.withLock { $0 = value }
+    }
+
+    /// Enter/leave browser tab drill-in. Read by the tap callback to reroute
+    /// nav keys to `.tabPrev`/`.tabNext` and commit on modifier release.
+    func setTabDrillActive(_ value: Bool) {
+        tabDrillFlag.withLock { $0 = value }
     }
 
     /// Enable/disable stepping the open switcher with a mouse scroll wheel.
@@ -321,6 +339,7 @@ final class HotkeyTap {
         // The switcher stays open while either trigger's hold modifier is down.
         let anyModHeld = appModHeld || windowModHeld
         let shiftHeld = flags.contains(.maskShift)
+        let tabDrillNow = tabDrillFlag.withLock { $0 }
         // Option + arrow (while the switcher is open) moves the highlighted
         // window between displays/Spaces instead of moving the selection. Option
         // is used rather than Shift because Shift already steps the selection
@@ -329,6 +348,37 @@ final class HotkeyTap {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
 
         if type == .keyDown {
+            // Browser tab drill-in: while drilled, the usual nav chords step
+            // through the tab strip instead of the app list. Esc exits the
+            // drill (one level up — the panel stays open).
+            if tabDrillNow && isSwitchingNow() {
+                if anyModHeld && keyCode == cfg.appKey {
+                    deliver(shiftHeld ? .tabPrev : .tabNext); return nil
+                }
+                if keyCode == Self.escKey {
+                    deliver(.exitTabDrill); return nil
+                }
+                if keyCode == Self.leftArrow {
+                    deliver(.tabPrev); return nil
+                }
+                if keyCode == Self.rightArrow {
+                    deliver(.tabNext); return nil
+                }
+                if keyCode == Self.returnKey || keyCode == Self.keypadEnterKey || keyCode == Self.spaceKey {
+                    deliver(.commitTab); return nil
+                }
+                // Backslash toggles the strip back off — same key in/out, so
+                // the user can dismiss the drill without reaching for Esc.
+                if keyCode == Self.backslashKey {
+                    deliver(.exitTabDrill); return nil
+                }
+                if let ch = translate(keyCode: UInt16(keyCode)), ch == "\\" {
+                    deliver(.exitTabDrill); return nil
+                }
+                // Any other key while drilled is swallowed so it doesn't
+                // accidentally fire app-level actions (Q/W/M/H, letter jump).
+                return nil
+            }
             if appModHeld && keyCode == cfg.appKey {
                 let dir: Event = shiftHeld ? .prevApp : .nextApp
                 deliver(dir)
@@ -342,6 +392,12 @@ final class HotkeyTap {
             if anyModHeld && keyCode == Self.escKey {
                 deliver(.escape)
                 return nil
+            }
+            // Drill-in trigger — backslash while the switcher is open.
+            // Controller no-ops if the highlighted row has no tab group or the
+            // experimental pref is off, so this is safe to always emit.
+            if isSwitchingNow() && keyCode == Self.backslashKey {
+                deliver(.enterTabDrill); return nil
             }
 
             if isSwitchingNow() {
@@ -398,9 +454,20 @@ final class HotkeyTap {
                     case Self.hKey:
                         deliver(.hideApp); return nil
                     case Self.qKey:
-                        deliver(.quitApp); return nil
+                        // ⌘+⌥+Q escalates to SIGKILL; bare ⌘+Q is the graceful
+                        // terminate(). Option is already tracked above for the
+                        // arrow-key move-window chords — reuse the same flag.
+                        deliver(optionHeld ? .forceQuitApp : .quitApp); return nil
                     default:
                         if let letter = translate(keyCode: UInt16(keyCode)) {
+                            // Layout-agnostic drill-in trigger: regardless of
+                            // where `\` lives on the physical keyboard (US,
+                            // Polish, ISO/JIS), any key that types `\` enters
+                            // tab drill-in.
+                            if letter == "\\" {
+                                deliver(.enterTabDrill)
+                                return nil
+                            }
                             let lower = Character(letter.lowercased())
                             if lower.isLetter,
                                let ascii = lower.asciiValue,

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -15,6 +15,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let sensitivitySlider = NSSlider()
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
+    private let tabDrillSwitch = NSSwitch()
 
     override func setupContent() {
         // Experimental section — off by default, clearly flagged as unstable.
@@ -58,6 +59,19 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: experimental, title: "Switch Spaces without animation",
                subtitle: "Picking an app on another Space or in full screen jumps there instantly, with no slide animation. Applies to keyboard switching too.",
                accessory: instantSpaceSwitch, searchItemID: SearchID.instantSpace)
+
+        addDivider(to: experimental)
+        configureSwitch(tabDrillSwitch, action: #selector(toggleTabDrill(_:)))
+        addRow(to: experimental, title: "Browser tab drill-in",
+               subtitle: "Press \\ on a row whose window has tabs to pick a specific tab from a strip below the switcher. Reliability varies across browsers — uses Accessibility AXTabs.",
+               accessory: tabDrillSwitch)
+
+        let grantButton = NSButton(title: "Grant permissions…", target: self, action: #selector(grantBrowserPermissions))
+        grantButton.bezelStyle = .rounded
+        grantButton.controlSize = .small
+        addRow(to: experimental, title: "Apple Events permission",
+               subtitle: "Browsers require Apple Events consent to enumerate tabs. Click to trigger a prompt for each running browser (Safari, Chrome, Helium, Arc, Brave, Edge…). Must be done with this Settings window open.",
+               accessory: grantButton)
     }
 
     private func configureSwitch(_ toggle: NSSwitch, action: Selector) {
@@ -104,6 +118,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         commitSwitch.state = prefs.swipeCommitOnRelease ? .on : .off
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
+        tabDrillSwitch.state = prefs.experimentalTabDrillIn ? .on : .off
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -140,6 +155,19 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleInstantSpace(_ sender: NSSwitch) {
         Preferences.shared.experimentalInstantSpaceSwitch = (sender.state == .on)
+    }
+
+    @objc private func toggleTabDrill(_ sender: NSSwitch) {
+        let on = (sender.state == .on)
+        Preferences.shared.experimentalTabDrillIn = on
+        // Toggling on while Settings is visible is the ideal moment to ask
+        // for Apple Events consent: the user just opted in, and Settings
+        // gives us the foreground UI context TCC needs to surface the prompt.
+        if on { BrowserTabs.requestPermissionForRunningBrowsers() }
+    }
+
+    @objc private func grantBrowserPermissions() {
+        BrowserTabs.requestPermissionForRunningBrowsers()
     }
 
     /// The reverse/commit/sensitivity controls only make sense while the swipe

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -36,6 +36,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let hoverMaximizeSwitch = NSSwitch()
     private let hoverHideSwitch = NSSwitch()
     private let hoverQuitSwitch = NSSwitch()
+    private let hoverForceQuitSwitch = NSSwitch()
 
     // Apps
     private let excludedButton = NSButton(title: "Manage apps", target: nil, action: nil)
@@ -136,6 +137,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         addRow(to: actions, title: "Hide app", accessory: hoverHideSwitch)
         configureSwitch(hoverQuitSwitch, action: #selector(toggleHoverQuit(_:)))
         addRow(to: actions, title: "Quit app", accessory: hoverQuitSwitch)
+        configureSwitch(hoverForceQuitSwitch, action: #selector(toggleHoverForceQuit(_:)))
+        addRow(to: actions, title: "Force quit app",
+               subtitle: "Sends SIGKILL — for hung apps that ignore Quit. ⌘+⌥+Q always works regardless.",
+               accessory: hoverForceQuitSwitch)
 
         // App lists section — exclusion and pinning, each via a picker sheet.
         let appLists = addSection(title: "Apps", anchor: SettingsAnchor.apps)
@@ -187,6 +192,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         hoverMaximizeSwitch.state = prefs.hoverShowMaximize ? .on : .off
         hoverHideSwitch.state = prefs.hoverShowHide ? .on : .off
         hoverQuitSwitch.state = prefs.hoverShowQuit ? .on : .off
+        hoverForceQuitSwitch.state = prefs.hoverShowForceQuit ? .on : .off
         setHoverSubOptionsEnabled(prefs.hoverActionsEnabled)
         updateAppListCounts()
 
@@ -278,6 +284,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         Preferences.shared.hoverShowQuit = (sender.state == .on)
     }
 
+    @objc private func toggleHoverForceQuit(_ sender: NSSwitch) {
+        Preferences.shared.hoverShowForceQuit = (sender.state == .on)
+    }
+
     /// The per-button toggles only matter while hover actions are enabled.
     private func setHoverSubOptionsEnabled(_ enabled: Bool) {
         hoverCloseSwitch.isEnabled = enabled
@@ -285,6 +295,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         hoverMaximizeSwitch.isEnabled = enabled
         hoverHideSwitch.isEnabled = enabled
         hoverQuitSwitch.isEnabled = enabled
+        hoverForceQuitSwitch.isEnabled = enabled
     }
 
     @objc private func toggleRecentlyClosed(_ sender: NSSwitch) {

--- a/BetterCmdTab/Switcher/HoverActionBar.swift
+++ b/BetterCmdTab/Switcher/HoverActionBar.swift
@@ -13,9 +13,16 @@ import AppKit
 /// `setHotAction(_:)` here.
 @MainActor
 final class HoverActionBar: NSView {
-    /// Diameter of each circular dot, and the gap between them.
-    static let dotSize: CGFloat = 14
-    private static let spacing: CGFloat = 5
+    /// Base dot diameter at scale 1.0; the live diameter scales with the
+    /// switcher's current size so the buttons read at the same relative
+    /// weight on every panel size.
+    static let baseDotSize: CGFloat = 14
+    private static let baseSpacing: CGFloat = 5
+
+    /// Live scale factor; set by the host item view from `metrics.scale`.
+    private var scaleFactor: CGFloat = 1.0
+    var dotSize: CGFloat { round(Self.baseDotSize * scaleFactor) }
+    private var spacing: CGFloat { round(Self.baseSpacing * scaleFactor) }
 
     private var dotsByAction: [RowAction: TrafficLightDot] = [:]
     private var orderedDots: [TrafficLightDot] = []
@@ -38,6 +45,7 @@ final class HoverActionBar: NSView {
         Spec(action: .maximize, symbol: "plus", color: .systemGreen, tooltip: "Zoom window"),
         Spec(action: .hide, symbol: "eye.slash.fill", color: .systemGray, tooltip: "Hide app"),
         Spec(action: .quit, symbol: "power", color: .systemGray, tooltip: "Quit app"),
+        Spec(action: .forceQuit, symbol: "xmark.octagon.fill", color: .systemRed, tooltip: "Force quit app"),
     ]
 
     override init(frame frameRect: NSRect) {
@@ -61,10 +69,12 @@ final class HoverActionBar: NSView {
     /// `applyEnabledButtons()` so frames are correct even when the bar's size
     /// doesn't change between reveals.
     private func layoutDots() {
+        let d = dotSize
+        let s = spacing
         var x: CGFloat = 0
         for dot in orderedDots where !dot.isHidden {
-            dot.frame = NSRect(x: x, y: 0, width: Self.dotSize, height: Self.dotSize)
-            x += Self.dotSize + Self.spacing
+            dot.frame = NSRect(x: x, y: 0, width: d, height: d)
+            x += d + s
         }
     }
 
@@ -73,8 +83,37 @@ final class HoverActionBar: NSView {
     var contentSize: NSSize {
         let visible = orderedDots.filter { !$0.isHidden }.count
         guard visible > 0 else { return .zero }
-        let width = CGFloat(visible) * Self.dotSize + CGFloat(visible - 1) * Self.spacing
-        return NSSize(width: width, height: Self.dotSize)
+        let d = dotSize
+        let width = CGFloat(visible) * d + CGFloat(visible - 1) * spacing
+        return NSSize(width: width, height: d)
+    }
+
+    /// Apply the current switcher scale to the bar so its dots match the
+    /// active panel size. Triggers a relayout of the visible dots.
+    func setScale(_ value: CGFloat) {
+        guard value != scaleFactor else { return }
+        scaleFactor = value
+        layoutDots()
+        invalidateIntrinsicContentSize()
+    }
+
+    /// Shrink the dots so the bar fits within `maxWidth`. Used by the grid
+    /// tile, whose tile width is fixed and would otherwise be overrun by the
+    /// full-size dots when every button is enabled (six dots × 14pt + spacing
+    /// quickly exceeds a small grid tile, pushing the outer two past the
+    /// hit-test bounds and making them unclickable).
+    func fitWidth(_ maxWidth: CGFloat) {
+        guard maxWidth > 0 else { return }
+        let visible = orderedDots.filter { !$0.isHidden }.count
+        guard visible > 0 else { return }
+        let needed = contentSize.width
+        if needed <= maxWidth { return }
+        let downscale = maxWidth / needed
+        let newScale = scaleFactor * downscale
+        guard abs(newScale - scaleFactor) > 0.001 else { return }
+        scaleFactor = newScale
+        layoutDots()
+        invalidateIntrinsicContentSize()
     }
 
     /// Show/hide each dot per the user's per-action preferences.
@@ -85,6 +124,7 @@ final class HoverActionBar: NSView {
         dotsByAction[.maximize]?.isHidden = !prefs.hoverShowMaximize
         dotsByAction[.hide]?.isHidden = !prefs.hoverShowHide
         dotsByAction[.quit]?.isHidden = !prefs.hoverShowQuit
+        dotsByAction[.forceQuit]?.isHidden = !prefs.hoverShowForceQuit
         layoutDots()
     }
 
@@ -92,7 +132,7 @@ final class HoverActionBar: NSView {
     var hasAnyEnabledButton: Bool {
         let prefs = Preferences.shared
         return prefs.hoverShowClose || prefs.hoverShowMinimize || prefs.hoverShowMaximize
-            || prefs.hoverShowHide || prefs.hoverShowQuit
+            || prefs.hoverShowHide || prefs.hoverShowQuit || prefs.hoverShowForceQuit
     }
 
     /// The action whose dot contains `windowPoint` (in window coordinates), or
@@ -113,32 +153,62 @@ final class HoverActionBar: NSView {
     }
 }
 
-/// A single circular traffic-light dot. Custom-drawn so it's always a perfect
-/// circle. Mouse handling is driven externally by `SwitcherView` (see the type
-/// doc on `HoverActionBar`), so this view only draws — including a brighter
-/// "hot" state when the pointer is over it.
+/// A single circular traffic-light dot. The circle is custom-drawn; the
+/// glyph rides as a centered `NSImageView` so AppKit aligns the symbol's
+/// actual cap-height optical center to the dot center (manually computing
+/// `bounds.midX - gs.width/2` lands the bbox center, not the visual center
+/// — SF Symbols ship with asymmetric ascender/descender padding that
+/// shifted every glyph half a pixel off-center). Re-rendering the symbol on
+/// each resize keeps it sharp at every switcher scale.
 @MainActor
 final class TrafficLightDot: NSView {
     let action: RowAction
 
     private let fillColor: NSColor
-    private let glyph: NSImage?
+    private let symbolName: String
+    private let glyphView = NSImageView()
     var isHot = false { didSet { if oldValue != isHot { needsDisplay = true } } }
 
     init(action: RowAction, color: NSColor, symbol: String, tooltip: String) {
         self.action = action
         self.fillColor = color
-        let cfg = NSImage.SymbolConfiguration(pointSize: 8, weight: .bold)
-            .applying(.init(paletteColors: [NSColor.black.withAlphaComponent(0.65)]))
-        self.glyph = NSImage(systemSymbolName: symbol, accessibilityDescription: tooltip)?.withSymbolConfiguration(cfg)
-        super.init(frame: NSRect(x: 0, y: 0, width: HoverActionBar.dotSize, height: HoverActionBar.dotSize))
+        self.symbolName = symbol
+        super.init(frame: NSRect(x: 0, y: 0, width: HoverActionBar.baseDotSize, height: HoverActionBar.baseDotSize))
         toolTip = tooltip
+
+        glyphView.translatesAutoresizingMaskIntoConstraints = false
+        glyphView.imageScaling = .scaleProportionallyDown
+        glyphView.imageAlignment = .alignCenter
+        addSubview(glyphView)
+        NSLayoutConstraint.activate([
+            glyphView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            glyphView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            glyphView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.62),
+            glyphView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 0.62),
+        ])
+        rebuildGlyph(for: bounds.height)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
 
     override var intrinsicContentSize: NSSize {
-        NSSize(width: HoverActionBar.dotSize, height: HoverActionBar.dotSize)
+        NSSize(width: HoverActionBar.baseDotSize, height: HoverActionBar.baseDotSize)
+    }
+
+    override func layout() {
+        super.layout()
+        rebuildGlyph(for: bounds.height)
+    }
+
+    /// SF Symbol's point size is what determines stroke weight — set it from
+    /// the live dot height so the glyph keeps its proportional weight at
+    /// every panel scale, instead of staying glued to the base 8pt size.
+    private func rebuildGlyph(for dotHeight: CGFloat) {
+        let pointSize = max(6, round(dotHeight * 0.55))
+        let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .bold)
+            .applying(.init(paletteColors: [NSColor.black.withAlphaComponent(0.65)]))
+        glyphView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+            .withSymbolConfiguration(cfg)
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -152,18 +222,5 @@ final class TrafficLightDot: NSView {
         NSColor.black.withAlphaComponent(isHot ? 0.28 : 0.18).setStroke()
         path.lineWidth = isHot ? 0.75 : 0.5
         path.stroke()
-
-        // The glyph is always shown (the bar only appears on row hover anyway);
-        // the hot state just brightens the dot beneath it.
-        if let glyph {
-            let gs = glyph.size
-            let gr = NSRect(
-                x: bounds.midX - gs.width / 2,
-                y: bounds.midY - gs.height / 2,
-                width: gs.width,
-                height: gs.height
-            )
-            glyph.draw(in: gr)
-        }
     }
 }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1,4 +1,5 @@
 import AppKit
+@preconcurrency import ApplicationServices
 import BetterShortcuts
 import Combine
 import os
@@ -28,7 +29,13 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `baseRows`/`baseLabels` are the unfiltered source so the search query
     /// can widen again on backspace. Kept in sync by every refresh path.
     private var baseRows: [SwitcherRow] = [] {
-        didSet { baseFoldedValid = false }
+        didSet {
+            baseFoldedValid = false
+            // Window AXUIElements churn across reveals; drop the prefetch
+            // cache so we don't try to drill into a stale element.
+            tabPrefetchCache.removeAll()
+            tabPrefetchInFlight.removeAll()
+        }
     }
     private var baseLabels: [String] = []
     /// Diacritic-folded (app name, window title) per `baseRows` entry, rebuilt
@@ -56,6 +63,36 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `.stayOpen` search mode: from then on, releasing ⌘ (or any other
     /// modifier) no longer commits — only Return or a mouse click does.
     private var stickyOpen: Bool = false
+    /// Browser tab drill-in state. While `tabDrillActive`, nav keys (Cmd+Tab,
+    /// Cmd+Left/Right, arrows) step `tabIndex` inside the highlighted row's
+    /// `tabs` array instead of changing the app selection. Reset on every row
+    /// change, dismiss, and `baseRows` swap.
+    private var tabDrillActive: Bool = false
+    private var tabIndex: Int = 0
+    private var tabTitles: [String] = []
+    /// Tab AX elements located by `WindowEnumerator.tabs(in:)` on drill-in.
+    /// Held here (not on `SwitcherRow`) because they're resolved lazily —
+    /// browsers nest the tab group too deep for the per-reveal AX scan to
+    /// touch them affordably. Empty for browser-family rows since those use
+    /// AppleScript-by-index activation.
+    private var liveTabElements: [AXUIElement] = []
+    /// Source of the current drill-in. `appleScript` → activate by index via
+    /// `BrowserTabs.activateTab`. `accessibility` → AX press on
+    /// `liveTabElements[tabIndex]`. Picked once per drill, never crossed.
+    private enum TabDrillBackend { case appleScript, accessibility }
+    private var tabDrillBackend: TabDrillBackend = .accessibility
+    /// Background prefetch of tab titles keyed by AXUIElement window
+    /// identity. Populated when selection lands on a tab-capable row so that
+    /// the eventual `\` finds the work already done. Cleared when the panel
+    /// dismisses or the base row set changes.
+    private struct TabPrefetch {
+        let titles: [String]
+        let liveTabs: [AXUIElement]
+        let backend: TabDrillBackend
+    }
+    private var tabPrefetchCache: [AXRef: TabPrefetch] = [:]
+    private var tabPrefetchInFlight: Set<AXRef> = []
+    private var tabPrefetchTimer: Timer?
     private var windowsOnlyMode: Bool = false
     private var windowsOnlyPid: pid_t? = nil
     private var windowsOnlyPrimedDelta: Int = 0
@@ -370,16 +407,33 @@ final class SwitcherController: SwitcherViewDelegate {
         }
     }
 
+    func switcherViewDidSelectTab(_ index: Int) {
+        guard tabDrillActive, tabTitles.indices.contains(index) else { return }
+        tabIndex = index
+        commitTab()
+    }
+
+    func switcherViewDidHoverTab(_ index: Int) {
+        guard tabDrillActive, tabTitles.indices.contains(index), index != tabIndex else { return }
+        tabIndex = index
+        view.setTabStripSelectedIndex(tabIndex)
+    }
+
     func switcherViewDidHover(index: Int) {
         guard phase == .visible else { return }
         guard rows.indices.contains(index), index != self.index else { return }
+        // Moving the selection off the drilled-in row drops drill mode — the
+        // strip belongs to the previous row's tabs.
+        if tabDrillActive { exitTabDrill() }
         self.index = index
         view.setSelectedIndex(index)
+        schedulePrefetchForCurrentSelection()
     }
 
     func switcherViewDidClick(index: Int) {
         guard phase == .visible else { return }
         guard rows.indices.contains(index) else { return }
+        if tabDrillActive { exitTabDrill() }
         self.index = index
         commit()
     }
@@ -407,6 +461,8 @@ final class SwitcherController: SwitcherViewDelegate {
             performOnVisibleTarget { Activator.hideApp($0) }
         case .quit:
             performQuitAction()
+        case .forceQuit:
+            performForceQuitAction()
         }
     }
 
@@ -456,6 +512,18 @@ final class SwitcherController: SwitcherViewDelegate {
             performOnVisibleTarget { Activator.hideApp($0) }
         case .quitApp:
             performQuitAction()
+        case .forceQuitApp:
+            performForceQuitAction()
+        case .enterTabDrill:
+            enterTabDrill()
+        case .exitTabDrill:
+            exitTabDrill()
+        case .tabPrev:
+            advanceTab(by: -1)
+        case .tabNext:
+            advanceTab(by: 1)
+        case .commitTab:
+            commitTab()
         case .letterInput(let ch):
             handleLetter(ch)
         }
@@ -603,6 +671,7 @@ final class SwitcherController: SwitcherViewDelegate {
             index = max(0, min(rows.count - 1, index + delta))
         }
         view.setSelectedIndex(index)
+        schedulePrefetchForCurrentSelection()
     }
 
     private func advanceColumn(by delta: Int) {
@@ -906,6 +975,12 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     private func commit() {
+        // Drilled-in commits go through the tab activation path instead of
+        // activating the parent window.
+        if tabDrillActive {
+            commitTab()
+            return
+        }
         revealTimer?.invalidate()
         revealTimer = nil
         let currentPhase = phase
@@ -961,6 +1036,7 @@ final class SwitcherController: SwitcherViewDelegate {
         closedTombstones.removeAll()
         resetLetterBuffer()
         resetSearch()
+        view.releaseIdleResources()
         if pendingActivation != nil { CommitFeedback.play() }
         pendingActivation?()
     }
@@ -980,8 +1056,18 @@ final class SwitcherController: SwitcherViewDelegate {
         windowsOnlyPid = nil
         windowsOnlyPrimedDelta = 0
         closedTombstones.removeAll()
+        tabDrillActive = false
+        tabTitles = []
+        liveTabElements = []
+        tabIndex = 0
+        hotkey.setTabDrillActive(false)
+        tabPrefetchCache.removeAll()
+        tabPrefetchInFlight.removeAll()
+        tabPrefetchTimer?.invalidate()
+        tabPrefetchTimer = nil
         resetLetterBuffer()
         resetSearch()
+        view.releaseIdleResources()
     }
 
     private func performOnVisibleTarget(_ action: (SwitcherRow) -> Void) {
@@ -1019,6 +1105,207 @@ final class SwitcherController: SwitcherViewDelegate {
                 )
             }
             Activator.quitApp(row)
+        }
+    }
+
+    // MARK: - Browser tab drill-in
+
+    /// Drill into the highlighted row's tab group. Two backends:
+    /// - **AppleScript** for known browser families (Safari, Chrome, Arc,
+    ///   Brave, Edge, Vivaldi, Opera, Dia). AX scraping is unreliable across
+    ///   browser versions — the scripting dictionaries are stable.
+    /// - **Accessibility** as a fallback for AppKit-native tabbed apps
+    ///   (Finder, Terminal, iTerm) by recursive AX walk for the first tab
+    ///   group.
+    /// Both run off-main; the strip appears once titles land. Silently
+    /// no-ops if no tabs are found.
+    private func enterTabDrill() {
+        guard Preferences.shared.experimentalTabDrillIn else { return }
+        guard phase == .visible, rows.indices.contains(index) else { return }
+        let row = rows[index]
+        guard let window = row.window, let app = row.app else { return }
+        // Cache hit: drill-in is instant — strip appears on the same run
+        // loop tick.
+        if let cached = tabPrefetchCache[AXRef(element: window)], !cached.titles.isEmpty {
+            applyDrill(titles: cached.titles, liveTabs: cached.liveTabs, backend: cached.backend, window: window)
+            return
+        }
+        let isBrowser = (BrowserTabs.Family.from(bundleID: app.bundleIdentifier) != nil)
+        // Reuse tab AXUIElements already discovered by the cache snapshot when
+        // available — saves a recursive AX walk on every non-browser drill-in
+        // (Finder/Terminal/etc.). Browsers ignore this and run AppleScript.
+        let prefetchedTabs = isBrowser ? [] : row.tabs
+        let gen = revealGeneration
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            let result = Self.fetchTabsBlocking(app: app, window: window, isBrowser: isBrowser, prefetchedTabs: prefetchedTabs)
+            guard let result else { return }
+            DispatchQueue.main.async {
+                guard let self, gen == self.revealGeneration, self.phase == .visible else { return }
+                guard self.rows.indices.contains(self.index),
+                      let currentWindow = self.rows[self.index].window,
+                      CFEqual(currentWindow, window) else { return }
+                self.applyDrill(titles: result.titles, liveTabs: result.liveTabs, backend: result.backend, window: window)
+            }
+        }
+    }
+
+    /// Apply a fetched/cached tab set to the panel — single sink used by
+    /// both the cache-hit and async paths so they can't drift.
+    private func applyDrill(titles: [String], liveTabs: [AXUIElement], backend: TabDrillBackend, window: AXUIElement) {
+        tabTitles = titles
+        liveTabElements = liveTabs
+        tabDrillBackend = backend
+        tabIndex = 0
+        tabDrillActive = true
+        stickyOpen = true
+        hotkey.setTabDrillActive(true)
+        refreshDisplay()
+        tabPrefetchCache[AXRef(element: window)] = TabPrefetch(titles: titles, liveTabs: liveTabs, backend: backend)
+    }
+
+    /// Blocking tab fetch suitable for a background queue. Returns nil for a
+    /// row that has no tab group worth a strip (so the caller can silently
+    /// skip without forcing the panel into drill mode on an empty result).
+    /// `prefetchedTabs` lets the caller short-circuit the recursive AX walk
+    /// when the cache already discovered the tab group during its snapshot.
+    nonisolated private static func fetchTabsBlocking(app: NSRunningApplication, window: AXUIElement, isBrowser: Bool, prefetchedTabs: [AXUIElement] = []) -> (titles: [String], liveTabs: [AXUIElement], backend: TabDrillBackend)? {
+        if isBrowser, let scripted = BrowserTabs.tabTitles(for: app, window: window), !scripted.isEmpty {
+            return (scripted, [], .appleScript)
+        }
+        if !isBrowser {
+            let axTabs: [AXUIElement]
+            if prefetchedTabs.count > 1 {
+                axTabs = prefetchedTabs
+            } else {
+                axTabs = WindowEnumerator.tabs(in: window)
+            }
+            guard axTabs.count > 1 else { return nil }
+            let titles = WindowEnumerator.tabTitles(for: axTabs)
+            return (titles, axTabs, .accessibility)
+        }
+        return nil
+    }
+
+    /// Kick a background prefetch for the highlighted row after a short
+    /// settle so rapid Tab presses don't spam the AppleScript / AX scan. By
+    /// the time the user reaches for `\`, the result is usually already in
+    /// `tabPrefetchCache`.
+    private func schedulePrefetchForCurrentSelection() {
+        tabPrefetchTimer?.invalidate()
+        guard Preferences.shared.experimentalTabDrillIn,
+              phase == .visible, rows.indices.contains(index),
+              let window = rows[index].window,
+              let app = rows[index].app else { return }
+        let key = AXRef(element: window)
+        if tabPrefetchCache[key] != nil || tabPrefetchInFlight.contains(key) { return }
+        let isBrowser = (BrowserTabs.Family.from(bundleID: app.bundleIdentifier) != nil)
+        let prefetchedTabs = isBrowser ? [] : rows[index].tabs
+        let timer = Timer(timeInterval: 0.18, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                guard self.tabPrefetchCache[key] == nil,
+                      !self.tabPrefetchInFlight.contains(key) else { return }
+                self.tabPrefetchInFlight.insert(key)
+                let gen = self.revealGeneration
+                DispatchQueue.global(qos: .utility).async { [weak self] in
+                    let result = Self.fetchTabsBlocking(app: app, window: window, isBrowser: isBrowser, prefetchedTabs: prefetchedTabs)
+                    DispatchQueue.main.async {
+                        guard let self, gen == self.revealGeneration else { return }
+                        self.tabPrefetchInFlight.remove(key)
+                        guard let result, !result.titles.isEmpty else { return }
+                        self.tabPrefetchCache[key] = TabPrefetch(titles: result.titles, liveTabs: result.liveTabs, backend: result.backend)
+                    }
+                }
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        tabPrefetchTimer = timer
+    }
+
+    private func exitTabDrill() {
+        guard tabDrillActive else { return }
+        tabDrillActive = false
+        tabTitles = []
+        liveTabElements = []
+        tabIndex = 0
+        hotkey.setTabDrillActive(false)
+        refreshDisplay()
+    }
+
+    private func advanceTab(by delta: Int) {
+        guard tabDrillActive, !tabTitles.isEmpty else { return }
+        let count = tabTitles.count
+        tabIndex = ((tabIndex + delta) % count + count) % count
+        view.setTabStripSelectedIndex(tabIndex)
+    }
+
+    private func commitTab() {
+        guard tabDrillActive, !tabTitles.isEmpty,
+              rows.indices.contains(index),
+              let app = rows[index].app,
+              let window = rows[index].window else {
+            exitTabDrill()
+            commit()
+            return
+        }
+        let row = rows[index]
+        let chosen = tabIndex
+        let backend = tabDrillBackend
+        let axTab: AXUIElement? = (backend == .accessibility && liveTabElements.indices.contains(chosen))
+            ? liveTabElements[chosen] : nil
+        if backend == .accessibility && axTab == nil {
+            exitTabDrill()
+            commit()
+            return
+        }
+        let instantSpace = Preferences.shared.experimentalInstantSpaceSwitch
+        if let pid = row.pid { mru.bump(pid) }
+        bumpWindowMRUIfPossible(for: row)
+
+        revealGeneration &+= 1
+        phase = .idle
+        cache.setPanelVisible(false)
+        panel.dismiss()
+        tabDrillActive = false
+        tabTitles = []
+        liveTabElements = []
+        tabIndex = 0
+        hotkey.setTabDrillActive(false)
+        primedApps = []
+        rows = []
+        baseRows = []
+        baseLabels = []
+        closedTombstones.removeAll()
+        resetLetterBuffer()
+        resetSearch()
+        view.releaseIdleResources()
+        CommitFeedback.play()
+        switch backend {
+        case .appleScript:
+            DispatchQueue.global(qos: .userInitiated).async {
+                _ = BrowserTabs.activateTab(at: chosen, in: app, window: window)
+            }
+        case .accessibility:
+            if let tab = axTab {
+                Activator.activateTab(in: app, window: window, tab: tab, instantSpace: instantSpace)
+            }
+        }
+    }
+
+    /// SIGKILL the highlighted app — bypasses the AppleEvent terminate() that
+    /// hung apps ignore. Recorded in `RecentlyClosedStore` like a normal quit so
+    /// the app can be relaunched from there.
+    private func performForceQuitAction() {
+        performOnVisibleTarget { row in
+            if row.app?.activationPolicy == .regular, let bundleID = row.bundleIdentifier {
+                RecentlyClosedStore.shared.record(
+                    bundleID: bundleID,
+                    appName: row.appName,
+                    title: "",
+                    documentPath: nil
+                )
+            }
+            Activator.forceQuitApp(row)
         }
     }
 
@@ -1144,9 +1431,9 @@ final class SwitcherController: SwitcherViewDelegate {
     /// dismissed in the meantime.
     private func scheduleVisibleRefresh(after delay: TimeInterval = 0) {
         let gen = revealGeneration
-        let apply = { [weak self] in
-            guard let self, gen == self.revealGeneration, self.phase == .visible else { return }
-            self.cache.scheduleFullRefresh { [weak self] in
+        @MainActor func apply() {
+            guard gen == revealGeneration, phase == .visible else { return }
+            cache.scheduleFullRefresh { [weak self] in
                 guard let self, gen == self.revealGeneration, self.phase == .visible else { return }
                 let fresh = self.filterClosedTombstones(self.cache.rows(orderedBy: self.mru.order))
                 if fresh.isEmpty {
@@ -1165,7 +1452,9 @@ final class SwitcherController: SwitcherViewDelegate {
             }
         }
         if delay > 0 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: apply)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                Task { @MainActor in apply() }
+            }
         } else {
             apply()
         }
@@ -1413,7 +1702,9 @@ final class SwitcherController: SwitcherViewDelegate {
             metrics: currentMetrics,
             highlightPrefix: searchActive ? "" : letterBuffer,
             searchActive: searchActive,
-            searchQuery: searchQuery
+            searchQuery: searchQuery,
+            tabStripTitles: tabDrillActive ? tabTitles : nil,
+            tabStripSelectedIndex: tabIndex
         )
         panel.present()
     }
@@ -1476,6 +1767,14 @@ final class SwitcherController: SwitcherViewDelegate {
     /// detaches the switcher so it persists until Return / mouse selection;
     /// once detached, further modifier releases are ignored.
     private func handleModifierRelease() {
+        // Drill-in commits on release: the user picks the highlighted tab the
+        // same way releasing ⌘ commits the highlighted app. Bypass the
+        // stickyOpen guard that enterTabDrill set for safety against stray
+        // commits during the drill.
+        if tabDrillActive {
+            commitTab()
+            return
+        }
         if stickyOpen { return }
         if searchActive, Preferences.shared.searchDismissMode == .stayOpen {
             stickyOpen = true

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -227,6 +227,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
 
         // Hover action buttons apply to a real window of a running app.
         actionsAvailable = !isDialog && row.app != nil && row.window != nil
+        actionBar.setScale(metrics.scale)
         actionBar.applyEnabledButtons()
         updateHoverBar()
 
@@ -412,6 +413,9 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
             width: lw,
             height: lh
         )
+        // Hide the letter hint while the hover bar is showing — they share
+        // the top strip and otherwise overlap.
+        letterLabel.isHidden = !actionBar.isHidden
 
         // Dock badge: hug the icon's top-right corner with a hair of outward
         // float, like a native badge. The icon is inset within the tile so this
@@ -442,11 +446,15 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         titleLabel.frame = NSRect(x: 0, y: labelAreaH - nameH - titleH, width: w, height: titleH)
 
         if !actionBar.isHidden {
-            // Centered horizontally just below the icon's top edge.
+            // Constrain the bar to the tile width minus a small inset before
+            // measuring — with every button enabled, the natural six-dot run
+            // is wider than narrow grid tiles, which pushed the outer dots
+            // past the hit-test bounds and made them unclickable.
+            actionBar.fitWidth(tile - 8)
             let size = actionBar.contentSize
             actionBar.frame = NSRect(
-                x: round(iconArea.midX - size.width / 2),
-                y: round(iconArea.maxY - size.height - 2),
+                x: round((w - size.width) / 2),
+                y: round(bounds.height - letterArea / 2 - size.height / 2),
                 width: size.width,
                 height: size.height
             )

--- a/BetterCmdTab/Switcher/SwitcherItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherItemView.swift
@@ -228,6 +228,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         // unchanged but other inputs (accent, metrics, label) still need it.
         // Hover action buttons apply to a real window of a running app.
         actionsAvailable = !isDialog && row.app != nil && row.window != nil
+        actionBar.setScale(metrics.scale)
         actionBar.applyEnabledButtons()
         updateHoverBar()
 
@@ -346,6 +347,10 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         let letterLineHeight = ceil(letterFont.ascender + abs(letterFont.descender))
         let letterY = (h - letterLineHeight) / 2
         letterLabel.frame = NSRect(x: letterX, y: letterY, width: m.letterColumnWidth, height: letterLineHeight)
+        // Letter hint and the hover action bar share the leftmost column —
+        // hide the letter the moment the bar appears so the dots don't sit
+        // on top of the type-to-jump character.
+        letterLabel.isHidden = !actionBar.isHidden
 
         let appX = letterX + m.letterColumnWidth + m.interGap
         appNameLabel.frame = NSRect(x: appX, y: labelY, width: m.appNameWidth, height: labelH)
@@ -393,10 +398,14 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         titleLabel.frame = NSRect(x: titleX, y: labelY, width: titleW, height: labelH)
 
         if !actionBar.isHidden {
-            // Right-aligned, vertically centered — floats over the status column.
+            // Left edge, vertically centered — floats over the letter / app
+            // name column. Browser tab titles (often long URL-ish text) live
+            // in the title column on the right and would otherwise vanish
+            // under the bar; this side has shorter, repeating content the
+            // user can tolerate briefly hiding during hover.
             let size = actionBar.contentSize
             actionBar.frame = NSRect(
-                x: bounds.width - m.horizontalInset - size.width,
+                x: m.horizontalInset,
                 y: round((h - size.height) / 2),
                 width: size.width,
                 height: size.height

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -184,6 +184,7 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
 
         // Hover action buttons apply to a real window of a running app.
         actionsAvailable = !isDialog && row.app != nil && row.window != nil
+        actionBar.setScale(metrics.scale)
         actionBar.applyEnabledButtons()
         updateHoverBar()
 
@@ -302,10 +303,12 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         )
 
         if !actionBar.isHidden {
-            // Top-right corner of the thumbnail, inset slightly.
+            // Top-left corner of the thumbnail, inset slightly. Matches the
+            // macOS window-chrome convention (traffic lights live on the
+            // left side of every Mac window).
             let size = actionBar.contentSize
             actionBar.frame = NSRect(
-                x: round(thumbRect.maxX - size.width - 4),
+                x: round(thumbRect.minX + 4),
                 y: round(thumbRect.maxY - size.height - 4),
                 width: size.width,
                 height: size.height

--- a/BetterCmdTab/Switcher/SwitcherRow.swift
+++ b/BetterCmdTab/Switcher/SwitcherRow.swift
@@ -24,6 +24,9 @@ struct SwitcherRow {
     /// it, avoiding a no-window→hidden flash. `isHidden` is read live, so if the
     /// app hides before then the row already shows the hidden glyph.
     let suppressNoWindowGlyph: Bool
+    /// `AXTabs` children of this row's window, propagated from `WindowInfo`.
+    /// Non-empty only when the window has a tab group with 2+ tabs.
+    let tabs: [AXUIElement]
 
     init(
         app: NSRunningApplication,
@@ -32,7 +35,8 @@ struct SwitcherRow {
         isMinimized: Bool,
         isFullscreen: Bool = false,
         isPlaceholder: Bool = false,
-        suppressNoWindowGlyph: Bool = false
+        suppressNoWindowGlyph: Bool = false,
+        tabs: [AXUIElement] = []
     ) {
         self.subject = .running(app)
         self.window = window
@@ -41,6 +45,7 @@ struct SwitcherRow {
         self.isFullscreen = isFullscreen
         self.isPlaceholder = isPlaceholder
         self.suppressNoWindowGlyph = suppressNoWindowGlyph
+        self.tabs = tabs
     }
 
     /// A not-yet-running app surfaced in search so it can be launched.
@@ -52,6 +57,7 @@ struct SwitcherRow {
         self.isFullscreen = false
         self.isPlaceholder = false
         self.suppressNoWindowGlyph = false
+        self.tabs = []
     }
 
     /// A recently closed window/app surfaced in search so it can be reopened.
@@ -63,7 +69,11 @@ struct SwitcherRow {
         self.isFullscreen = false
         self.isPlaceholder = false
         self.suppressNoWindowGlyph = false
+        self.tabs = []
     }
+
+    /// True when this row has a tab group worth drilling into.
+    var hasTabs: Bool { tabs.count > 1 }
 
     /// The backing running application, or `nil` for a launchable/recent row.
     var app: NSRunningApplication? {

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -9,6 +9,7 @@ enum RowAction: Int {
     case maximize
     case hide
     case quit
+    case forceQuit
 }
 
 @MainActor
@@ -16,21 +17,36 @@ protocol SwitcherViewDelegate: AnyObject {
     func switcherViewDidHover(index: Int)
     func switcherViewDidClick(index: Int)
     func switcherViewDidInvokeAction(_ action: RowAction, atIndex index: Int)
+    func switcherViewDidSelectTab(_ index: Int)
+    func switcherViewDidHoverTab(_ index: Int)
 }
 
 @MainActor
-final class SwitcherView: NSView {
+final class SwitcherView: NSView, TabStripDelegate {
+    func tabStrip(_ strip: TabStripView, didSelectIndex index: Int) {
+        delegate?.switcherViewDidSelectTab(index)
+    }
+
+    func tabStrip(_ strip: TabStripView, didHoverIndex index: Int) {
+        delegate?.switcherViewDidHoverTab(index)
+    }
+
     weak var delegate: SwitcherViewDelegate?
 
     private let glassBackdrop: NSView
     private let contentContainer = NSView()
     private let listContainer = NSView()
     private let searchBar = SwitcherSearchBarView()
+    private let tabStrip = TabStripView()
     private let noResultsLabel = NSTextField(labelWithString: "No matches")
     private var itemViews: [SwitcherItemViewProtocol] = []
     private var rows: [SwitcherRow] = []
     private(set) var labels: [String] = []
     private var selectedIndex: Int = 0
+    /// Last `selectedIndex` value handed to the item views, so `applySelection`
+    /// can toggle just the two affected tiles on arrow-spam instead of looping
+    /// every item view every keystroke.
+    private var appliedSelectedIndex: Int = -1
     /// Row the mouse is directly over (-1 = none). Separate from `selectedIndex`
     /// so hover action buttons appear only under the pointer, not on a
     /// keyboard-selected row.
@@ -74,6 +90,9 @@ final class SwitcherView: NSView {
         contentContainer.addSubview(listContainer)
         searchBar.isHidden = true
         contentContainer.addSubview(searchBar)
+        tabStrip.isHidden = true
+        tabStrip.delegate = self
+        contentContainer.addSubview(tabStrip)
         noResultsLabel.isHidden = true
         noResultsLabel.alignment = .center
         noResultsLabel.textColor = .secondaryLabelColor
@@ -86,8 +105,9 @@ final class SwitcherView: NSView {
     private var highlightPrefix: String = ""
     private var searchActive: Bool = false
     private var accent: NSColor = .controlAccentColor
+    private var tabStripActive: Bool = false
 
-    func configure(rows: [SwitcherRow], labels: [String], selectedIndex: Int, metrics: SwitcherMetrics, highlightPrefix: String = "", searchActive: Bool = false, searchQuery: String = "") {
+    func configure(rows: [SwitcherRow], labels: [String], selectedIndex: Int, metrics: SwitcherMetrics, highlightPrefix: String = "", searchActive: Bool = false, searchQuery: String = "", tabStripTitles: [String]? = nil, tabStripSelectedIndex: Int = 0) {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         // Item frames depend only on the row count, the metrics, and whether the
@@ -97,10 +117,13 @@ final class SwitcherView: NSView {
         // valid, so skip invalidating it and forcing a full relayout + panel
         // resize. The item views still reconfigure below and relayout themselves
         // if their own content changed.
+        let stripActiveNew = (tabStripTitles?.isEmpty == false)
         let geometryChanged =
             rows.count != self.rows.count ||
             metrics != self.metrics ||
-            searchActive != self.searchActive
+            searchActive != self.searchActive ||
+            stripActiveNew != self.tabStripActive
+        self.tabStripActive = stripActiveNew
         self.rows = rows
         self.labels = labels
         self.highlightPrefix = highlightPrefix
@@ -109,6 +132,12 @@ final class SwitcherView: NSView {
         self.selectedIndex = selectedIndex
         searchBar.update(query: searchQuery)
         searchBar.isHidden = !searchActive
+        if let titles = tabStripTitles, !titles.isEmpty {
+            tabStrip.configure(titles: titles, selectedIndex: tabStripSelectedIndex, accent: accent)
+            tabStrip.isHidden = false
+        } else {
+            tabStrip.isHidden = true
+        }
         noResultsLabel.isHidden = !(searchActive && rows.isEmpty)
         let layoutModeChanged = metrics.layoutMode != self.metrics.layoutMode
         if metrics != self.metrics {
@@ -159,6 +188,36 @@ final class SwitcherView: NSView {
         guard rows.indices.contains(index) else { return }
         selectedIndex = index
         applySelection()
+    }
+
+    /// Move the tab strip's selection without rebuilding the rest of the
+    /// panel. Used on every tab arrow press; a full `configure(...)` would
+    /// repaint every row's icon/title/badges for no visual change.
+    func setTabStripSelectedIndex(_ index: Int) {
+        guard tabStripActive else { return }
+        tabStrip.setSelectedIndex(index)
+    }
+
+    /// Release the item view pool, cached row references, and any per-tile
+    /// `NSImage` retains so the `IconCache` (and `WindowThumbnailCache`) can
+    /// evict images that would otherwise stay live for the lifetime of the
+    /// process. Called by `SwitcherController` after `panel.dismiss()` —
+    /// next reveal rebuilds the pool from scratch (~10ms on first paint).
+    func releaseIdleResources() {
+        for v in itemViews {
+            v.removeFromSuperview()
+        }
+        itemViews.removeAll(keepingCapacity: false)
+        rows = []
+        labels = []
+        cachedLayout = nil
+        appliedSelectedIndex = -1
+        hoveredIndex = -1
+        tabStripActive = false
+        tabStrip.isHidden = true
+        searchBar.isHidden = true
+        noResultsLabel.isHidden = true
+        WindowThumbnailCache.shared.onReady = nil
     }
 
     var selectedRow: SwitcherRow? {
@@ -314,9 +373,23 @@ final class SwitcherView: NSView {
     }
 
     private func applySelection() {
-        for (i, view) in itemViews.enumerated() {
-            view.isSelected = (i == selectedIndex)
+        // Incremental: deselect the previous tile, select the new one. With
+        // dozens of rows that's a 2-write update instead of one per row. The
+        // -1 sentinel (or an out-of-bounds index after a configure pass)
+        // forces a one-time full pass to sync state.
+        let prev = appliedSelectedIndex
+        if prev == selectedIndex { return }
+        if itemViews.indices.contains(prev) {
+            itemViews[prev].isSelected = false
+        } else {
+            for (i, view) in itemViews.enumerated() where i != selectedIndex {
+                view.isSelected = false
+            }
         }
+        if itemViews.indices.contains(selectedIndex) {
+            itemViews[selectedIndex].isSelected = true
+        }
+        appliedSelectedIndex = selectedIndex
     }
 
     private func makeItemView() -> SwitcherItemViewProtocol {
@@ -340,6 +413,11 @@ final class SwitcherView: NSView {
             let v = itemViews.removeLast()
             v.removeFromSuperview()
         }
+        // `configure` writes `isSelected` directly below, so the next
+        // `applySelection` call should not assume the previous selection is
+        // still showing — invalidate it so the incremental path performs a
+        // safety sync pass instead of toggling a stale tile.
+        appliedSelectedIndex = -1
         for (i, row) in rows.enumerated() {
             // Quick-jump labels are inert in search mode (typing builds the
             // query, not a label jump), so suppress them to avoid confusion.
@@ -364,10 +442,15 @@ final class SwitcherView: NSView {
     private var reservedSearchHeight: CGFloat {
         searchActive ? searchBarHeight + metrics.outerPadding : 0
     }
+    /// Height the tab strip occupies under the list (with a gap).
+    private var tabStripHeight: CGFloat { TabStripView.stripHeight }
+    private var reservedTabStripHeight: CGFloat {
+        tabStripActive ? tabStripHeight + metrics.outerPadding : 0
+    }
 
     override var intrinsicContentSize: NSSize {
         var size = computeLayout().total
-        size.height += reservedSearchHeight
+        size.height += reservedSearchHeight + reservedTabStripHeight
         return size
     }
 
@@ -389,15 +472,26 @@ final class SwitcherView: NSView {
             )
         }
 
-        // List occupies the region below the reserved search strip; center it
-        // there so the layout matches the non-search case when inactive.
-        let listAreaHeight = bounds.height - reservedSearchHeight
+        // List occupies the region below the reserved search strip and above
+        // the reserved tab strip; center it there so the layout matches the
+        // non-search/non-drill case when both are inactive.
+        let listAreaHeight = bounds.height - reservedSearchHeight - reservedTabStripHeight
+        let listOriginY = reservedTabStripHeight + (listAreaHeight - info.listSize.height) / 2
         let listOrigin = NSPoint(
             x: (bounds.width - info.listSize.width) / 2,
-            y: (listAreaHeight - info.listSize.height) / 2
+            y: listOriginY
         )
         listContainer.frame = NSRect(origin: listOrigin, size: info.listSize)
-        noResultsLabel.frame = NSRect(x: 0, y: 0, width: bounds.width, height: listAreaHeight)
+        noResultsLabel.frame = NSRect(x: 0, y: reservedTabStripHeight, width: bounds.width, height: listAreaHeight)
+
+        if tabStripActive {
+            tabStrip.frame = NSRect(
+                x: outer,
+                y: outer,
+                width: max(0, bounds.width - outer * 2),
+                height: tabStripHeight
+            )
+        }
 
         for (i, rect) in info.frames.enumerated() where i < itemViews.count {
             itemViews[i].frame = rect

--- a/BetterCmdTab/Switcher/TabStripView.swift
+++ b/BetterCmdTab/Switcher/TabStripView.swift
@@ -1,0 +1,198 @@
+import AppKit
+
+/// Horizontal strip of tab titles shown below the switcher list while the user
+/// is drilled into a browser/Finder row. Cells are title-only — no icons or
+/// thumbnails — sized to ~22pt tall and laid out in a horizontal scroll view so
+/// long tab sets stay reachable. Selection is keyboard-driven from the
+/// `SwitcherController`; this view only renders.
+@MainActor
+protocol TabStripDelegate: AnyObject {
+    func tabStrip(_ strip: TabStripView, didSelectIndex index: Int)
+    func tabStrip(_ strip: TabStripView, didHoverIndex index: Int)
+}
+
+@MainActor
+final class TabStripView: NSView {
+    weak var delegate: TabStripDelegate?
+
+    private let scrollView = NSScrollView()
+    private let stack = NSStackView()
+    private var cells: [TabStripCell] = []
+    private var accent: NSColor = .controlAccentColor
+    private var selectedIndex: Int = 0
+
+    static let stripHeight: CGFloat = 30
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.cornerCurve = .continuous
+        layer?.backgroundColor = NSColor.black.withAlphaComponent(0.18).cgColor
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.horizontalScrollElasticity = .allowed
+        scrollView.verticalScrollElasticity = .none
+        scrollView.scrollerStyle = .overlay
+
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 4
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let doc = NSView()
+        doc.translatesAutoresizingMaskIntoConstraints = false
+        doc.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: doc.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: doc.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: doc.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: doc.bottomAnchor),
+            doc.heightAnchor.constraint(equalToConstant: Self.stripHeight),
+        ])
+        scrollView.documentView = doc
+
+        addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    func configure(titles: [String], selectedIndex: Int, accent: NSColor) {
+        self.accent = accent
+        self.selectedIndex = selectedIndex
+        while cells.count < titles.count {
+            let cell = TabStripCell()
+            cell.onSelect = { [weak self] cell in
+                guard let self, let i = self.cells.firstIndex(where: { $0 === cell }) else { return }
+                self.delegate?.tabStrip(self, didSelectIndex: i)
+            }
+            cell.onHover = { [weak self] cell in
+                guard let self, let i = self.cells.firstIndex(where: { $0 === cell }) else { return }
+                self.delegate?.tabStrip(self, didHoverIndex: i)
+            }
+            stack.addArrangedSubview(cell)
+            cells.append(cell)
+        }
+        while cells.count > titles.count {
+            let cell = cells.removeLast()
+            stack.removeArrangedSubview(cell)
+            cell.removeFromSuperview()
+        }
+        for (i, title) in titles.enumerated() {
+            cells[i].configure(title: title.isEmpty ? "Untitled" : title,
+                               selected: i == selectedIndex,
+                               accent: accent)
+        }
+        scrollSelectedIntoView()
+    }
+
+    func setSelectedIndex(_ index: Int) {
+        guard cells.indices.contains(index) else { return }
+        selectedIndex = index
+        for (i, cell) in cells.enumerated() {
+            cell.setSelected(i == index, accent: accent)
+        }
+        scrollSelectedIntoView()
+    }
+
+    private func scrollSelectedIntoView() {
+        guard cells.indices.contains(selectedIndex), let doc = scrollView.documentView else { return }
+        let cell = cells[selectedIndex]
+        let cellFrame = cell.convert(cell.bounds, to: doc)
+        doc.scrollToVisible(cellFrame.insetBy(dx: -16, dy: 0))
+    }
+}
+
+@MainActor
+private final class TabStripCell: NSView {
+    private let label = NSTextField(labelWithString: "")
+    private var isSelected = false
+    private var accentColor: NSColor = .controlAccentColor
+    private var trackingArea: NSTrackingArea?
+    private var mouseInside = false
+
+    var onSelect: ((TabStripCell) -> Void)?
+    var onHover: ((TabStripCell) -> Void)?
+
+    init() {
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.cornerCurve = .continuous
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 12, weight: .medium)
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            heightAnchor.constraint(equalToConstant: 22),
+            widthAnchor.constraint(lessThanOrEqualToConstant: 220),
+        ])
+        applyAppearance()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    func configure(title: String, selected: Bool, accent: NSColor) {
+        label.stringValue = title
+        isSelected = selected
+        accentColor = accent
+        applyAppearance()
+    }
+
+    func setSelected(_ selected: Bool, accent: NSColor) {
+        isSelected = selected
+        accentColor = accent
+        applyAppearance()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        mouseInside = true
+        onHover?(self)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        mouseInside = false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onSelect?(self)
+    }
+
+    private func applyAppearance() {
+        if isSelected {
+            layer?.backgroundColor = accentColor.withAlphaComponent(0.85).cgColor
+            label.textColor = .white
+        } else {
+            layer?.backgroundColor = NSColor.white.withAlphaComponent(0.08).cgColor
+            label.textColor = .labelColor
+        }
+    }
+}

--- a/BetterCmdTab/Switcher/WindowThumbnailCache.swift
+++ b/BetterCmdTab/Switcher/WindowThumbnailCache.swift
@@ -34,7 +34,16 @@ final class WindowThumbnailCache {
     private let refreshTTL: TimeInterval = 2.0
 
     private init() {
-        cache.countLimit = 64
+        // Preview mode rarely surfaces more than ~24 windows at once (one row
+        // per visible window of the front app); cap at 32 so the cache holds
+        // a generous working set without retaining stale captures from
+        // long-past reveals that would never be reused.
+        cache.countLimit = 32
+        // Cost-side ceiling so a 4K thumbnail can't single-handedly evict the
+        // rest of the cache by counting as 32MB on its own. Anchored to a
+        // typical Retina preview tile (~512×288 RGBA ≈ 590KB) × the count
+        // limit, with headroom for occasional wider previews.
+        cache.totalCostLimit = 32 * 600_000
     }
 
     /// Cached thumbnail for `wid`, or nil if not captured yet.

--- a/BetterCmdTab/System/DockBadgeReader.swift
+++ b/BetterCmdTab/System/DockBadgeReader.swift
@@ -56,6 +56,10 @@ final class DockBadgeReader {
 
     nonisolated private static let statusLabelAttribute = "AXStatusLabel"
 
+    nonisolated private static func bundleID(for url: URL) -> String? {
+        BundleIDURLCache.shared.lookup(url)
+    }
+
     nonisolated private static func readDockBadges() -> [String: String] {
         guard let dockPid = NSRunningApplication
             .runningApplications(withBundleIdentifier: "com.apple.dock")
@@ -86,9 +90,8 @@ final class DockBadgeReader {
             guard (values[0] as? String) == (kAXApplicationDockItemSubrole as String) else { continue }
             guard (values[1] as? Bool) == true else { continue }
             guard let badge = values[3] as? String, !badge.isEmpty else { continue }
-            guard let url = values[2] as? URL,
-                  let bundleID = Bundle(url: url)?.bundleIdentifier else { continue }
-            result[bundleID] = badge
+            guard let url = values[2] as? URL, let bid = bundleID(for: url) else { continue }
+            result[bid] = badge
         }
         return result
     }
@@ -114,5 +117,26 @@ final class DockBadgeReader {
         var value: AnyObject?
         guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
         return value as? String
+    }
+}
+
+/// Thread-safe URL → bundle ID cache, separated so the underlying `NSCache`
+/// (which is documented thread-safe but unmarked `Sendable`) can be captured
+/// by nonisolated code without a Swift 6 complaint. Used by the dock badge
+/// reader; trivially extendable to other scrapers that map a `file://` URL to
+/// a bundle ID.
+final class BundleIDURLCache: @unchecked Sendable {
+    static let shared = BundleIDURLCache()
+    private let cache: NSCache<NSURL, NSString> = {
+        let c = NSCache<NSURL, NSString>()
+        c.countLimit = 128
+        return c
+    }()
+    func lookup(_ url: URL) -> String? {
+        let nsURL = url as NSURL
+        if let hit = cache.object(forKey: nsURL) { return hit as String }
+        guard let bid = Bundle(url: url)?.bundleIdentifier else { return nil }
+        cache.setObject(bid as NSString, forKey: nsURL)
+        return bid
     }
 }

--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -137,6 +137,40 @@ enum Activator {
         AXUIElementSetAttributeValue(window, kAXFocusedAttribute as CFString, kCFBooleanTrue)
     }
 
+    /// Activate a specific tab inside `window`. Same window-bringing steps as
+     /// `activateRunning`, then press the tab's AX element so the host app
+     /// selects it. Some browsers (Chrome, Arc) respond to `kAXPressAction`;
+     /// others (Safari for non-current tabs) only flip selection via the
+     /// `kAXSelectedAttribute` write. Try the press first, then the attribute —
+     /// neither call short-circuits, so doing both is safe.
+    static func activateTab(in app: NSRunningApplication, window: AXUIElement, tab: AXUIElement, instantSpace: Bool) {
+        let pid = app.processIdentifier
+
+        if app.isHidden {
+            app.unhide()
+        }
+
+        var minimizedValue: AnyObject?
+        AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimizedValue)
+        if (minimizedValue as? Bool) == true {
+            AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
+        }
+
+        let wid = PrivateAPI.cgWindowId(of: window)
+        let postedSpaceSwitch = instantSpace && wid != 0 && PrivateAPI.switchToSpace(ofWindow: wid)
+
+        activateProcess(app)
+        AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+        if wid != 0 && !postedSpaceSwitch {
+            PrivateAPI.raiseWindow(pid: pid, wid: wid)
+        }
+        AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
+        AXUIElementSetAttributeValue(window, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+
+        AXUIElementPerformAction(tab, kAXPressAction as CFString)
+        AXUIElementSetAttributeValue(tab, kAXSelectedAttribute as CFString, kCFBooleanTrue)
+    }
+
     private static func activateProcess(_ app: NSRunningApplication) {
         if #available(macOS 14.0, *) {
             _ = app.activate(from: NSRunningApplication.current, options: [])
@@ -345,20 +379,37 @@ enum Activator {
         app.terminate()
     }
 
+    /// SIGKILL the row's app. Use when the AppleEvent that `terminate()` sends
+    /// is being ignored (hung event loop, runaway script). Finder is guarded
+    /// like `quitApp` — killing it would log the user out via launchd respawn
+    /// loops on some setups.
+    static func forceQuitApp(_ row: SwitcherRow) {
+        guard let app = row.app else { return }
+        if app.bundleIdentifier == finderBundleID {
+            return
+        }
+        let pid = app.processIdentifier
+        guard pid > 0 else { return }
+        kill(pid, SIGKILL)
+    }
+
     // MARK: - Move window between displays / Spaces
 
     /// Move the row's window to the adjacent display in `direction`, preserving
     /// its relative position within the screen and clamping it to fit. Uses the
     /// stable Accessibility position API — no private symbols.
     static func moveWindowToDisplay(_ row: SwitcherRow, direction: MoveDirection) {
-        guard let window = row.window, let app = row.app else { return }
-        let apply = { Self.repositionToAdjacentDisplay(window: window, direction: direction) }
-        // Our own window must mutate on the main thread (window-management
-        // constraint, as with close/minimize); other apps stay off-main.
-        if app.processIdentifier == getpid() {
-            DispatchQueue.main.async(execute: apply)
-        } else {
-            DispatchQueue.global(qos: .userInitiated).async(execute: apply)
+        guard let window = row.window, let _ = row.app else { return }
+        // Run on main regardless of target pid: `repositionToAdjacentDisplay`
+        // reads `NSScreen.screens`, which Apple documents as main-thread only.
+        // Under macOS Tahoe (26) off-main `NSScreen.screens` access triggers
+        // an `NSInternalInconsistencyException` (layout engine modified from a
+        // background thread) the next time AppKit lays out — sometimes
+        // immediately, sometimes on a later reveal. The AX position write is
+        // cheap (microseconds) so keeping the whole call on main has no
+        // latency cost worth chasing.
+        DispatchQueue.main.async {
+            Self.repositionToAdjacentDisplay(window: window, direction: direction)
         }
     }
 

--- a/BetterCmdTab/Windows/BrowserTabs.swift
+++ b/BetterCmdTab/Windows/BrowserTabs.swift
@@ -1,0 +1,319 @@
+import AppKit
+import ApplicationServices
+import Darwin
+import Foundation
+
+// Private SPI from libsystem: detaches the spawned child's TCC
+// "responsibility" so it acts as its own client (osascript) instead of
+// inheriting from us (BetterCmdTab). This is the documented escape hatch
+// when an LSUIElement agent can't surface Apple Events TCC prompts — a known
+// gap on macOS Tahoe (26). Same symbol that Witch, TabTab, and several other
+// shipping switchers use.
+@_silgen_name("responsibility_spawnattrs_setdisclaim")
+private func responsibility_spawnattrs_setdisclaim(_ attrs: UnsafeMutablePointer<posix_spawnattr_t?>, _ disclaim: Int32) -> Int32
+
+/// Per-browser tab enumeration + activation via Apple Events. AX scraping is
+/// unreliable across Safari/Chromium versions (the tab strip is deeply nested
+/// and frequently restructured); the scripting dictionaries every major browser
+/// ships are the only stable interface for "list tabs of window N" and "select
+/// tab N of window N".
+///
+/// All three operations (raise window, list tabs, select tab) are bound to the
+/// `AppleScript window 1` of the target app. Since we cannot map an AX window
+/// to a stable AppleScript window index, we first force the row's window to be
+/// the browser's frontmost via `AXRaiseAction` and a brief delay so subsequent
+/// scripts read the right window.
+enum BrowserTabs {
+
+    enum Family {
+        case chromium  // Chrome, Brave, Edge, Vivaldi, Opera, Arc, Dia
+        case safari    // Safari, Safari Technology Preview
+
+        static func from(bundleID: String?) -> Family? {
+            guard let id = bundleID?.lowercased() else { return nil }
+            // Chromium family: bundle IDs use a stable AppleScript dictionary
+            // identical to Chrome's. Arc and Dia (The Browser Company) also
+            // adopt the same dialect.
+            let chromiumIDs: Set<String> = [
+                "com.google.chrome",
+                "com.google.chrome.canary",
+                "com.google.chrome.beta",
+                "com.google.chrome.dev",
+                "com.brave.browser",
+                "com.brave.browser.beta",
+                "com.brave.browser.nightly",
+                "com.brave.browser.dev",
+                "com.microsoft.edgemac",
+                "com.microsoft.edgemac.beta",
+                "com.microsoft.edgemac.dev",
+                "com.microsoft.edgemac.canary",
+                "com.vivaldi.vivaldi",
+                "com.operasoftware.opera",
+                "com.operasoftware.operadeveloper",
+                "company.thebrowser.browser",
+                "company.thebrowser.dia",
+                "net.imput.helium",
+            ]
+            if chromiumIDs.contains(id) { return .chromium }
+            if id == "com.apple.safari" || id == "com.apple.safaritechnologypreview" { return .safari }
+            return nil
+        }
+    }
+
+    /// Quote a string for embedding inside an AppleScript string literal.
+    /// AppleScript needs `\` and `"` escaped; everything else can stay as-is.
+    private static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// AppleScript identifier prefix for an app — `application id "com.foo"`.
+    /// Using the bundle ID instead of the name avoids localization issues and
+    /// is rejected gracefully if the app isn't installed (returns an empty
+    /// title list rather than failing the script).
+    private static func appLiteral(_ bundleID: String) -> String {
+        "application id \"\(escape(bundleID))\""
+    }
+
+    /// Force the row's window to be the browser's frontmost window so the
+    /// subsequent `window 1` scripts target it. Synchronous AX call, runs on
+    /// the caller's queue. Does NOT activate the process — keeps the panel
+    /// visible. Skips entirely when the app has only one window: there's no
+    /// "wrong window" to raise away from, and the AX call still costs ~10ms
+    /// even for a no-op raise.
+    private static func raiseInBrowser(_ window: AXUIElement, pid: pid_t) {
+        let axApp = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(axApp, 0.05)
+        var windowsValue: AnyObject?
+        AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsValue)
+        let windowCount = (windowsValue as? [AXUIElement])?.count ?? 0
+        if windowCount <= 1 { return }
+        AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+    }
+
+    /// Run an AppleScript. In-process `NSAppleScript` fails silently with
+    /// -1743 on LSUIElement agents under macOS Tahoe (no TCC prompt ever
+    /// appears, no entry shows up in System Settings → Privacy → Automation).
+    /// We sidestep this by spawning `/usr/bin/osascript` with the
+    /// `responsibility_spawnattrs_setdisclaim` SPI, which makes the child
+    /// process its own TCC responsibility — so the prompt either uses
+    /// osascript's pre-existing permission or surfaces correctly under
+    /// osascript's name. Stdout is the script's text result, one line per
+    /// item separated by ", " (osascript's default list serialization).
+    private static func runScript(_ source: String) -> String? {
+        var attrs: posix_spawnattr_t?
+        guard posix_spawnattr_init(&attrs) == 0 else { return nil }
+        defer { posix_spawnattr_destroy(&attrs) }
+        _ = responsibility_spawnattrs_setdisclaim(&attrs, 1)
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        let outFd = outPipe.fileHandleForWriting.fileDescriptor
+        let errFd = errPipe.fileHandleForWriting.fileDescriptor
+        // Guarantee parent-side write descriptors are released even on the
+        // failure paths below. `Pipe` deinit ultimately closes them, but
+        // hanging on to them until ARC drains can stack up FDs across a burst
+        // of failures (e.g. repeated TCC denials). Tracked by a flag so the
+        // success path can close them at exactly the right moment (after
+        // spawn, before reading the child's output).
+        var parentWriteClosed = false
+        func closeParentWriteEnds() {
+            guard !parentWriteClosed else { return }
+            parentWriteClosed = true
+            outPipe.fileHandleForWriting.closeFile()
+            errPipe.fileHandleForWriting.closeFile()
+        }
+        defer { closeParentWriteEnds() }
+
+        var actions: posix_spawn_file_actions_t?
+        guard posix_spawn_file_actions_init(&actions) == 0 else { return nil }
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        posix_spawn_file_actions_adddup2(&actions, outFd, 1)
+        posix_spawn_file_actions_adddup2(&actions, errFd, 2)
+        posix_spawn_file_actions_addclose(&actions, outFd)
+        posix_spawn_file_actions_addclose(&actions, errFd)
+
+        let path = "/usr/bin/osascript"
+        let args: [String] = ["osascript", "-e", source]
+        let cArgs: [UnsafeMutablePointer<CChar>?] = args.map { strdup($0) } + [nil]
+        defer { for a in cArgs where a != nil { free(a) } }
+
+        var pid: pid_t = 0
+        let status = path.withCString { cPath in
+            posix_spawn(&pid, cPath, &actions, &attrs, cArgs, environ)
+        }
+        guard status == 0 else {
+            NSLog("BrowserTabs: posix_spawn osascript failed \(status)")
+            return nil
+        }
+        closeParentWriteEnds()
+
+        var stat: Int32 = 0
+        waitpid(pid, &stat, 0)
+        let exitCode = (stat & 0xff00) >> 8
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let stdout = String(data: outData, encoding: .utf8) ?? ""
+        let stderr = String(data: errData, encoding: .utf8) ?? ""
+        if exitCode != 0 || !stderr.isEmpty {
+            NSLog("BrowserTabs: osascript exit=\(exitCode) stderr=\(stderr)")
+        }
+        if exitCode != 0 { return nil }
+        return stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Split osascript's list output into items. AppleScript's default text
+    /// representation of a list separates items with ", " — split there.
+    /// Returns the raw items in declaration order.
+    private static func parseList(_ raw: String) -> [String] {
+        guard !raw.isEmpty else { return [] }
+        return raw.components(separatedBy: ", ")
+    }
+
+    /// Force the macOS TCC prompt for Apple Events to the target app. Returns
+    /// true when permission is granted (now or previously). Without this the
+    /// first script call fails with -1743 silently if TCC happens to suppress
+    /// the prompt (already-denied / stale signature). Run off-main.
+    /// Walk the running app list, pick every supported browser, and send a
+    /// minimal Apple Event (`get name`) to each. On a fresh install this
+    /// triggers the TCC consent prompt per browser. **Must be called while
+    /// the app is foreground** — agents (`LSUIElement = YES`) without a
+    /// presentable UI window don't get a prompt; TCC silently denies and the
+    /// entry never appears in System Settings → Privacy → Automation. The
+    /// caller is expected to be the Settings window's "Browser tab drill-in"
+    /// toggle, which provides exactly that foreground context.
+    @MainActor
+    static func requestPermissionForRunningBrowsers() {
+        // Force ourselves to the foreground so TCC has a window context.
+        NSApp.activate(ignoringOtherApps: true)
+        var prompted: Set<String> = []
+        var bundleIDs: [String] = []
+        for app in NSWorkspace.shared.runningApplications {
+            guard let bid = app.bundleIdentifier?.lowercased(),
+                  Family.from(bundleID: bid) != nil,
+                  prompted.insert(bid).inserted else { continue }
+            bundleIDs.append(bid)
+        }
+        guard !bundleIDs.isEmpty else { return }
+        // Each runScript is a blocking waitpid; doing this on the main thread
+        // froze the UI for the full per-browser round-trip (multi-second on
+        // installs with several browsers running).
+        DispatchQueue.global(qos: .userInitiated).async {
+            for bid in bundleIDs {
+                let escaped = bid.replacingOccurrences(of: "\\", with: "\\\\")
+                                 .replacingOccurrences(of: "\"", with: "\\\"")
+                let source = """
+                tell application id "\(escaped)"
+                    with timeout of 3 seconds
+                        return name
+                    end timeout
+                end tell
+                """
+                NSLog("BrowserTabs: requesting permission for \(bid)")
+                _ = runScript(source)
+            }
+        }
+    }
+
+    @discardableResult
+    static func ensurePermission(bundleID: String) -> Bool {
+        guard let cString = bundleID.cString(using: .utf8) else { return false }
+        var targetDesc = AEAddressDesc()
+        let bidLen = bundleID.utf8.count
+        let status = cString.withUnsafeBufferPointer { buf -> OSStatus in
+            guard let base = buf.baseAddress else { return OSStatus(-108) /* memFullErr */ }
+            return OSStatus(AECreateDesc(
+                DescType(typeApplicationBundleID),
+                base,
+                bidLen,
+                &targetDesc
+            ))
+        }
+        guard status == noErr else { return false }
+        defer { AEDisposeDesc(&targetDesc) }
+        let permission = AEDeterminePermissionToAutomateTarget(
+            &targetDesc,
+            DescType(typeWildCard),
+            DescType(typeWildCard),
+            true  // askUserIfNeeded — surfaces the TCC prompt
+        )
+        if permission != noErr {
+            NSLog("BrowserTabs: AEDeterminePermissionToAutomateTarget \(bundleID) → \(permission)")
+        }
+        return permission == noErr
+    }
+
+    /// Enumerate the row window's tabs. Returns nil if the app isn't a
+    /// supported browser; returns [] if the browser has fewer than 2 tabs
+    /// (drill-in is only meaningful past 1). Run off-main.
+    static func tabTitles(for app: NSRunningApplication, window: AXUIElement) -> [String]? {
+        guard let family = Family.from(bundleID: app.bundleIdentifier),
+              let bid = app.bundleIdentifier else { return nil }
+        NSLog("BrowserTabs: tabTitles for \(bid) family=\(family)")
+        raiseInBrowser(window, pid: app.processIdentifier)
+        let appLit = appLiteral(app.bundleIdentifier ?? "")
+        let attr: String = (family == .safari) ? "name" : "title"
+        // `as text` joins list items with the current text item delimiter,
+        // which defaults to "". We pin it to LF so the output is one title
+        // per line and parses unambiguously even when a title contains
+        // commas.
+        let source = """
+        tell \(appLit)
+            with timeout of 3 seconds
+                if (count of windows) = 0 then return ""
+                set theList to \(attr) of every tab of window 1
+            end timeout
+        end tell
+        set AppleScript's text item delimiters to (ASCII character 10)
+        return theList as text
+        """
+        guard let raw = runScript(source) else { return [] }
+        NSLog("BrowserTabs: raw output (\(raw.count) chars) = \(raw.prefix(200))")
+        let titles = raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        NSLog("BrowserTabs: parsed \(titles.count) titles")
+        return titles.count > 1 ? titles : []
+    }
+
+    /// Switch the row window's frontmost browser tab to `tabIndex` (1-based
+    /// for AppleScript) and bring the browser forward. Run off-main.
+    static func activateTab(at tabIndex: Int, in app: NSRunningApplication, window: AXUIElement) -> Bool {
+        guard let family = Family.from(bundleID: app.bundleIdentifier) else { return false }
+        NSLog("BrowserTabs: activateTab index=\(tabIndex) bid=\(app.bundleIdentifier ?? "?")")
+        raiseInBrowser(window, pid: app.processIdentifier)
+        let appLit = appLiteral(app.bundleIdentifier ?? "")
+        let oneBased = tabIndex + 1
+        let source: String
+        switch family {
+        case .chromium:
+            source = """
+            tell \(appLit)
+                with timeout of 3 seconds
+                    if (count of windows) = 0 then return "false"
+                    set tabCount to count of tabs of window 1
+                    if \(oneBased) > tabCount then return "false"
+                    set active tab index of window 1 to \(oneBased)
+                    set index of window 1 to 1
+                    activate
+                    return "true"
+                end timeout
+            end tell
+            """
+        case .safari:
+            source = """
+            tell \(appLit)
+                with timeout of 3 seconds
+                    if (count of windows) = 0 then return "false"
+                    set tabCount to count of tabs of window 1
+                    if \(oneBased) > tabCount then return "false"
+                    set current tab of window 1 to tab \(oneBased) of window 1
+                    set index of window 1 to 1
+                    activate
+                    return "true"
+                end timeout
+            end tell
+            """
+        }
+        guard let raw = runScript(source) else { return false }
+        return raw == "true"
+    }
+}

--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -7,21 +7,32 @@ struct WindowInfo {
     let title: String
     let isMinimized: Bool
     let isFullscreen: Bool
+    /// `AXTabs` children of this window (browsers, tabbed Finder, iTerm, …).
+    /// Empty when the window has no tab group or only a single tab — drill-in
+    /// is only meaningful with at least two tabs.
+    let tabs: [AXUIElement]
 
     init(
         ref: AXUIElement,
         title: String,
         isMinimized: Bool,
-        isFullscreen: Bool = false
+        isFullscreen: Bool = false,
+        tabs: [AXUIElement] = []
     ) {
         self.ref = ref
         self.title = title
         self.isMinimized = isMinimized
         self.isFullscreen = isFullscreen
+        self.tabs = tabs
     }
 }
 
-private struct AXRef: Hashable {
+/// Hashable wrapper around `AXUIElement` whose equality follows the CF identity
+/// contract (`CFEqual`), not raw pointer or `CFHash` integer comparison. Use
+/// this as a dictionary key when the value semantically belongs to a specific
+/// AX element — CFHash alone is non-unique across distinct elements and would
+/// silently collide.
+struct AXRef: Hashable {
     let element: AXUIElement
     static func == (lhs: AXRef, rhs: AXRef) -> Bool { CFEqual(lhs.element, rhs.element) }
     func hash(into hasher: inout Hasher) { hasher.combine(CFHash(element)) }
@@ -213,36 +224,78 @@ enum WindowEnumerator {
             kAXMinimizedAttribute,
             "AXFullScreen" as CFString,
             kAXTitleAttribute,
+            kAXPositionAttribute,
+            kAXSizeAttribute,
         ] as CFArray
         var seenTabGroups: Set<[AXRef]> = []
+        var addedTabGroupForPid = false
+        // Native macOS window tabs (Finder, Terminal, TextEdit, Ghostty, ...)
+        // expose each tab as its own AXWindow with its own CGWindowID — but
+        // they share the same on-screen frame because only one tab renders
+        // at a time and macOS keeps the merged-window outline identical
+        // across tabs. Dedup by (origin × size) keeps one row per visual
+        // merged window. Edge case: two separate tabbed windows of the same
+        // app happening to occupy exactly the same frame would collapse,
+        // but that requires the user to overlap two windows pixel-perfect.
+        var seenFrames: Set<String> = []
         for window in elements {
             AXUIElementSetMessagingTimeout(window, Self.confirmedTimeout)
             var valuesRef: CFArray?
             guard AXUIElementCopyMultipleAttributeValues(window, attrNames, AXCopyMultipleAttributeOptions(rawValue: 0), &valuesRef) == .success,
-                  let values = valuesRef as? [AnyObject], values.count == 5 else { continue }
+                  let values = valuesRef as? [AnyObject], values.count == 7 else { continue }
 
             let subrole = (values[0] as? String) ?? ""
             guard acceptedSubroles.contains(subrole) else { continue }
 
+            var windowTabs: [AXUIElement] = []
             if let tabs = values[1] as? [AXUIElement], tabs.count > 1 {
+                if addedTabGroupForPid { continue }
                 let key = tabs.map { AXRef(element: $0) }
                 if seenTabGroups.contains(key) { continue }
                 seenTabGroups.insert(key)
+                windowTabs = tabs
+                addedTabGroupForPid = true
             }
 
             let minimized = (values[2] as? Bool) ?? false
             let fullscreen = (values[3] as? Bool) ?? false
             let windowTitle = (values[4] as? String) ?? ""
 
+            // Native-tab dedup by frame. Minimized windows legitimately
+            // share (0, 0) sometimes — skip the frame check for them.
+            if !minimized,
+               let frameKey = frameKeyFromAttributes(values[5], values[6]) {
+                if seenFrames.contains(frameKey) { continue }
+                seenFrames.insert(frameKey)
+            }
+
             infos.append(WindowInfo(
                 ref: window,
                 title: windowTitle,
                 isMinimized: minimized,
-                isFullscreen: fullscreen
+                isFullscreen: fullscreen,
+                tabs: windowTabs
             ))
         }
 
         return sortedByZOrder(infos, cgZOrder: cgZOrder)
+    }
+
+    /// Stringify a window's (position, size) for dedup. Returns nil when
+    /// either attribute is missing or fails to decode — defaults to "keep
+    /// the window" rather than collapsing on incomplete data.
+    private static func frameKeyFromAttributes(_ posValue: AnyObject, _ sizeValue: AnyObject) -> String? {
+        guard CFGetTypeID(posValue) == AXValueGetTypeID(),
+              CFGetTypeID(sizeValue) == AXValueGetTypeID() else { return nil }
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(posValue as! AXValue, .cgPoint, &origin),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else { return nil }
+        // Round to whole pixels — tab-sibling NSWindows occasionally differ
+        // by a sub-pixel due to autosize; the visual outline is identical.
+        let x = Int(origin.x.rounded()), y = Int(origin.y.rounded())
+        let w = Int(size.width.rounded()), h = Int(size.height.rounded())
+        return "\(x),\(y),\(w),\(h)"
     }
 
     /// Re-orders the AX-derived window list to match the WindowServer
@@ -266,5 +319,62 @@ enum WindowEnumerator {
             if lhs.rank != rhs.rank { return lhs.rank < rhs.rank }
             return lhs.fallback < rhs.fallback
         }.map { $0.info }
+    }
+
+    /// Fetch titles for a tab group's `AXTab` children. Each tab is a separate
+    /// AX element so the call is N IPCs — keep off the reveal path and only
+    /// invoke when the user actually drills in.
+    static func tabTitles(for tabs: [AXUIElement]) -> [String] {
+        var titles: [String] = []
+        titles.reserveCapacity(tabs.count)
+        for tab in tabs {
+            AXUIElementSetMessagingTimeout(tab, Self.confirmedTimeout)
+            var titleValue: AnyObject?
+            AXUIElementCopyAttributeValue(tab, kAXTitleAttribute as CFString, &titleValue)
+            titles.append((titleValue as? String) ?? "")
+        }
+        return titles
+    }
+
+    /// Recursively locate a window's tab buttons. Apps that use AppKit's native
+    /// window-tab feature (Finder, Terminal, some older browsers) expose
+    /// `AXTabs` directly on the window, but Safari/Chrome/Arc/Edge nest their
+    /// tab strip several levels deep inside an `AXTabGroup`. DFS through the
+    /// AX tree with a depth cap so a deep but tab-less hierarchy doesn't burn
+    /// time, and return the first non-empty `AXTabs` we find.
+    static func tabs(in window: AXUIElement) -> [AXUIElement] {
+        if let direct = tabsAttribute(of: window), direct.count > 1 {
+            return direct
+        }
+        return findTabsRecursive(in: window, depth: 0)
+    }
+
+    private static let tabSearchMaxDepth = 6
+
+    private static func tabsAttribute(of element: AXUIElement) -> [AXUIElement]? {
+        var value: AnyObject?
+        AXUIElementSetMessagingTimeout(element, Self.confirmedTimeout)
+        guard AXUIElementCopyAttributeValue(element, kAXTabsAttribute as CFString, &value) == .success,
+              let arr = value as? [AXUIElement], !arr.isEmpty else {
+            return nil
+        }
+        return arr
+    }
+
+    private static func findTabsRecursive(in element: AXUIElement, depth: Int) -> [AXUIElement] {
+        guard depth < tabSearchMaxDepth else { return [] }
+        var childrenValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenValue) == .success,
+              let children = childrenValue as? [AXUIElement] else {
+            return []
+        }
+        for child in children {
+            if let tabs = tabsAttribute(of: child), tabs.count > 1 {
+                return tabs
+            }
+            let nested = findTabsRecursive(in: child, depth: depth + 1)
+            if !nested.isEmpty { return nested }
+        }
+        return []
     }
 }


### PR DESCRIPTION
## Summary

Two-commit branch — feature work plus an independently revertable perf pass.

### Commit 1 — feat
- **Browser/Finder tab drill-in** (`\` on a tabbed row reveals a `TabStripView`). Browsers (Safari/Chrome/Arc/Brave/Edge/Vivaldi/Opera/Dia/Helium) use a TCC-disclaimed `osascript` spawn so the LSUIElement agent can surface Apple Events prompts under Tahoe; non-browser tabbed apps use AX `AXTabs`. Tab group cached on the catalog snapshot, prefetch warms hovered windows. Gated by the Experimental setting; opt-in triggers a "grant permissions for running browsers" prompt.
- **Force-quit hover button** + `⌘⌥Q` keyboard escalation (`SIGKILL` for hung apps). Bare `⌘Q` stays graceful. Hidden by default; new Switcher Settings toggle.
- **Scaled hover action bar** rescales dots with the panel size and width-clamps on small grid tiles so the outer dots stay hit-testable. Glyphs ride on an `NSImageView` for SF Symbol optical centering.
- **Panel-size remap**: Small → 1.0×, Medium → 1.2×, Large → 1.5× (raw pref values unchanged so existing settings shift one notch).

Plumbing: `HotkeyTap` routes the new events, `AXRef` (CFEqual identity) hoisted internal so `SwitcherController` can key its tab-prefetch cache by AX identity, `WindowEnumerator` batches `AXTabs` into the existing per-window multi-attr IPC, `Activator` picks up zoom/force-quit/move-window. Entitlements + `NSAppleEventsUsageDescription` for TCC.

Bundled correctness fixes (couldn't be cleanly extracted without per-hunk surgery on shared files):
- `BrowserTabs.runScript` wraps every script with `with timeout of 3 seconds` and closes the parent pipe write-ends via a defer-tracked flag so a burst of TCC denials can't stack up FDs.
- Permission-prompt loop dispatches off-main (used to freeze the UI for the per-browser round-trip).
- `Activator.moveWindowToDisplay` now runs on main regardless of target pid. The helper reads `NSScreen.screens` (documented main-only); under Tahoe off-main access taints the layout engine and trips `NSInternalInconsistencyException: Modifications to the layout engine must not be performed from a background thread...` on a later reveal. AX position writes are microseconds; the off-main split bought nothing and risked the crash.
- `@preconcurrency import ApplicationServices` + an `@MainActor` inner func in `scheduleVisibleRefresh` silence the Sendable warnings the new drill code introduced.

### Commit 2 — perf
- `IconCache` raster 320→256 (~36% smaller per entry), capacity 64→32, sibling `bundleCache` for launchable/recently-closed rows. Eager `prewarm` dropped (no-op kept for API stability) — was both the largest contributor to post-launch RSS (~12 MB for ~30 apps) and the AutoLayout crash source (bundle icons restyle through lazily-initialized AppKit views during `NSImage.draw`). `flattened` is now `@MainActor`.
- `DockBadgeReader` URL → bundle ID cache (`BundleIDURLCache`, `@unchecked Sendable` wrapper around `NSCache`) so the dock scan stops parsing Info.plist per item.
- `InstalledAppsIndex.scan` per-directory `autoreleasepool` drains transient bundle Info.plists during build (~5 MB hump → 0).
- `WindowThumbnailCache` countLimit 64→32 + `totalCostLimit = 32 * 600_000`.

Combined RSS impact (measured locally, 6 running apps):  ~50 MB → ~40 MB after first reveal, ~25–30 MB once the panel dismisses.

## Test plan

- [ ] Open the switcher with both modifier triggers — confirm rows render, selection moves on arrow keys, scroll-to-switch still works.
- [ ] Press `\` on a Safari/Chrome row with multiple tabs — the tab strip appears, arrow keys step tabs, Return commits the chosen tab.
- [ ] Press `\` on a Finder/Terminal/iTerm window with multiple tabs — same flow via the AX backend.
- [ ] Toggle "Browser tab drill-in" off in Experimental — `\` becomes a no-op.
- [ ] Click "Grant permissions…" in Experimental — TCC prompts appear for each running browser without freezing Settings.
- [ ] Toggle Force-quit hover button on, hover a row — extra red dot appears; `⌘⌥Q` SIGKILLs the highlighted app.
- [ ] `⌥+Arrow` on a row whose window belongs to another app — window moves to the adjacent display, no `NSInternalInconsistencyException` in Console.
- [ ] Activity Monitor before/after `panel.dismiss()` — RSS drops once the item pool releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)