### PR TITLE
fix(switcher): don't collapse separate fullscreen windows; guard tab commit against selection drift

### DIFF
--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -2671,6 +2671,9 @@
         }
       }
     },
+    "How long a typed letter sequence stays active. When it expires, the highlight clears and the list returns to its original order." : {
+
+    },
     "How many recently closed items to list." : {
       "localizations" : {
         "de" : {
@@ -3258,6 +3261,9 @@
           }
         }
       }
+    },
+    "Letter chain timeout" : {
+
     },
     "Letter hints" : {
       "localizations" : {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -101,6 +101,13 @@ final class SwitcherController: SwitcherViewDelegate {
     /// Picked once per drill, never crossed.
     private enum TabDrillBackend { case appleScript, accessibility, windows }
     private var tabDrillBackend: TabDrillBackend = .accessibility
+    /// The window `applyDrill` built the current tab strip against. `commitTab`
+    /// re-validates that the selected row still points at this window before
+    /// pairing it with the captured tab elements — a background refresh can move
+    /// the selection off the drilled row (the drilled app quits, or a re-sort
+    /// reorders rows) while the strip stays open, which would otherwise activate
+    /// the wrong window or a different app. Cleared whenever the drill ends.
+    private var drillWindow: AXUIElement?
     /// Background prefetch of tab titles keyed by AXUIElement window
     /// identity. Populated when selection lands on a tab-capable row so that
     /// the eventual `\` finds the work already done. Cleared when the panel
@@ -1676,6 +1683,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabTitles = []
         liveTabElements = []
         tabIndex = 0
+        drillWindow = nil
         hotkey.setTabDrillActive(false)
         tabPrefetchCache.removeAll()
         tabPrefetchInFlight.removeAll()
@@ -1835,6 +1843,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabIndex = 0
         tabDrillActive = true
         tabDrillHint = nil
+        drillWindow = window
         stickyOpen = true
         hotkey.setTabDrillActive(true)
         refreshDisplay()
@@ -1951,6 +1960,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabTitles = []
         liveTabElements = []
         tabIndex = 0
+        drillWindow = nil
         hotkey.setTabDrillActive(false)
         refreshDisplay()
     }
@@ -1966,7 +1976,14 @@ final class SwitcherController: SwitcherViewDelegate {
         guard tabDrillActive, !tabTitles.isEmpty,
               rows.indices.contains(index),
               let app = rows[index].app,
-              let window = rows[index].window else {
+              let window = rows[index].window,
+              // The selection must still be the row the strip was built against.
+              // A background refresh can drift `index` onto a different row while
+              // the strip stays open (the drilled app quit, or a re-sort moved
+              // rows); the captured tab elements then no longer belong to
+              // rows[index]. Fall back to a plain commit rather than activating a
+              // mismatched window/app.
+              let dw = drillWindow, CFEqual(window, dw) else {
             exitTabDrill()
             commit()
             return
@@ -1996,6 +2013,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabTitles = []
         liveTabElements = []
         tabIndex = 0
+        drillWindow = nil
         hotkey.setTabDrillActive(false)
         primedApps = []
         rows = []

--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -303,8 +303,13 @@ enum WindowEnumerator {
             let minimized = (values[2] as? Bool) ?? false
             let fullscreen = (values[3] as? Bool) ?? false
             let windowTitle = (values[4] as? String) ?? ""
-            // Minimized windows legitimately share (0, 0) — never frame-group them.
-            let frameKey = minimized ? nil : frameKeyFromAttributes(values[5], values[6])
+            // Minimized windows legitimately share (0, 0); fullscreen windows
+            // each fill the same display bounds, so two separate fullscreen
+            // windows of one app (each on its own Space — recovered by the brute
+            // scan) share a frame yet are NOT tabs (macOS never tabs fullscreen
+            // windows). Excluding both from frame-grouping prevents collapsing a
+            // real off-Space fullscreen window into an unrelated row (issue #10).
+            let frameKey = (minimized || fullscreen) ? nil : frameKeyFromAttributes(values[5], values[6])
 
             raws.append(RawWindow(
                 element: window,
@@ -365,7 +370,7 @@ enum WindowEnumerator {
 
     /// Decide which windows to surface and which are native background tabs.
     /// Pure (no AX) so it is unit-testable. `frameKeys[i] == nil` means the
-    /// window is unframeable/minimized and is never treated as a tab.
+    /// window is unframeable/minimized/fullscreen and is never treated as a tab.
     ///
     /// - expand: every window is kept as its own row (one entry per tab); no
     ///   grouping.

--- a/BetterCmdTabTests/TabStackResolutionTests.swift
+++ b/BetterCmdTabTests/TabStackResolutionTests.swift
@@ -78,4 +78,20 @@ struct TabStackResolutionTests {
         #expect(r.keep == [true, true])
         #expect(r.siblingIndices.isEmpty)
     }
+
+    @Test("a brute-only nil-frame window (fullscreen) is kept even next to an AX window with a real frame")
+    func fullscreenNilFrameKept() {
+        // The caller maps fullscreen (and minimized) windows to a nil frameKey,
+        // so two separate fullscreen windows of one app — one AX-listed on the
+        // current Space, one recovered off-Space by the brute scan — are never
+        // folded into one row (issue #10 / off-Space fullscreen vanish). Here the
+        // brute window's nil frame must not collapse despite an AX window present.
+        let r = WindowEnumerator.resolveTabStacks(
+            frameKeys: ["F", nil],
+            fromAXList: [true, false],
+            expand: false
+        )
+        #expect(r.keep == [true, true])
+        #expect(r.siblingIndices.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two **HIGH** correctness bugs found by an audit of the merged native window-tabs feature. No critical (crash/UAF/deadlock) issues; these are wrong-result/wrong-activation defects.

### Fix 1 — separate fullscreen windows no longer collapse into one row
`WindowEnumerator.resolveTabStacks` grouped a pid's windows purely by frame. Two genuinely separate fullscreen windows of one app on the same display — one AX-listed on the current Space, the other recovered off-Space by the brute scan — share an identical full-screen frame, so the off-Space one was folded in as a fake "tab" and **vanished from the switcher** (reachable only via an unrelated window's `\` peek). This is the issue #10 class of defect the collapse was supposed to avoid; the "two real overlapping windows are both AX-listed" assumption is false for off-Space fullscreen windows, which by design are *not* both AX-listed.

Fix: fullscreen windows now get a `nil` frame key (like minimized), so `resolveTabStacks` never folds them. Native macOS window tabs are never fullscreen, so legitimate tab collapse is unaffected. Added regression test `fullscreenNilFrameKept`.

### Fix 2 — `commitTab` no longer activates the wrong window on selection drift
The tab-strip drill payload (`liveTabElements`) was bound only to the live `index`, not to the row it was built from, and no background refresh exits the drill. If a refresh moved the selection off the drilled row while the strip was open (e.g. the drilled app quits → `handleAppTerminated` → `refreshDisplay` clamps `index` onto a different row), `commitTab` paired the *drifted* row's app/window with the *stale* tab elements → wrong-window / cross-app activation.

Fix: a new `drillWindow` records the window the strip was built against; `commitTab` re-validates `CFEqual(rows[index].window, drillWindow)` and falls back to a plain `commit()` on mismatch. `drillWindow` is set in `applyDrill` and cleared on every drill exit (`exitTabDrill`, `cancel`, `commitTab` teardown).

## Test plan
- Builds clean; **106 unit tests pass** (added `fullscreenNilFrameKept`).
- Adversarial multi-agent review of the diff returned zero findings.

(The `Localizable.xcstrings` hunk is the build extracting two already-shipped letter-chain UI strings into the catalog — no behavior change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
