### PR TITLE
fix: switcher sized for wrong screen on first open after monitor switch

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -579,14 +579,12 @@ final class SwitcherView: NSView, TabStripDelegate {
         return layout
     }
 
-    /// Resolves the screen the switcher should size itself for. `window?.screen`
-    /// reflects where the panel was actually placed (set by `SwitcherPanel.present`),
-    /// so layout bounds and presentation position stay on the same display when
-    /// the panel is shown under the cursor on an external monitor. `NSScreen.main`
-    /// would otherwise leak the keyboard-focus monitor into layout math, picking
-    /// the wrong DPI / visible area when those don't match.
+    /// Returns the visible frame of the screen to size the panel for. Uses
+    /// `window?.screen` while visible (reflects actual placement); falls back to
+    /// `preferredScreen()` when ordered out, because `NSWindow.screen` is
+    /// frame-based and would otherwise return the screen from the previous open.
     private func layoutScreenFrame() -> NSRect {
-        let screen = window?.screen ?? SwitcherPanel.preferredScreen()
+        let screen = (window?.isVisible == true ? window?.screen : nil) ?? SwitcherPanel.preferredScreen()
         return screen.visibleFrame
     }
 


### PR DESCRIPTION
## What

When multiple monitors with different resolutions are connected, opening the switcher on the high-res screen, closing it, moving the cursor to the smaller screen, and opening it again showed the panel at the wrong (too large) size. It only corrected itself on the second open.

## Root cause

`NSWindow.screen` is frame-based, not visibility-based. After `orderOut()`, the panel's frame still overlaps the previous screen, so `window?.screen` returned the high-res screen even though the cursor had moved elsewhere. `layoutScreenFrame()` fed those stale dimensions into `computeLayout()` and `fittedMetrics()`, producing a layout sized for the high-res screen. On the first open, `present()` clamped the oversized height to the small screen's full visible height. On the second open the frame had already been repositioned by the first `setFrame()` call, so `window?.screen` was correct.

## Fix

Guard `window?.screen` on `isVisible` in `layoutScreenFrame()`. When the panel is ordered out, fall back to `preferredScreen()` (cursor position) — the same source used by `forScreen()` to compute `currentMetrics`.

## Checklist

- [x] Builds clean, no new warnings
- [x] All 146 existing tests pass
- [x] No new test needed — the fix is in AppKit window/screen state, no pure-logic surface
- [x] No commented-out code, no `print` statements
- [x] One logical change