### PR TITLE
fix: post-audit hardening (tap lock, AX teardown, popup bounds)

### DIFF
--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -332,6 +332,13 @@ final class AppCatalogCache {
 
     private func uninstallAXObserver(forPid pid: pid_t) {
         guard let observer = axObservers.removeValue(forKey: pid) else { return }
+        // Drop the AX-server subscriptions before detaching the run-loop source,
+        // mirroring the add side in `buildAXObserver` (same names, same element).
+        // Removing only the source leaves the notifications dangling.
+        let axApp = AXUIElementCreateApplication(pid)
+        for name in Self.axNotifications {
+            _ = AXObserverRemoveNotification(observer, axApp, name as CFString)
+        }
         CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .defaultMode)
     }
 

--- a/BetterCmdTab/Input/SpaceSwipeSuppressor.swift
+++ b/BetterCmdTab/Input/SpaceSwipeSuppressor.swift
@@ -15,10 +15,23 @@ import os
 /// why this lives behind the off-by-default Experimental swipe toggle.
 final class SpaceSwipeSuppressor {
 
-    private var tap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
-    private var tapThread: Thread?
-    private var tapRunLoop: CFRunLoop?
+    /// CGEvent-tap lifecycle handles. The tap callback runs on its own thread and
+    /// reads `tap` (the disabled-tap re-enable path in `handle`), while
+    /// `uninstall()` nils them from main (via `setEnabled` on the experimental
+    /// toggle, or `deinit`). `CFRunLoopStop` is async, so the callback can be
+    /// mid-`handle` during tear-down — an unsynchronized read/write data race.
+    /// Guard every field with the same `OSAllocatedUnfairLock` discipline
+    /// `HotkeyTap` uses: copy a ref into a local under the lock, release, then
+    /// touch CGEvent/CFRunLoop on the local — never hold the lock across
+    /// `CFRunLoopRun`/`CFRunLoopStop`. CF ports and `Thread` are thread-safe
+    /// reference types, so `TapPorts` is `@unchecked Sendable`.
+    private struct TapPorts: @unchecked Sendable {
+        var tap: CFMachPort?
+        var runLoopSource: CFRunLoopSource?
+        var tapThread: Thread?
+        var tapRunLoop: CFRunLoop?
+    }
+    private let ports = OSAllocatedUnfairLock<TapPorts>(initialState: TapPorts())
 
     /// Undocumented CGS gesture event types and fields (from the IOHID/CGS
     /// private headers; same constants InstantSpaceSwitcher uses).
@@ -36,7 +49,7 @@ final class SpaceSwipeSuppressor {
     }
 
     private func install() {
-        guard tap == nil else { return }
+        guard ports.withLock({ $0.tap }) == nil else { return }
 
         let mask: CGEventMask =
             (1 << UInt64(CGS.eventGesture)) | (1 << UInt64(CGS.eventDockControl))
@@ -61,8 +74,12 @@ final class SpaceSwipeSuppressor {
         }
 
         let src = CFMachPortCreateRunLoopSource(nil, port, 0)
-        tap = port
-        runLoopSource = src
+        // Publish tap/source before starting the worker so the callback's
+        // re-enable path sees them on first dispatch.
+        ports.withLock {
+            $0.tap = port
+            $0.runLoopSource = src
+        }
         CGEvent.tapEnable(tap: port, enable: true)
 
         // Run on a dedicated thread so main-thread stalls can't trip the tap's
@@ -71,7 +88,7 @@ final class SpaceSwipeSuppressor {
         let thread = Thread { [weak self] in
             let loop = CFRunLoopGetCurrent()!
             CFRunLoopAddSource(loop, src, .commonModes)
-            self?.tapRunLoop = loop
+            self?.ports.withLock { $0.tapRunLoop = loop }
             started.signal()
             CFRunLoopRun()
         }
@@ -79,13 +96,18 @@ final class SpaceSwipeSuppressor {
         thread.qualityOfService = .userInteractive
         thread.start()
         started.wait()
-        tapThread = thread
+        // `withLockUnchecked`: the closure captures the non-Sendable `Thread`,
+        // which the `@Sendable`-bodied `withLock` would reject. Still serialized
+        // by the same lock.
+        ports.withLockUnchecked { $0.tapThread = thread }
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         // Re-enable if the watchdog or a user-input burst disabled the tap.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if let tap = ports.withLock({ $0.tap }) {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
             return Unmanaged.passUnretained(event)
         }
 
@@ -116,17 +138,24 @@ final class SpaceSwipeSuppressor {
     }
 
     func uninstall() {
-        if let tap { CGEvent.tapEnable(tap: tap, enable: false) }
-        if let loop = tapRunLoop {
-            if let runLoopSource {
+        // Snapshot the handles under the lock, then nil them out in the SAME
+        // critical section so the callback thread never observes a torn state.
+        // Every CGEvent/CFRunLoop call below runs on the locals outside the lock
+        // — `CFRunLoopStop` is async and must never be held across the lock.
+        let snapshot = ports.withLock { current -> TapPorts in
+            let copy = current
+            current = TapPorts()
+            return copy
+        }
+        if let tap = snapshot.tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let loop = snapshot.tapRunLoop {
+            if let runLoopSource = snapshot.runLoopSource {
                 CFRunLoopRemoveSource(loop, runLoopSource, .commonModes)
             }
             CFRunLoopStop(loop)
         }
-        tap = nil
-        runLoopSource = nil
-        tapRunLoop = nil
-        tapThread = nil
     }
 
     deinit {

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -282,11 +282,15 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     }
 
     @objc private func gridChanged() {
-        Preferences.shared.gridMaxColumns = gridValues[gridPopup.indexOfSelectedItem]
+        let i = gridPopup.indexOfSelectedItem
+        guard gridValues.indices.contains(i) else { return }
+        Preferences.shared.gridMaxColumns = gridValues[i]
     }
 
     @objc private func accentChanged() {
-        let choice = accents[accentPopup.indexOfSelectedItem]
+        let i = accentPopup.indexOfSelectedItem
+        guard accents.indices.contains(i) else { return }
+        let choice = accents[i]
         Preferences.shared.accentChoice = choice
         if choice == .custom { presentColorPanel() }
     }


### PR DESCRIPTION
Residual fixes from a deep whole-app bug audit (2026-06-02). The audit
verdict was that the app is clean — no crashers, no consequential leaks,
no hot-path perf regressions — so this is the small, fully-verified
residual, three independent low-severity hardening changes.

## Changes

- **fix: lock SpaceSwipeSuppressor tap state** — the tap-callback thread
  read `tap` in `handle()`'s watchdog re-enable path while the main thread
  nilled it in `uninstall()` during an experimental-swipe toggle, an
  unsynchronized cross-thread access. Wrapped the four port handles in an
  `OSAllocatedUnfairLock`-guarded `TapPorts` struct with snapshot-and-reset
  on teardown, mirroring the discipline `HotkeyTap` already applies to the
  identical state. Benign outcome before, but now correct under TSan /
  Swift 6 strict concurrency.
- **fix: remove AX notifications on observer teardown** —
  `uninstallAXObserver` detached the run-loop source but never called
  `AXObserverRemoveNotification`, leaving the eight per-app subscriptions
  registered in the AX server. Now dropped first, mirroring the add loop.
- **fix: bounds-check Appearance popup selections** —
  `NSPopUpButton.indexOfSelectedItem` returns -1 when nothing is selected,
  so the direct array subscript in the grid/accent handlers could trap.
  Bounds-checked both, matching the safe `firstIndex`-based read the rest
  of the controller already uses.

No feature/behavior change — correctness and resource-hygiene only.

## Verification

- `xcodebuild -scheme "BetterCmdTab Debug" build` — **BUILD SUCCEEDED**.
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test`
  — **146 tests in 20 suites passed** (incl. the Settings-lifecycle
  controller-dealloc tests covering the touched Appearance pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)