### PR TITLE
feat(switcher): click outside to dismiss (#9)

### DIFF
--- a/BetterCmdTab.xcodeproj/xcshareddata/xcschemes/BetterCmdTab Debug.xcscheme
+++ b/BetterCmdTab.xcodeproj/xcshareddata/xcschemes/BetterCmdTab Debug.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2610"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -52,7 +52,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      disableMainThreadChecker = "NO"
       stopOnEveryMainThreadCheckerIssue = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -265,6 +265,7 @@ final class Preferences: ObservableObject {
         static let swipeSensitivity = "Switcher.swipeSensitivity"
         static let scrollToSwitch = "Switcher.scrollToSwitch"
         static let scrollReverseDirection = "Switcher.scrollReverseDirection"
+        static let clickOutsideToDismiss = "Switcher.clickOutsideToDismiss"
         static let experimentalInstantSpaceSwitch = "Switcher.experimentalInstantSpaceSwitch"
         static let experimentalTabDrillIn = "Switcher.experimentalTabDrillIn"
         static let showUnreadBadges = "Switcher.showUnreadBadges"
@@ -507,6 +508,17 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != scrollReverseDirection else { return }
             UserDefaults.standard.set(scrollReverseDirection, forKey: Keys.scrollReverseDirection)
+        }
+    }
+
+    /// Dismiss the switcher when the user clicks outside the panel, leaving the
+    /// currently focused window untouched — like a macOS context menu or
+    /// Spotlight. The click is swallowed so it doesn't also activate whatever
+    /// was under the pointer. Default on.
+    @Published var clickOutsideToDismiss: Bool {
+        didSet {
+            guard oldValue != clickOutsideToDismiss else { return }
+            UserDefaults.standard.set(clickOutsideToDismiss, forKey: Keys.clickOutsideToDismiss)
         }
     }
 
@@ -762,6 +774,7 @@ final class Preferences: ObservableObject {
         self.swipeSensitivity = Self.clampSwipeSensitivity(sensitivity)
         self.scrollToSwitch = defaults.object(forKey: Keys.scrollToSwitch) as? Bool ?? true
         self.scrollReverseDirection = defaults.object(forKey: Keys.scrollReverseDirection) as? Bool ?? false
+        self.clickOutsideToDismiss = defaults.object(forKey: Keys.clickOutsideToDismiss) as? Bool ?? true
         self.experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
         self.experimentalTabDrillIn = defaults.object(forKey: Keys.experimentalTabDrillIn) as? Bool ?? false
         // Badges graduated out of the Experimental tab and now default on. Honor

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -19,6 +19,10 @@ final class HotkeyTap {
         case releaseCmd
         case commit
         case escape
+        /// A click landed outside the open switcher panel. Dismiss without
+        /// committing, leaving the current window focused (the tap swallows the
+        /// click so it doesn't activate whatever was under the pointer).
+        case dismiss
         case closeWindow
         case minimizeWindow
         case hideApp
@@ -86,6 +90,15 @@ final class HotkeyTap {
     private let scrollEnabledFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
     /// Flip the scroll-to-switch direction.
     private let scrollReverseFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
+    /// When true, a mouse-down outside `switcherFrame` while the switcher is
+    /// open dismisses it (the click is swallowed). Off → clicks always pass
+    /// through.
+    private let clickDismissFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
+    /// The open switcher panel's frame in CGEvent global (top-left origin,
+    /// y-down) coordinates, so a mouse-down location can be hit-tested on the
+    /// tap thread without touching AppKit. `nil` while the panel is hidden.
+    /// Published by SwitcherController on present/dismiss and on every relayout.
+    private let switcherFrame = OSAllocatedUnfairLock<CGRect?>(initialState: nil)
     private let config = OSAllocatedUnfairLock<Config>(
         initialState: Config(appModifier: .maskCommand, appKey: 48, windowModifier: .maskCommand, windowKey: 50)
     )
@@ -118,7 +131,10 @@ final class HotkeyTap {
         let mask: CGEventMask =
             (1 << CGEventType.keyDown.rawValue) |
             (1 << CGEventType.flagsChanged.rawValue) |
-            (1 << CGEventType.scrollWheel.rawValue)
+            (1 << CGEventType.scrollWheel.rawValue) |
+            (1 << CGEventType.leftMouseDown.rawValue) |
+            (1 << CGEventType.rightMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseDown.rawValue)
 
         let opaqueSelf = Unmanaged.passUnretained(self).toOpaque()
 
@@ -236,6 +252,18 @@ final class HotkeyTap {
         scrollReverseFlag.withLock { $0 = value }
     }
 
+    /// Enable/disable click-outside-to-dismiss for the open switcher.
+    func setClickOutsideDismiss(_ value: Bool) {
+        clickDismissFlag.withLock { $0 = value }
+    }
+
+    /// Publish the open switcher panel's frame in CGEvent global (top-left
+    /// origin, y-down) coordinates, or `nil` once it's hidden. Read by the tap
+    /// callback to hit-test outside clicks.
+    func setSwitcherFrame(_ frame: CGRect?) {
+        switcherFrame.withLock { $0 = frame }
+    }
+
     /// Apply user-chosen modifiers + trigger keys. Safe to call any time; the
     /// tap callback reads the new value on its next event.
     func updateConfig(_ newConfig: Config) {
@@ -329,6 +357,23 @@ final class HotkeyTap {
             let reverse = scrollReverseFlag.withLock { $0 }
             let forward = (delta < 0) != reverse
             deliver(forward ? .nextApp : .prevApp)
+            return nil
+        }
+
+        if type == .leftMouseDown || type == .rightMouseDown || type == .otherMouseDown {
+            // Click-outside-to-dismiss: only while the switcher is open and the
+            // feature is enabled. A click inside the panel passes through so row
+            // clicks and hover-action buttons keep working; a click outside is
+            // swallowed (return nil) and dismisses the switcher, leaving the
+            // current window focused instead of activating whatever was clicked.
+            guard isSwitchingNow(), clickDismissFlag.withLock({ $0 }),
+                  let frame = switcherFrame.withLock({ $0 }) else {
+                return Unmanaged.passUnretained(event)
+            }
+            if frame.contains(event.location) {
+                return Unmanaged.passUnretained(event)
+            }
+            deliver(.dismiss)
             return nil
         }
 

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -73,6 +73,7 @@ enum SearchID {
     static let searchMode = "switcher.searchMode"
     static let scroll = "switcher.scroll"
     static let scrollReverse = "switcher.scrollReverse"
+    static let clickDismiss = "switcher.clickDismiss"
     static let hoverActions = "switcher.hoverActions"
     static let excludedApps = "switcher.excludedApps"
     static let pinnedApps = "switcher.pinnedApps"
@@ -235,6 +236,8 @@ enum SettingsCatalog {
              "Switch with mouse scroll", ["scroll", "wheel", "mouse"]),
         item(SearchID.scrollReverse, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
              "Reverse scroll direction", ["scroll", "reverse", "invert"]),
+        item(SearchID.clickDismiss, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
+             "Click outside to dismiss", ["click", "outside", "dismiss", "cancel", "spotlight"]),
         // Switcher · Actions
         item(SearchID.hoverActions, .switcher, SettingsAnchor.actions, "Switcher", "Hover actions",
              "Action buttons on hover", ["hover", "buttons", "close", "minimize", "maximize", "hide", "quit", "actions"]),

--- a/BetterCmdTab/Settings/SettingsWindowPresenter.swift
+++ b/BetterCmdTab/Settings/SettingsWindowPresenter.swift
@@ -1,3 +1,4 @@
+import AppKit
 import BetterSettings
 
 /// Presents the settings window. Lifecycle (lazy creation, activation,
@@ -12,13 +13,65 @@ final class SettingsWindowPresenter {
         SettingsCatalog.makeConfiguration()
     }
 
+    /// Observer that reverts the activation policy when the settings window
+    /// closes. Re-created on every `show()` because `.releaseOnClose` builds a
+    /// fresh window each time.
+    private var closeObserver: NSObjectProtocol?
+
     private init() {}
 
     func show() {
+        // The app normally runs as `.accessory` (no Dock icon, menu-bar only).
+        // An accessory app can't pull a window in front of the active app —
+        // `NSApp.activate(ignoringOtherApps:)` is weakened for accessory apps on
+        // macOS 14+, so Settings opens *behind* whatever's frontmost. Promote to
+        // `.regular` so the app can activate as a normal foreground app; revert
+        // to `.accessory` once the window closes so the Dock icon doesn't linger.
+        NSApp.setActivationPolicy(.regular)
         presenter.show()
+
+        let window = NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first {
+            $0.isVisible && $0.styleMask.contains(.titled)
+        }
+        observeCloseForPolicyRevert(window)
+
+        // Activate on the next runloop tick. A just-promoted accessory app can't
+        // foreground in the same tick the policy changed — the change has to
+        // register with the window server first, so a synchronous `activate` is
+        // a no-op and the window stays behind. Deferring one tick lets the
+        // activation actually raise the window above other apps.
+        DispatchQueue.main.async {
+            NSApp.activate(ignoringOtherApps: true)
+            window?.makeKeyAndOrderFront(nil)
+            window?.orderFrontRegardless()
+        }
     }
 
     func hide() {
         presenter.hide()
+    }
+
+    /// Watch the now-visible settings window for close and drop the app back to
+    /// `.accessory`. Keyed off that specific window so a stray close of some
+    /// other window (e.g. an apps-picker sheet) doesn't demote us early.
+    private func observeCloseForPolicyRevert(_ window: NSWindow?) {
+        if let closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+            self.closeObserver = nil
+        }
+        guard let window else { return }
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                NSApp.setActivationPolicy(.accessory)
+                if let token = self?.closeObserver {
+                    NotificationCenter.default.removeObserver(token)
+                    self?.closeObserver = nil
+                }
+            }
+        }
     }
 }

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -28,6 +28,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     // Navigation
     private let scrollSwitch = NSSwitch()
     private let scrollReverseSwitch = NSSwitch()
+    private let clickDismissSwitch = NSSwitch()
 
     // Hover actions
     private let hoverSwitch = NSSwitch()
@@ -120,6 +121,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         addRow(to: navigation, title: "Reverse scroll direction",
                subtitle: "Scroll up to move forward instead of down.",
                accessory: scrollReverseSwitch, searchItemID: SearchID.scrollReverse)
+        configureSwitch(clickDismissSwitch, action: #selector(toggleClickDismiss(_:)))
+        addRow(to: navigation, title: "Click outside to dismiss",
+               subtitle: "Click anywhere outside the switcher to close it, leaving the current window focused.",
+               accessory: clickDismissSwitch, searchItemID: SearchID.clickDismiss)
 
         // Hover actions section — buttons revealed on a row under the pointer.
         let actions = addSection(title: "Hover actions", anchor: SettingsAnchor.actions)
@@ -186,6 +191,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         scrollSwitch.state = prefs.scrollToSwitch ? .on : .off
         scrollReverseSwitch.state = prefs.scrollReverseDirection ? .on : .off
         scrollReverseSwitch.isEnabled = prefs.scrollToSwitch
+        clickDismissSwitch.state = prefs.clickOutsideToDismiss ? .on : .off
         hoverSwitch.state = prefs.hoverActionsEnabled ? .on : .off
         hoverCloseSwitch.state = prefs.hoverShowClose ? .on : .off
         hoverMinimizeSwitch.state = prefs.hoverShowMinimize ? .on : .off
@@ -256,6 +262,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleScrollReverse(_ sender: NSSwitch) {
         Preferences.shared.scrollReverseDirection = (sender.state == .on)
+    }
+
+    @objc private func toggleClickDismiss(_ sender: NSSwitch) {
+        Preferences.shared.clickOutsideToDismiss = (sender.state == .on)
     }
 
     @objc private func toggleHover(_ sender: NSSwitch) {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -349,6 +349,16 @@ final class SwitcherController: SwitcherViewDelegate {
             .sink { [weak self] reverse in self?.hotkey.setScrollReverse(reverse) }
             .store(in: &cancellables)
 
+        // Click-outside-to-dismiss: the panel publishes its frame (in CGEvent
+        // global coordinates) on every present/dismiss; the tap hit-tests an
+        // outside click against it and swallows it to dismiss the switcher.
+        panel.onFrameDidChange = { [weak self] frame in self?.hotkey.setSwitcherFrame(frame) }
+        hotkey.setClickOutsideDismiss(Preferences.shared.clickOutsideToDismiss)
+        Preferences.shared.$clickOutsideToDismiss
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] enabled in self?.hotkey.setClickOutsideDismiss(enabled) }
+            .store(in: &cancellables)
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             self?.prewarmPanel()
         }
@@ -681,6 +691,10 @@ final class SwitcherController: SwitcherViewDelegate {
             commit()
         case .escape:
             if searchActive { exitSearch() } else { cancel() }
+        case .dismiss:
+            // Click outside the panel: always fully dismiss, even mid-search or
+            // drilled into a tab strip, leaving the current window focused.
+            cancel()
         case .toggleSearch:
             toggleSearch()
         case .searchInput(let ch):
@@ -1378,6 +1392,9 @@ final class SwitcherController: SwitcherViewDelegate {
         guard phase == .visible, rows.indices.contains(index) else { return }
         let row = rows[index]
         guard let window = row.window, let app = row.app else { return }
+        // Never drill our own windows — the AX walk would run in-process off the
+        // main thread and crash the layout engine (see `isOwnProcess`).
+        guard !Self.isOwnProcess(app) else { return }
         // Cache hit: drill-in is instant — strip appears on the same run
         // loop tick.
         if let cached = tabPrefetchCache[AXRef(element: window)], !cached.titles.isEmpty {
@@ -1456,6 +1473,21 @@ final class SwitcherController: SwitcherViewDelegate {
         case tabs(titles: [String], liveTabs: [AXUIElement], backend: TabDrillBackend)
     }
 
+    /// AX tab enumeration must never target our own process. Accessibility
+    /// requests to a *same-process* element are serviced in-process by AppKit,
+    /// and reading `kAXChildrenAttribute` forces a layout pass — illegal off the
+    /// main thread, which is exactly where the tab fetch runs (a background
+    /// queue, so the recursive AX walk stays off the reveal path). Querying
+    /// another app is safe off-main because that work happens in the *other*
+    /// process and only serialized data crosses back. Our own windows (Settings,
+    /// About) have no drillable tabs anyway, so skip them outright. Without this
+    /// guard, having our own window highlighted (e.g. Settings open) crashes with
+    /// "Modifications to the layout engine must not be performed from a
+    /// background thread."
+    private static func isOwnProcess(_ app: NSRunningApplication) -> Bool {
+        app.processIdentifier == NSRunningApplication.current.processIdentifier
+    }
+
     nonisolated private static func fetchTabsBlocking(app: NSRunningApplication, window: AXUIElement, title: String, isBrowser: Bool, prefetchedTabs: [AXUIElement] = []) -> DrillFetch {
         if isBrowser {
             switch BrowserTabs.tabTitles(for: app, window: window, title: title) {
@@ -1488,6 +1520,9 @@ final class SwitcherController: SwitcherViewDelegate {
               phase == .visible, rows.indices.contains(index),
               let window = rows[index].window,
               let app = rows[index].app else { return }
+        // Skip our own process: the prefetch AX walk runs off-main and would
+        // crash the layout engine on a same-process element (see `isOwnProcess`).
+        guard !Self.isOwnProcess(app) else { return }
         let key = AXRef(element: window)
         if tabPrefetchCache[key] != nil || tabPrefetchInFlight.contains(key) { return }
         let isBrowser = (BrowserTabs.Family.from(bundleID: app.bundleIdentifier) != nil)

--- a/BetterCmdTab/Switcher/SwitcherPanel.swift
+++ b/BetterCmdTab/Switcher/SwitcherPanel.swift
@@ -6,6 +6,12 @@ import ObjectiveC
 final class SwitcherPanel: NSPanel {
     private var prefCancellable: AnyCancellable?
 
+    /// Invoked whenever the panel is shown or relayed out (with its frame in
+    /// CGEvent global / top-left-origin coordinates) and when it's hidden (with
+    /// `nil`). SwitcherController forwards this to the hotkey tap so an outside
+    /// click can be hit-tested off the main thread.
+    var onFrameDidChange: ((CGRect?) -> Void)?
+
     /// Replace the inherited `-[NSWindow appearsActive]` getter for
     /// `SwitcherPanel` instances with a constant `true`. Dynamic NSColors used
     /// by row views (`.labelColor`, `.controlAccentColor`,
@@ -132,6 +138,7 @@ final class SwitcherPanel: NSPanel {
         alphaValue = CGFloat(Preferences.shared.panelOpacity) / 100
         makeKeyAndOrderFront(nil)
         CATransaction.commit()
+        onFrameDidChange?(Self.cgGlobalFrame(from: frame))
     }
 
     /// Hide the panel. `NSGlassEffectView` / `NSVisualEffectView` is a
@@ -155,6 +162,23 @@ final class SwitcherPanel: NSPanel {
         contentView?.isHidden = true
         orderOut(nil)
         CATransaction.commit()
+        onFrameDidChange?(nil)
+    }
+
+    /// Convert a Cocoa global rect (bottom-left origin, y-up) to the CGEvent
+    /// global coordinate space (top-left origin of the primary display, y-down)
+    /// used by `CGEvent.location`. Multi-display safe: both spaces are anchored
+    /// to the menu-bar screen, so the same primary-height flip applies to every
+    /// display's coordinates.
+    private static func cgGlobalFrame(from cocoaRect: NSRect) -> CGRect {
+        let primaryHeight = NSScreen.screens.first(where: { $0.frame.origin == .zero })?
+            .frame.height ?? NSScreen.screens.first?.frame.height ?? 0
+        return CGRect(
+            x: cocoaRect.minX,
+            y: primaryHeight - cocoaRect.maxY,
+            width: cocoaRect.width,
+            height: cocoaRect.height
+        )
     }
 
     private func activeScreen() -> NSScreen {


### PR DESCRIPTION
Closes #9.

## Feature
Clicking outside the open switcher HUD dismisses it and leaves the current window focused — the click is swallowed, like a macOS context menu or Spotlight. Gated behind a **Click outside to dismiss** preference (default on) in **Switcher → Navigation**.

`HotkeyTap` now watches mouse-downs; `SwitcherPanel` publishes its frame in CGEvent global coordinates so an outside click is hit-tested off the main thread and consumed, delivering a new `.dismiss` event that cancels the switcher. Clicks inside the panel still pass through (row clicks, hover action buttons).

## Fixes found while testing
- **Crash on tab drill-in of our own window.** The catalog intentionally lists our own Settings window; highlighting it (or pressing `\`) ran a `kAXChildrenAttribute` walk on a same-process element off the main thread. AppKit services same-process AX in-process and that read forces a layout pass → `Modifications to the layout engine must not be performed from a background thread`. Now skips our own pid in both the prefetch and drill paths.
- **Settings window opened behind the frontmost app.** As an accessory app we can't foreground a window in the same runloop tick the activation policy is promoted to `.regular`. Activation is now deferred one tick and reverted to `.accessory` on close.

## Test
- Build: ✅ `BetterCmdTab Debug`
- Unit tests: ✅ 63 passing
- Manual: open switcher, click outside → dismisses, current window stays focused; toggle pref off → old behavior; open Settings → comes to front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)