### PR TITLE
Document Secure Event Input limitation, log secure-input transitions

### DIFF
--- a/BetterCmdTab/App/AppDelegate.swift
+++ b/BetterCmdTab/App/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var controller: SwitcherController?
     private var statusItem: NSStatusItem?
     private var axWaiter: AccessibilityWaiter?
+    private var secureInputMonitor: SecureInputMonitor?
     private var cancellables = Set<AnyCancellable>()
 
     static func main() {
@@ -81,6 +82,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         waiter.start()
         axWaiter = waiter
+
+        let secureMonitor = SecureInputMonitor()
+        secureMonitor.start()
+        secureInputMonitor = secureMonitor
 
         Task { @MainActor in
             // Touch the singleton so it boots its scheduled auto-check task,

--- a/BetterCmdTab/System/SecureInputMonitor.swift
+++ b/BetterCmdTab/System/SecureInputMonitor.swift
@@ -1,0 +1,54 @@
+import AppKit
+import Carbon.HIToolbox
+import os
+
+/// Polls `IsSecureEventInputEnabled()` on the main thread and emits a log
+/// when the state transitions. Secure event input is a macOS feature that
+/// some apps (KeePassXC, password managers, login windows, terminals with
+/// secure-keyboard-entry on) engage while a password field is focused.
+///
+/// While it is engaged, untrusted (non-root) Quartz event taps cannot
+/// receive key events — the system delivers them only to the secure
+/// process. That means BetterCmdTab's ⌘+Tab tap stops seeing keystrokes
+/// and the user hits Dock's native switcher instead. There is no in-app
+/// workaround short of shipping a root helper; surfacing the state in
+/// the log lets power users diagnose "why didn't BetterCmdTab open?"
+/// without guessing.
+@MainActor
+final class SecureInputMonitor {
+    private var timer: Timer?
+    private var lastState = false
+
+    func start() {
+        lastState = IsSecureEventInputEnabled()
+        if lastState {
+            Log.hotkey.warning("Secure event input already active at launch; ⌘+Tab tap cannot intercept keys")
+        }
+        let t = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    private func tick() {
+        let now = IsSecureEventInputEnabled()
+        guard now != lastState else { return }
+        lastState = now
+        if now {
+            let front = NSWorkspace.shared.frontmostApplication?.localizedName ?? "unknown"
+            Log.hotkey.warning("Secure event input enabled by \(front, privacy: .public); ⌘+Tab tap suspended")
+        } else {
+            Log.hotkey.info("Secure event input disabled; ⌘+Tab tap operational")
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Fast · Native · Liquid Glass · Zero telemetry · Free forever
   <a href="#install">Install</a> ·
   <a href="#features">Features</a> ·
   <a href="#shortcuts">Shortcuts</a> ·
+  <a href="#known-limitations">Limitations</a> ·
   <a href="#build-from-source">Build</a> ·
   <a href="#contributing">Contribute</a>
 </sub>
@@ -110,6 +111,20 @@ The `Cmd + Tab` activation hotkey is configurable in Settings; you can also trig
 - Accessibility permission
 
 Liquid Glass rendering requires macOS 26. On 13–15 you get NSVisualEffectView with `.hudWindow` material, which looks similar enough.
+
+## Known limitations
+
+### Secure event input
+
+When the focused app has engaged macOS **Secure Event Input** — typically while a password field is active in apps like KeePassXC, 1Password, the macOS login window, or a terminal with secure keyboard entry on — the OS delivers key events only to that process. Untrusted (non-root) Quartz event taps, including BetterCmdTab's ⌘+Tab tap, stop seeing keystrokes for the duration. ⌘+Tab will fall back to the native Dock switcher until the password field loses focus.
+
+This is a system-level restriction with no in-app workaround short of shipping a privileged helper. If you hit it often with a specific app, the practical fixes are:
+
+- Dismiss the password prompt first, then press ⌘+Tab.
+- For KeePassXC: either unlock the database before opening the switcher, or disable its quick-unlock / always-on-top behavior so the unlock dialog doesn't hold focus.
+- Press `Ctrl + ⌘ + Q` and back in to bounce out of any stuck secure-input session.
+
+The current secure-input state is logged to Console under subsystem `pro.bettercmdtab.BetterCmdTab`, category `hotkey`, if you want to confirm the cause.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary
- Adds a `SecureInputMonitor` that polls `IsSecureEventInputEnabled()` and logs transitions to the `hotkey` Console category, so users can confirm why ⌘+Tab fell back to the native switcher.
- Documents the macOS Secure Event Input limitation in the README under a new **Known limitations** section, with practical user-side workarounds.

## Context
Fixes #7. KeePassXC's database-unlock screen (and other apps focusing an `NSSecureTextField`) engages macOS Secure Event Input. While that is on, untrusted (non-root) Quartz event taps cannot receive key events — ⌘+Tab is delivered straight to Dock and the native switcher takes over. There is no in-app workaround short of shipping a privileged helper, so the fix is detection + documentation rather than interception.

## Test plan
- [x] `xcodebuild -scheme "BetterCmdTab Debug" build` succeeds
- [ ] Launch app, focus a `NSSecureTextField` (KeePassXC unlock, Terminal "Secure Keyboard Entry" on) and confirm a `warning` line appears in Console under subsystem `pro.bettercmdtab.BetterCmdTab` category `hotkey`
- [ ] README renders with the new Known Limitations section and TOC entry