### PR TITLE
feat(switcher): surface native macOS window tabs

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -396,7 +396,17 @@ final class Preferences: ObservableObject {
         static let clickOutsideToDismiss = "Switcher.clickOutsideToDismiss"
         static let cycleTileWidths = "Switcher.cycleTileWidths"
         static let experimentalInstantSpaceSwitch = "Switcher.experimentalInstantSpaceSwitch"
-        static let experimentalTabDrillIn = "Switcher.experimentalTabDrillIn"
+        /// `\` tab drill-in (peek the highlighted window's tabs in a strip).
+        /// Graduated out of the Experimental tab in 26.x and flipped to default
+        /// ON (intentional — the `\` peek is now the standard way to reach tabs).
+        /// The pre-graduation key `Switcher.experimentalTabDrillIn` defaulted OFF
+        /// and is deliberately not migrated: everyone, including users who never
+        /// touched the old toggle, gets the peek on by default now.
+        static let tabDrillEnabled = "Switcher.tabDrillEnabled"
+        /// Expand native-system-tab windows (Finder, Terminal, TextEdit, …) into
+        /// one switcher row per tab instead of a single collapsed window row.
+        /// Default off — the collapsed row + `\` peek is the default.
+        static let expandTabsAsWindows = "Switcher.expandTabsAsWindows"
         static let showUnreadBadges = "Switcher.showUnreadBadges"
         /// Pre-graduation key (badges used to live behind the Experimental tab);
         /// read once at launch to carry a user's earlier choice over to the new key.
@@ -702,14 +712,26 @@ final class Preferences: ObservableObject {
         }
     }
 
-    /// Browser/Finder tab drill-in: pressing `\` on a row with a tab group
-    /// reveals a horizontal tab strip beneath the switcher. Off by default —
-    /// depends on AX `AXTabs`/`AXPress` which varies in reliability across
-    /// browsers and ships changes.
-    @Published var experimentalTabDrillIn: Bool {
+    /// Tab drill-in: pressing `\` on a row whose window has a tab group reveals
+    /// a horizontal tab strip beneath the switcher so a specific tab can be
+    /// picked. Native AX `AXTabs` for Finder/Terminal/…; AppleScript for
+    /// Safari/Chromium. Default on (graduated out of Experimental).
+    @Published var tabDrillEnabled: Bool {
         didSet {
-            guard oldValue != experimentalTabDrillIn else { return }
-            UserDefaults.standard.set(experimentalTabDrillIn, forKey: Keys.experimentalTabDrillIn)
+            guard oldValue != tabDrillEnabled else { return }
+            UserDefaults.standard.set(tabDrillEnabled, forKey: Keys.tabDrillEnabled)
+        }
+    }
+
+    /// Show each native-system-tab window's tabs as their own switcher rows
+    /// (one entry per tab) instead of a single collapsed window row. Applies to
+    /// apps that expose AppKit `AXTabs` (Finder, Terminal, TextEdit, Ghostty,
+    /// …); browsers keep a single row and the `\` peek. Default off. Read
+    /// off-main by `WindowEnumerator`, so the key is shared.
+    @Published var expandTabsAsWindows: Bool {
+        didSet {
+            guard oldValue != expandTabsAsWindows else { return }
+            UserDefaults.standard.set(expandTabsAsWindows, forKey: Keys.expandTabsAsWindows)
         }
     }
 
@@ -984,7 +1006,8 @@ final class Preferences: ObservableObject {
         self.clickOutsideToDismiss = defaults.object(forKey: Keys.clickOutsideToDismiss) as? Bool ?? true
         self.cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false
         self.experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
-        self.experimentalTabDrillIn = defaults.object(forKey: Keys.experimentalTabDrillIn) as? Bool ?? false
+        self.tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
+        self.expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         // Badges graduated out of the Experimental tab and now default on. Honor
         // the new key if present, otherwise carry over a choice made under the
         // old experimental key, otherwise default to on.
@@ -1065,7 +1088,8 @@ final class Preferences: ObservableObject {
         clickOutsideToDismiss = defaults.object(forKey: Keys.clickOutsideToDismiss) as? Bool ?? true
         cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false
         experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
-        experimentalTabDrillIn = defaults.object(forKey: Keys.experimentalTabDrillIn) as? Bool ?? false
+        tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
+        expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         showUnreadBadges = defaults.object(forKey: Keys.showUnreadBadges) as? Bool ?? true
 
         showWindowTitleLabel = defaults.object(forKey: Keys.showWindowTitleLabel) as? Bool ?? true

--- a/BetterCmdTab/Catalog/AppCatalog.swift
+++ b/BetterCmdTab/Catalog/AppCatalog.swift
@@ -92,15 +92,7 @@ enum AppCatalog {
                 ))
             } else {
                 for win in entry.windows {
-                    rows.append(SwitcherRow(
-                        app: entry.app,
-                        window: win.ref,
-                        windowTitle: win.title,
-                        isMinimized: win.isMinimized,
-                        isFullscreen: win.isFullscreen,
-                        tabs: win.tabs,
-                        cgWindowID: win.cgWindowID
-                    ))
+                    rows.append(SwitcherRow.from(app: entry.app, window: win))
                 }
             }
         }

--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -112,15 +112,7 @@ final class AppCatalogCache {
                 }
             } else {
                 for window in entry.windows {
-                    result.append(SwitcherRow(
-                        app: entry.app,
-                        window: window.ref,
-                        windowTitle: window.title,
-                        isMinimized: window.isMinimized,
-                        isFullscreen: window.isFullscreen,
-                        tabs: window.tabs,
-                        cgWindowID: window.cgWindowID
-                    ))
+                    result.append(SwitcherRow.from(app: entry.app, window: window))
                 }
             }
         }

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -534,6 +534,7 @@
       }
     },
     "Apple Events permission" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -785,7 +786,11 @@
         }
       }
     },
+    "Browser tab access" : {
+
+    },
     "Browser tab drill-in" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -813,7 +818,11 @@
         }
       }
     },
+    "Browsers need Apple Events consent to list their tabs. Click to prompt for each running browser (Safari, Chrome, Arc, Brave, Edge…). Must be done with this window open." : {
+
+    },
     "Browsers require Apple Events consent to enumerate tabs. Click to trigger a prompt for each running browser (Safari, Chrome, Helium, Arc, Brave, Edge…). Must be done with this Settings window open." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -3334,6 +3343,9 @@
         }
       }
     },
+    "List each tab of a native-tab window (Finder, Terminal, TextEdit, …) as its own row instead of one collapsed window. Off keeps one row per window — peek its tabs with \\." : {
+
+    },
     "Lists apps and windows you just closed so you can reopen them." : {
       "localizations" : {
         "de" : {
@@ -4119,6 +4131,9 @@
         }
       }
     },
+    "Peek tabs with \\" : {
+
+    },
     "Permissions" : {
       "localizations" : {
         "de" : {
@@ -4372,6 +4387,7 @@
       }
     },
     "Press \\ on a row whose window has tabs to pick a specific tab from a strip below the switcher. Reliability varies across browsers — uses Accessibility AXTabs." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -4398,6 +4414,9 @@
           }
         }
       }
+    },
+    "Press \\ on a window that has tabs to reveal a strip below the switcher and pick a tab. Native tabs use Accessibility; browsers use Apple Events." : {
+
     },
     "Press Tile left / Tile right again to step the window through ½ → ⅔ → ⅓ of the screen on that side." : {
       "localizations" : {
@@ -5603,6 +5622,9 @@
         }
       }
     },
+    "Show tabs as separate entries" : {
+
+    },
     "Show unread badges" : {
       "localizations" : {
         "de" : {
@@ -6278,6 +6300,9 @@
           }
         }
       }
+    },
+    "Tabs" : {
+
     },
     "Tap to switch instantly; hold longer to open the switcher." : {
       "localizations" : {

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -15,7 +15,6 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let sensitivitySlider = NSSlider()
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
-    private let tabDrillSwitch = NSSwitch()
 
     override func setupContent() {
         // Experimental section — off by default, clearly flagged as unstable.
@@ -59,19 +58,9 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: experimental, title: String(localized: "Switch Spaces without animation"),
                subtitle: String(localized: "Picking an app on another Space or in full screen jumps there instantly, with no slide animation. Applies to keyboard switching too."),
                accessory: instantSpaceSwitch, searchItemID: SearchID.instantSpace)
-
-        addDivider(to: experimental)
-        configureSwitch(tabDrillSwitch, action: #selector(toggleTabDrill(_:)))
-        addRow(to: experimental, title: String(localized: "Browser tab drill-in"),
-               subtitle: String(localized: "Press \\ on a row whose window has tabs to pick a specific tab from a strip below the switcher. Reliability varies across browsers — uses Accessibility AXTabs."),
-               accessory: tabDrillSwitch)
-
-        let grantButton = NSButton(title: String(localized: "Grant permissions…"), target: self, action: #selector(grantBrowserPermissions))
-        grantButton.bezelStyle = .rounded
-        grantButton.controlSize = .small
-        addRow(to: experimental, title: String(localized: "Apple Events permission"),
-               subtitle: String(localized: "Browsers require Apple Events consent to enumerate tabs. Click to trigger a prompt for each running browser (Safari, Chrome, Helium, Arc, Brave, Edge…). Must be done with this Settings window open."),
-               accessory: grantButton)
+        // Tab drill-in (the `\` peek) + tab expansion graduated to the Switcher
+        // tab's "Tabs" section — they are stable, on by default, and belong with
+        // the other content options.
     }
 
     private func configureSwitch(_ toggle: NSSwitch, action: Selector) {
@@ -118,7 +107,6 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         commitSwitch.state = prefs.swipeCommitOnRelease ? .on : .off
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
-        tabDrillSwitch.state = prefs.experimentalTabDrillIn ? .on : .off
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -155,19 +143,6 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleInstantSpace(_ sender: NSSwitch) {
         Preferences.shared.experimentalInstantSpaceSwitch = (sender.state == .on)
-    }
-
-    @objc private func toggleTabDrill(_ sender: NSSwitch) {
-        let on = (sender.state == .on)
-        Preferences.shared.experimentalTabDrillIn = on
-        // Toggling on while Settings is visible is the ideal moment to ask
-        // for Apple Events consent: the user just opted in, and Settings
-        // gives us the foreground UI context TCC needs to surface the prompt.
-        if on { BrowserTabs.requestPermissionForRunningBrowsers() }
-    }
-
-    @objc private func grantBrowserPermissions() {
-        BrowserTabs.requestPermissionForRunningBrowsers()
     }
 
     /// The reverse/commit/sensitivity controls only make sense while the swipe

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -37,6 +37,7 @@ enum SettingsAnchor {
     static let permissions = "privacy.permissions"
     // Switcher
     static let contents = "switcher.contents"
+    static let tabs = "switcher.tabs"
     static let search = "switcher.search"
     static let navigation = "switcher.navigation"
     static let actions = "switcher.actions"
@@ -80,6 +81,9 @@ enum SearchID {
     static let sortOrder = "switcher.sortOrder"
     static let showRecentlyClosed = "switcher.showRecentlyClosed"
     static let recentlyClosedLimit = "switcher.recentlyClosedLimit"
+    static let tabDrill = "switcher.tabDrill"
+    static let expandTabs = "switcher.expandTabs"
+    static let tabPermissions = "switcher.tabPermissions"
     static let letterHints = "switcher.letterHints"
     static let fuzzy = "switcher.fuzzy"
     static let launcher = "switcher.launcher"
@@ -254,6 +258,13 @@ enum SettingsCatalog {
              String(localized: "Show recently closed apps"), ["recently closed", "reopen", "recent"]),
         item(SearchID.recentlyClosedLimit, .switcher, SettingsAnchor.contents, "Switcher", "Contents",
              String(localized: "Recently closed to show"), ["recently closed", "limit", "count"]),
+        // Switcher · Tabs
+        item(SearchID.tabDrill, .switcher, SettingsAnchor.tabs, "Switcher", "Tabs",
+             String(localized: "Peek tabs with \\"), ["tabs", "tab", "drill", "peek", "backslash", "finder tabs", "browser tabs", "safari", "chrome"]),
+        item(SearchID.expandTabs, .switcher, SettingsAnchor.tabs, "Switcher", "Tabs",
+             String(localized: "Show tabs as separate entries"), ["tabs", "tab", "expand", "separate", "rows", "per tab", "finder", "terminal", "native tabs"]),
+        item(SearchID.tabPermissions, .switcher, SettingsAnchor.tabs, "Switcher", "Tabs",
+             String(localized: "Browser tab access"), ["tabs", "apple events", "automation", "permission", "browser", "consent"]),
         // Switcher · Search
         item(SearchID.letterHints, .switcher, SettingsAnchor.search, "Switcher", "Search",
              String(localized: "Letter hints"), ["letter hints", "jump", "vim"]),

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -20,6 +20,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let sortOrderPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let sortOrders: [SwitcherSortOrder] = SwitcherSortOrder.allCases
 
+    // Tabs
+    private let tabDrillSwitch = NSSwitch()
+    private let expandTabsSwitch = NSSwitch()
+
     // Search
     private let letterHintsSwitch = NSSwitch()
     private let fuzzySwitch = NSSwitch()
@@ -90,6 +94,26 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         addRow(to: contents, title: String(localized: "Recently closed to show"),
                subtitle: String(localized: "How many recently closed items to list."),
                accessory: recentlyClosedLimitPopup, searchItemID: SearchID.recentlyClosedLimit)
+
+        // Tabs section — how windows that use native system tabs (Finder,
+        // Terminal, TextEdit, …) are surfaced. Browsers (Safari/Chromium) can't
+        // expand to rows, but the `\` peek still drills their tabs.
+        let tabs = addSection(title: String(localized: "Tabs"), anchor: SettingsAnchor.tabs)
+        configureSwitch(tabDrillSwitch, action: #selector(toggleTabDrill(_:)))
+        addRow(to: tabs, title: String(localized: "Peek tabs with \\"),
+               subtitle: String(localized: "Press \\ on a window that has tabs to reveal a strip below the switcher and pick a tab. Native tabs use Accessibility; browsers use Apple Events."),
+               accessory: tabDrillSwitch, searchItemID: SearchID.tabDrill)
+        configureSwitch(expandTabsSwitch, action: #selector(toggleExpandTabs(_:)))
+        addRow(to: tabs, title: String(localized: "Show tabs as separate entries"),
+               subtitle: String(localized: "List each tab of a native-tab window (Finder, Terminal, TextEdit, …) as its own row instead of one collapsed window. Off keeps one row per window — peek its tabs with \\."),
+               accessory: expandTabsSwitch, searchItemID: SearchID.expandTabs)
+
+        let grantButton = NSButton(title: String(localized: "Grant permissions…"), target: self, action: #selector(grantBrowserPermissions))
+        grantButton.bezelStyle = .rounded
+        grantButton.controlSize = .small
+        addRow(to: tabs, title: String(localized: "Browser tab access"),
+               subtitle: String(localized: "Browsers need Apple Events consent to list their tabs. Click to prompt for each running browser (Safari, Chrome, Arc, Brave, Edge…). Must be done with this window open."),
+               accessory: grantButton, searchItemID: SearchID.tabPermissions)
 
         // Search section — type-to-filter behavior.
         let search = addSection(title: String(localized: "Search"), anchor: SettingsAnchor.search)
@@ -172,6 +196,8 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         badgesSwitch.state = prefs.showUnreadBadges ? .on : .off
         currentSpaceSwitch.state = prefs.currentSpaceOnly ? .on : .off
         selectSortOrder(prefs.sortOrder)
+        tabDrillSwitch.state = prefs.tabDrillEnabled ? .on : .off
+        expandTabsSwitch.state = prefs.expandTabsAsWindows ? .on : .off
         letterHintsSwitch.state = prefs.letterHintsEnabled ? .on : .off
         fuzzySwitch.state = prefs.fuzzySearchEnabled ? .on : .off
         launcherSwitch.state = prefs.searchIncludesLaunchableApps ? .on : .off
@@ -231,6 +257,22 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
 
     private func selectSortOrder(_ order: SwitcherSortOrder) {
         if let i = sortOrders.firstIndex(of: order) { sortOrderPopup.selectItem(at: i) }
+    }
+
+    @objc private func toggleTabDrill(_ sender: NSSwitch) {
+        let on = (sender.state == .on)
+        Preferences.shared.tabDrillEnabled = on
+        // Opting in while Settings is foreground is the right moment to ask for
+        // Apple Events consent — TCC needs that UI context to surface the prompt.
+        if on { BrowserTabs.requestPermissionForRunningBrowsers() }
+    }
+
+    @objc private func toggleExpandTabs(_ sender: NSSwitch) {
+        Preferences.shared.expandTabsAsWindows = (sender.state == .on)
+    }
+
+    @objc private func grantBrowserPermissions() {
+        BrowserTabs.requestPermissionForRunningBrowsers()
     }
 
     @objc private func toggleLetterHints(_ sender: NSSwitch) {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -96,8 +96,10 @@ final class SwitcherController: SwitcherViewDelegate {
     private var liveTabElements: [AXUIElement] = []
     /// Source of the current drill-in. `appleScript` → activate by index via
     /// `BrowserTabs.activateTab`. `accessibility` → AX press on
-    /// `liveTabElements[tabIndex]`. Picked once per drill, never crossed.
-    private enum TabDrillBackend { case appleScript, accessibility }
+    /// `liveTabElements[tabIndex]`. `windows` → native window tabs: each
+    /// `liveTabElements[i]` is a real NSWindow; raising it selects that tab.
+    /// Picked once per drill, never crossed.
+    private enum TabDrillBackend { case appleScript, accessibility, windows }
     private var tabDrillBackend: TabDrillBackend = .accessibility
     /// Background prefetch of tab titles keyed by AXUIElement window
     /// identity. Populated when selection lands on a tab-capable row so that
@@ -1696,10 +1698,22 @@ final class SwitcherController: SwitcherViewDelegate {
     /// Both run off-main; the strip appears once titles land. Silently
     /// no-ops if no tabs are found.
     private func enterTabDrill() {
-        guard Preferences.shared.experimentalTabDrillIn else { return }
+        guard Preferences.shared.tabDrillEnabled else { return }
         guard phase == .visible, rows.indices.contains(index) else { return }
         let row = rows[index]
         guard let window = row.window, let app = row.app else { return }
+        // Native macOS window tabs: the sibling tab windows + titles were already
+        // resolved during the scan, so the strip appears instantly with no fetch.
+        // Committing a strip entry raises that tab's window (selecting the tab).
+        if row.tabWindows.count > 1 {
+            applyDrill(
+                titles: row.tabWindows.map(\.title),
+                liveTabs: row.tabWindows.map(\.ref),
+                backend: .windows,
+                window: window
+            )
+            return
+        }
         // Never drill our own windows — the AX walk would run in-process off the
         // main thread and crash the layout engine (see `isOwnProcess`).
         guard !Self.isOwnProcess(app) else { return }
@@ -1824,7 +1838,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `tabPrefetchCache`.
     private func schedulePrefetchForCurrentSelection() {
         tabPrefetchTimer?.invalidate()
-        guard Preferences.shared.experimentalTabDrillIn,
+        guard Preferences.shared.tabDrillEnabled,
               phase == .visible, rows.indices.contains(index),
               let window = rows[index].window,
               let app = rows[index].app else { return }
@@ -1900,9 +1914,12 @@ final class SwitcherController: SwitcherViewDelegate {
         let row = rows[index]
         let chosen = tabIndex
         let backend = tabDrillBackend
-        let axTab: AXUIElement? = (backend == .accessibility && liveTabElements.indices.contains(chosen))
+        // For AX/native-window backends the target element is `liveTabElements[chosen]`
+        // (an AXTab control, or a real tab window respectively). Bail to a plain
+        // commit if it's somehow missing.
+        let targetElement: AXUIElement? = (backend != .appleScript && liveTabElements.indices.contains(chosen))
             ? liveTabElements[chosen] : nil
-        if backend == .accessibility && axTab == nil {
+        if backend != .appleScript && targetElement == nil {
             exitTabDrill()
             commit()
             return
@@ -1936,8 +1953,14 @@ final class SwitcherController: SwitcherViewDelegate {
                 _ = BrowserTabs.activateTab(at: chosen, in: app, window: window, title: title)
             }
         case .accessibility:
-            if let tab = axTab {
+            if let tab = targetElement {
                 Activator.activateTab(in: app, window: window, tab: tab, instantSpace: instantSpace)
+            }
+        case .windows:
+            // The chosen tab is a real NSWindow — raising it selects that tab.
+            if let tabWindow = targetElement {
+                let tabRow = SwitcherRow(app: app, window: tabWindow, windowTitle: row.windowTitle, isMinimized: false)
+                Activator.activate(tabRow, instantSpace: instantSpace)
             }
         }
     }

--- a/BetterCmdTab/Switcher/SwitcherRow.swift
+++ b/BetterCmdTab/Switcher/SwitcherRow.swift
@@ -28,9 +28,15 @@ struct SwitcherRow {
     /// it, avoiding a no-window→hidden flash. `isHidden` is read live, so if the
     /// app hides before then the row already shows the hidden glyph.
     let suppressNoWindowGlyph: Bool
-    /// `AXTabs` children of this row's window, propagated from `WindowInfo`.
-    /// Non-empty only when the window has a tab group with 2+ tabs.
+    /// In-content `AXTabs` of this row's window (rare; most apps don't expose
+    /// it). Drives the AX `\` drill backend for apps that do.
     let tabs: [AXUIElement]
+    /// Native macOS window-tab siblings, when this row is the collapsed front
+    /// tab of a group (Finder/Terminal/TextEdit/…). Each is a real NSWindow;
+    /// the `\` peek lists them and committing one raises that window (selecting
+    /// the tab). Empty for ordinary windows and in "expand tabs as windows" mode
+    /// (each tab is then its own row).
+    let tabWindows: [TabWindowRef]
 
     init(
         app: NSRunningApplication,
@@ -41,6 +47,7 @@ struct SwitcherRow {
         isPlaceholder: Bool = false,
         suppressNoWindowGlyph: Bool = false,
         tabs: [AXUIElement] = [],
+        tabWindows: [TabWindowRef] = [],
         cgWindowID: CGWindowID = 0
     ) {
         self.subject = .running(app)
@@ -52,6 +59,24 @@ struct SwitcherRow {
         self.isPlaceholder = isPlaceholder
         self.suppressNoWindowGlyph = suppressNoWindowGlyph
         self.tabs = tabs
+        self.tabWindows = tabWindows
+    }
+
+    /// Map one enumerated window to its switcher row, carrying its native
+    /// window-tab siblings (if any) for the `\` peek. Expansion to one row per
+    /// tab is decided upstream in `WindowEnumerator` (it emits one `WindowInfo`
+    /// per tab in that mode), so this is always 1:1.
+    static func from(app: NSRunningApplication, window w: WindowInfo) -> SwitcherRow {
+        SwitcherRow(
+            app: app,
+            window: w.ref,
+            windowTitle: w.title,
+            isMinimized: w.isMinimized,
+            isFullscreen: w.isFullscreen,
+            tabs: w.tabs,
+            tabWindows: w.tabWindows,
+            cgWindowID: w.cgWindowID
+        )
     }
 
     /// A not-yet-running app surfaced in search so it can be launched.
@@ -65,6 +90,7 @@ struct SwitcherRow {
         self.isPlaceholder = false
         self.suppressNoWindowGlyph = false
         self.tabs = []
+        self.tabWindows = []
     }
 
     /// A recently closed window/app surfaced in search so it can be reopened.
@@ -78,6 +104,7 @@ struct SwitcherRow {
         self.isPlaceholder = false
         self.suppressNoWindowGlyph = false
         self.tabs = []
+        self.tabWindows = []
     }
 
     /// A copy of this row with an updated window title, used for in-place title
@@ -94,12 +121,14 @@ struct SwitcherRow {
             isPlaceholder: isPlaceholder,
             suppressNoWindowGlyph: suppressNoWindowGlyph,
             tabs: tabs,
+            tabWindows: tabWindows,
             cgWindowID: cgWindowID
         )
     }
 
-    /// True when this row has a tab group worth drilling into.
-    var hasTabs: Bool { tabs.count > 1 }
+    /// True when this row has a tab group worth peeking with `\` — either native
+    /// window-tab siblings or an in-content `AXTabs` group.
+    var hasTabs: Bool { tabWindows.count > 1 || tabs.count > 1 }
 
     /// The backing running application, or `nil` for a launchable/recent row.
     var app: NSRunningApplication? {

--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -11,10 +11,18 @@ struct WindowInfo {
     let title: String
     let isMinimized: Bool
     let isFullscreen: Bool
-    /// `AXTabs` children of this window (browsers, tabbed Finder, iTerm, …).
-    /// Empty when the window has no tab group or only a single tab — drill-in
-    /// is only meaningful with at least two tabs.
+    /// In-content `AXTabs` children of this window (the deep tab strip some apps
+    /// expose, e.g. via an `AXTabGroup`). Empty for the common case — most apps,
+    /// including Finder/Terminal/TextEdit, do NOT expose this. Native window
+    /// tabs are represented by `tabWindows` instead.
     let tabs: [AXUIElement]
+    /// Native macOS window-tab siblings, when this is the collapsed front tab of
+    /// a group (Finder/Terminal/TextEdit/Ghostty/…). Each entry is a real
+    /// NSWindow (own title + CGWindowID) at the same on-screen frame; raising
+    /// one selects that tab. Includes this window itself, in tab order. Empty
+    /// for an ordinary single window and whenever "expand tabs as windows" is on
+    /// (each tab is then its own `WindowInfo`).
+    let tabWindows: [TabWindowRef]
 
     init(
         ref: AXUIElement,
@@ -22,7 +30,8 @@ struct WindowInfo {
         title: String,
         isMinimized: Bool,
         isFullscreen: Bool = false,
-        tabs: [AXUIElement] = []
+        tabs: [AXUIElement] = [],
+        tabWindows: [TabWindowRef] = []
     ) {
         self.ref = ref
         self.cgWindowID = cgWindowID
@@ -30,7 +39,18 @@ struct WindowInfo {
         self.isMinimized = isMinimized
         self.isFullscreen = isFullscreen
         self.tabs = tabs
+        self.tabWindows = tabWindows
     }
+}
+
+/// One window in a native macOS window-tab group. Each tab is a distinct
+/// NSWindow — own AX element, title, and CGWindowID — sharing the group's
+/// on-screen frame; AX exposes only the front tab, the others are recovered by
+/// the brute-force scan. Raising a tab's window selects that tab.
+struct TabWindowRef {
+    let ref: AXUIElement
+    let title: String
+    let cgWindowID: CGWindowID
 }
 
 /// Hashable wrapper around `AXUIElement` whose equality follows the CF identity
@@ -155,6 +175,14 @@ enum WindowEnumerator {
             for w in axWindows { appendIfNew(w) }
         }
 
+        // Snapshot which elements the app's own window list exposed, before the
+        // brute scan runs. This is the discriminator for native window tabs:
+        // AppKit lists only the FRONT tab of a group, so any window the brute
+        // scan recovers at the same frame as an AX-listed window is a background
+        // tab — never a genuinely separate window (two real overlapping windows
+        // are both in the AX list). Drives collapse/expand below.
+        let axListRefs = seenByElement
+
         // Skip brute-force AX scan when the CG window list says AX already has
         // every on-screen window covered. Apps with no CG-AX gap (the common
         // case) pay zero brute-scan cost.
@@ -253,17 +281,15 @@ enum WindowEnumerator {
         struct RawWindow {
             let element: AXUIElement
             let cgWindowID: CGWindowID
-            let tabs: [AXUIElement]?
+            let tabs: [AXUIElement]
             let minimized: Bool
             let fullscreen: Bool
             let title: String
             let frameKey: String?
+            let fromAXList: Bool
         }
         var raws: [RawWindow] = []
         raws.reserveCapacity(elements.count)
-        // Frames occupied by a native macOS window-tab group. Only these are
-        // eligible for the merged-window dedup further down.
-        var tabGroupFrames: Set<String> = []
         for window in elements {
             AXUIElementSetMessagingTimeout(window, Self.confirmedTimeout)
             var valuesRef: CFArray?
@@ -273,14 +299,12 @@ enum WindowEnumerator {
             let subrole = (values[0] as? String) ?? ""
             guard acceptedSubroles.contains(subrole) else { continue }
 
-            let tabs = values[1] as? [AXUIElement]
+            let tabs = (values[1] as? [AXUIElement]) ?? []
             let minimized = (values[2] as? Bool) ?? false
             let fullscreen = (values[3] as? Bool) ?? false
             let windowTitle = (values[4] as? String) ?? ""
-            // Minimized windows legitimately share (0, 0) — never frame-dedup them.
+            // Minimized windows legitimately share (0, 0) — never frame-group them.
             let frameKey = minimized ? nil : frameKeyFromAttributes(values[5], values[6])
-
-            if let tabs, tabs.count > 1, let frameKey { tabGroupFrames.insert(frameKey) }
 
             raws.append(RawWindow(
                 element: window,
@@ -289,50 +313,86 @@ enum WindowEnumerator {
                 minimized: minimized,
                 fullscreen: fullscreen,
                 title: windowTitle,
-                frameKey: frameKey
+                frameKey: frameKey,
+                fromAXList: axListRefs.contains(AXRef(element: window))
             ))
         }
 
-        var seenTabGroups: Set<[AXRef]> = []
-        var addedTabGroupForPid = false
-        // Native macOS window tabs (Finder, Terminal, TextEdit, Ghostty, ...)
-        // expose each tab as its own AXWindow with its own CGWindowID — but
-        // they share the same on-screen frame because only one tab renders at
-        // a time and macOS keeps the merged-window outline identical across
-        // tabs. Collapsing by (origin × size) keeps one row per visual merged
-        // window. Crucially this is gated on `tabGroupFrames`: two genuinely
-        // separate windows that merely overlap (e.g. two maximized Chrome
-        // windows, which don't use native window tabs) must NOT collapse —
-        // doing so was issue #10, where the second maximized window vanished
-        // from the switcher.
-        var seenFrames: Set<String> = []
-        for raw in raws {
-            var windowTabs: [AXUIElement] = []
-            if let tabs = raw.tabs, tabs.count > 1 {
-                if addedTabGroupForPid { continue }
-                let key = tabs.map { AXRef(element: $0) }
-                if seenTabGroups.contains(key) { continue }
-                seenTabGroups.insert(key)
-                windowTabs = tabs
-                addedTabGroupForPid = true
-            }
-
-            if let frameKey = raw.frameKey, tabGroupFrames.contains(frameKey) {
-                if seenFrames.contains(frameKey) { continue }
-                seenFrames.insert(frameKey)
-            }
-
+        // Native macOS window tabs: each tab is its own NSWindow at the group's
+        // shared frame, but AppKit exposes only the FRONT tab in the app's window
+        // list — the background tabs surface only via the brute scan. So a
+        // brute-only window whose frame matches an AX-listed window of the same
+        // app is a background tab, never a separate window (two real overlapping
+        // windows are both AX-listed — issue #10 stays safe). Collapse keeps the
+        // front tab and attaches the rest as `tabWindows` for the `\` peek;
+        // expand emits one row per tab. No reliance on `AXTabs` (which these
+        // apps don't expose).
+        let expand = UserDefaults.standard.bool(forKey: Preferences.Keys.expandTabsAsWindows)
+        let resolution = resolveTabStacks(
+            frameKeys: raws.map(\.frameKey),
+            fromAXList: raws.map(\.fromAXList),
+            expand: expand
+        )
+        for (i, raw) in raws.enumerated() where resolution.keep[i] {
+            let siblings = resolution.siblingIndices[i] ?? []
+            let tabWindows: [TabWindowRef] = siblings.isEmpty ? [] :
+                ([i] + siblings).map { idx in
+                    TabWindowRef(ref: raws[idx].element, title: raws[idx].title, cgWindowID: raws[idx].cgWindowID)
+                }
             infos.append(WindowInfo(
                 ref: raw.element,
                 cgWindowID: raw.cgWindowID,
                 title: raw.title,
                 isMinimized: raw.minimized,
                 isFullscreen: raw.fullscreen,
-                tabs: windowTabs
+                tabs: raw.tabs.count > 1 ? raw.tabs : [],
+                tabWindows: tabWindows
             ))
         }
 
         return sortedByZOrder(infos, cgZOrder: cgZOrder)
+    }
+
+    /// Result of grouping a pid's windows into native tab stacks.
+    /// `keep[i]` is false for background-tab windows folded into their front tab
+    /// (collapse mode only). `siblingIndices[front]` lists the background-tab
+    /// indices folded under that kept front window, so the caller can attach
+    /// them as `tabWindows` for the `\` peek.
+    struct TabResolution {
+        let keep: [Bool]
+        let siblingIndices: [Int: [Int]]
+    }
+
+    /// Decide which windows to surface and which are native background tabs.
+    /// Pure (no AX) so it is unit-testable. `frameKeys[i] == nil` means the
+    /// window is unframeable/minimized and is never treated as a tab.
+    ///
+    /// - expand: every window is kept as its own row (one entry per tab); no
+    ///   grouping.
+    /// - collapse: every AX-listed window is kept; a brute-only window whose
+    ///   frame matches an AX-listed window's frame is dropped and recorded as a
+    ///   background tab of the first AX-listed window at that frame. Brute-only
+    ///   windows at a frame with no AX-listed window are kept (e.g. fullscreen
+    ///   windows the public list misses), preserving prior behavior.
+    static func resolveTabStacks(frameKeys: [String?], fromAXList: [Bool], expand: Bool) -> TabResolution {
+        let n = frameKeys.count
+        var keep = [Bool](repeating: true, count: n)
+        guard !expand else { return TabResolution(keep: keep, siblingIndices: [:]) }
+
+        var axFrames = Set<String>()
+        var frontForFrame: [String: Int] = [:]
+        for i in 0..<n where fromAXList[i] {
+            guard let f = frameKeys[i] else { continue }
+            axFrames.insert(f)
+            if frontForFrame[f] == nil { frontForFrame[f] = i }
+        }
+        var siblings: [Int: [Int]] = [:]
+        for i in 0..<n where !fromAXList[i] {
+            guard let f = frameKeys[i], axFrames.contains(f) else { continue }
+            keep[i] = false
+            if let front = frontForFrame[f] { siblings[front, default: []].append(i) }
+        }
+        return TabResolution(keep: keep, siblingIndices: siblings)
     }
 
     /// Stringify a window's (position, size) for dedup. Returns nil when

--- a/BetterCmdTabTests/SwitcherRowTests.swift
+++ b/BetterCmdTabTests/SwitcherRowTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Testing
 @testable import BetterCmdTab
 
@@ -9,6 +10,22 @@ struct SwitcherRowTests {
     /// for any NSRunningApplication. Properties we exercise (localizedName, pid)
     /// are guaranteed non-nil for the current process.
     private var hostApp: NSRunningApplication { .current }
+
+    /// A throwaway AX element. `SwitcherRow.from` never messages it — so the app
+    /// element of the test process is a fine stand-in.
+    private func axElement() -> AXUIElement { AXUIElementCreateApplication(getpid()) }
+
+    private func windowInfo(tabWindows: Int, titles: [String], title: String = "Window") -> WindowInfo {
+        WindowInfo(
+            ref: axElement(),
+            cgWindowID: 42,
+            title: title,
+            isMinimized: false,
+            tabWindows: (0..<tabWindows).map { i in
+                TabWindowRef(ref: axElement(), title: titles.indices.contains(i) ? titles[i] : "", cgWindowID: CGWindowID(100 + i))
+            }
+        )
+    }
 
     @Test("placeholder rows always show app name")
     func placeholderShowsAppName() {
@@ -84,5 +101,26 @@ struct SwitcherRowTests {
         let row = SwitcherRow(app: hostApp, window: nil, windowTitle: "", isMinimized: false)
         #expect(!row.isLaunchable)
         #expect(row.app != nil)
+    }
+
+    // MARK: - native window-tab rows
+
+    @Test("from carries the window's native tab siblings for the peek")
+    func fromCarriesTabWindows() {
+        let info = windowInfo(tabWindows: 3, titles: ["A", "B", "C"], title: "Window A")
+        let row = SwitcherRow.from(app: hostApp, window: info)
+        #expect(row.tabWindows.count == 3)
+        #expect(row.hasTabs)                      // peekable with `\`
+        #expect(row.windowTitle == "Window A")    // front tab's title
+        #expect(row.cgWindowID == 42)
+        #expect(row.tabWindows.map(\.title) == ["A", "B", "C"])
+    }
+
+    @Test("a plain window (no tab siblings) is not peekable")
+    func plainWindowNoTabs() {
+        let info = WindowInfo(ref: axElement(), cgWindowID: 7, title: "Solo", isMinimized: false)
+        let row = SwitcherRow.from(app: hostApp, window: info)
+        #expect(row.tabWindows.isEmpty)
+        #expect(!row.hasTabs)
     }
 }

--- a/BetterCmdTabTests/TabStackResolutionTests.swift
+++ b/BetterCmdTabTests/TabStackResolutionTests.swift
@@ -1,0 +1,81 @@
+import Testing
+@testable import BetterCmdTab
+
+/// Native macOS window tabs surface as several NSWindows at one frame, but
+/// AppKit lists only the front tab; the brute scan recovers the rest. These
+/// cover `resolveTabStacks`, the pure rule that decides which are background
+/// tabs to fold (collapse) vs. genuinely separate windows to keep.
+@Suite("Tab stack resolution")
+struct TabStackResolutionTests {
+
+    @Test("expand keeps every window as its own row")
+    func expandKeepsAll() {
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: ["F", "F", "F"],
+            fromAXList: [true, false, false],
+            expand: true
+        )
+        #expect(r.keep == [true, true, true])
+        #expect(r.siblingIndices.isEmpty)
+    }
+
+    @Test("collapse folds brute-only siblings into the AX-listed front tab")
+    func collapseFoldsBackgroundTabs() {
+        // Ghostty/TextEdit shape: 1 front (AX-listed) + 2 background tabs (brute).
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: ["F", "F", "F"],
+            fromAXList: [true, false, false],
+            expand: false
+        )
+        #expect(r.keep == [true, false, false])
+        #expect(r.siblingIndices[0] == [1, 2])
+    }
+
+    @Test("collapse never merges two real overlapping windows (issue #10)")
+    func collapseKeepsTwoAXListedWindows() {
+        // Two maximized Chrome windows: both in the AX list, same frame, NOT tabs.
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: ["F", "F"],
+            fromAXList: [true, true],
+            expand: false
+        )
+        #expect(r.keep == [true, true])
+        #expect(r.siblingIndices.isEmpty)
+    }
+
+    @Test("collapse keeps brute-only windows whose frame has no AX-listed window")
+    func collapseKeepsLoneBruteWindow() {
+        // e.g. a fullscreen window the public list misses — keep it (prior behavior).
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: ["G"],
+            fromAXList: [false],
+            expand: false
+        )
+        #expect(r.keep == [true])
+        #expect(r.siblingIndices.isEmpty)
+    }
+
+    @Test("collapse handles a tab group alongside a separate window")
+    func collapseMixed() {
+        // [front F (ax), bg F (brute), bg F (brute), other G (ax)]
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: ["F", "F", "F", "G"],
+            fromAXList: [true, false, false, true],
+            expand: false
+        )
+        #expect(r.keep == [true, false, false, true])
+        #expect(r.siblingIndices[0] == [1, 2])
+        #expect(r.siblingIndices[3] == nil)   // the separate window has no siblings
+    }
+
+    @Test("a nil frame (minimized/unframeable) is never treated as a tab")
+    func nilFrameNotTab() {
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: [nil, nil],
+            fromAXList: [true, false],
+            expand: false
+        )
+        #expect(r.keep == [true, true])
+        #expect(r.siblingIndices.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces native macOS window tabs (Finder, Terminal, TextEdit, Ghostty, …) in the switcher. AppKit lists only the front tab of a tab stack, so the brute-force scan used to drag background tabs back in — each showing as its own row with no way to collapse them.

`WindowEnumerator` now identifies a tab stack as brute-only windows whose frame matches an AX-listed window (two genuinely separate overlapping windows are both AX-listed, so issue #10 stays safe), via the pure, unit-tested `resolveTabStacks` helper:

- **Default:** collapse to the front tab; siblings ride along as `WindowInfo.tabWindows` for the `\` peek (instant — titles come from the scan, no AppleScript/AX walk). Committing a strip entry raises that tab's window.
- **"Show tabs as separate entries"** (Switcher ▸ Tabs, off by default): one row per tab window, each with its own title.

The `\` tab peek graduates out of Experimental into a new **Switcher ▸ Tabs** section (on by default); browser drill-in (Safari/Chromium via Apple Events) is unchanged and joins that section.

Replaces the earlier AXTabs-based approach, which these apps don't expose.

## Test plan

- 105 unit tests pass (new `resolveTabStacks` + `SwitcherRow.from` coverage in `TabStackResolutionTests` / `SwitcherRowTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
