### PR TITLE
fix: disable the switcher trigger when its shortcut is cleared

### DIFF
--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -79,9 +79,12 @@ final class HotkeyTap {
     /// recorders are independent), so each has its own modifier mask.
     struct Config {
         var appModifier: CGEventFlags
-        var appKey: Int64
+        /// `nil` when the user cleared the app-switch shortcut — the chord then
+        /// matches nothing and the event falls through to the OS (native ⌘Tab).
+        var appKey: Int64?
         var windowModifier: CGEventFlags
-        var windowKey: Int64
+        /// `nil` when the user cleared the window-switch shortcut. See `appKey`.
+        var windowKey: Int64?
     }
 
     /// The CGEvent-tap lifecycle handles. The tap callback runs on its own
@@ -618,8 +621,10 @@ final class HotkeyTap {
 
         let cfg = config.withLock { $0 }
         let flags = event.flags
-        let appModHeld = flags.contains(cfg.appModifier)
-        let windowModHeld = flags.contains(cfg.windowModifier)
+        // A disabled trigger (nil key) holds nothing — so it never contributes to
+        // `anyModHeld` (which keeps the panel open / drives Esc) and never matches.
+        let appModHeld = cfg.appKey != nil && flags.contains(cfg.appModifier)
+        let windowModHeld = cfg.windowKey != nil && flags.contains(cfg.windowModifier)
         // The switcher stays open while either trigger's hold modifier is down.
         let anyModHeld = appModHeld || windowModHeld
         let shiftHeld = flags.contains(.maskShift)
@@ -640,7 +645,7 @@ final class HotkeyTap {
             // through the tab strip instead of the app list. Esc exits the
             // drill (one level up — the panel stays open).
             if tabDrillNow && isSwitchingNow() {
-                if anyModHeld && keyCode == cfg.appKey {
+                if anyModHeld, let appKey = cfg.appKey, keyCode == appKey {
                     deliver(shiftHeld ? .tabPrev : .tabNext); return nil
                 }
                 if keyCode == Self.escKey {
@@ -671,13 +676,13 @@ final class HotkeyTap {
             // fall through to the focused app instead of opening the switcher.
             // Only when not already switching — an open switcher still navigates.
             let suppressTrigger = !isSwitchingNow() && suppressTriggerFlag.withLock { $0 }
-            if appModHeld && keyCode == cfg.appKey {
+            if appModHeld, let appKey = cfg.appKey, keyCode == appKey {
                 if suppressTrigger { return Unmanaged.passUnretained(event) }
                 let dir: Event = shiftHeld ? .prevApp : .nextApp
                 deliver(dir)
                 return nil
             }
-            if windowModHeld && keyCode == cfg.windowKey {
+            if windowModHeld, let windowKey = cfg.windowKey, keyCode == windowKey {
                 if suppressTrigger { return Unmanaged.passUnretained(event) }
                 let dir: Event = shiftHeld ? .prevWindow : .nextWindow
                 deliver(dir)

--- a/BetterCmdTab/Input/NativeOverridePlan.swift
+++ b/BetterCmdTab/Input/NativeOverridePlan.swift
@@ -31,10 +31,18 @@ import Carbon.HIToolbox
 /// delivered for it under secure input — see `HoldModifierMonitor`) and commits.
 
 /// The configured trigger, in the Carbon terms the override decision needs.
+///
+/// `appEnabled` / `windowEnabled` are `false` when the user has *cleared* that
+/// shortcut (BetterShortcuts' explicit "disabled" marker). A disabled trigger
+/// reserves no native chord: its symbolic-hotkey disable and Carbon chords are
+/// both dropped, so the native macOS ⌘Tab (or ⌘`) keeps working. They default
+/// to `true` so existing call sites and tests describe an enabled trigger.
 struct TriggerSpec: Equatable {
+    var appEnabled: Bool = true
     var appKeyCode: UInt32
     var appCarbonModifiers: UInt32
     var appIsCommandOnly: Bool
+    var windowEnabled: Bool = true
     var windowKeyCode: UInt32
     var windowCarbonModifiers: UInt32
     var windowIsCommandOnly: Bool
@@ -139,13 +147,14 @@ func computeNativeOverridePlan(
 
     // Symbolic hotkeys to free so RegisterEventHotKey can claim the reserved
     // native chord. Only when the trigger IS that reserved chord (⌘Tab / ⌘`);
-    // a remapped trigger reserves nothing, so nothing is disabled.
+    // a remapped trigger reserves nothing, so nothing is disabled. A *disabled*
+    // trigger likewise frees nothing — the user wants the native chord back.
     var symbolic: [Int32] = []
-    if trigger.appIsCommandOnly && trigger.appKeyCode == 48 {
+    if trigger.appEnabled && trigger.appIsCommandOnly && trigger.appKeyCode == 48 {
         symbolic.append(PrivateAPI.SymbolicHotKey.commandTab.rawValue)      // 1
         symbolic.append(PrivateAPI.SymbolicHotKey.commandShiftTab.rawValue) // 2
     }
-    if trigger.windowIsCommandOnly && trigger.windowKeyCode == 50 {
+    if trigger.windowEnabled && trigger.windowIsCommandOnly && trigger.windowKeyCode == 50 {
         symbolic.append(PrivateAPI.SymbolicHotKey.commandKeyAboveTab.rawValue) // 6
     }
 
@@ -155,12 +164,18 @@ func computeNativeOverridePlan(
     // rejected by RegisterEventHotKey). Always registered so the panel can be
     // *opened* the instant the tap goes deaf.
     let shift = UInt32(shiftKey)
-    var chords: [ChordSpec] = [
-        ChordSpec(keyCode: trigger.appKeyCode, modifiers: trigger.appCarbonModifiers, kind: .nextApp),
-        ChordSpec(keyCode: trigger.appKeyCode, modifiers: trigger.appCarbonModifiers | shift, kind: .prevApp),
-    ]
-    if trigger.windowKeyCode != trigger.appKeyCode
-        || trigger.windowCarbonModifiers != trigger.appCarbonModifiers {
+    var chords: [ChordSpec] = []
+    if trigger.appEnabled {
+        chords.append(ChordSpec(keyCode: trigger.appKeyCode, modifiers: trigger.appCarbonModifiers, kind: .nextApp))
+        chords.append(ChordSpec(keyCode: trigger.appKeyCode, modifiers: trigger.appCarbonModifiers | shift, kind: .prevApp))
+    }
+    // Register the window chord when it's enabled and isn't a duplicate of the
+    // app chord (RegisterEventHotKey rejects duplicates). With the app chord
+    // disabled there's nothing to duplicate, so the window chord always stands.
+    if trigger.windowEnabled
+        && (!trigger.appEnabled
+            || trigger.windowKeyCode != trigger.appKeyCode
+            || trigger.windowCarbonModifiers != trigger.appCarbonModifiers) {
         chords.append(ChordSpec(keyCode: trigger.windowKeyCode, modifiers: trigger.windowCarbonModifiers, kind: .nextWindow))
         chords.append(ChordSpec(keyCode: trigger.windowKeyCode, modifiers: trigger.windowCarbonModifiers | shift, kind: .prevWindow))
     }
@@ -171,8 +186,10 @@ func computeNativeOverridePlan(
     // key from the focused password field. The remaining true limit under secure
     // input: once the modifier is released in stay-open/sticky mode, no key can
     // reach a background app — only the mouse works (documented).
-    if secureInputActive && panelOpen && holdModifierDown {
-        let mod = trigger.appCarbonModifiers
+    if secureInputActive && panelOpen && holdModifierDown && (trigger.appEnabled || trigger.windowEnabled) {
+        // Qualify the in-panel chords with the hold modifier of whichever trigger
+        // is live (they share ⌘ by default); the app trigger wins when both exist.
+        let mod = trigger.appEnabled ? trigger.appCarbonModifiers : trigger.windowCarbonModifiers
         // Control/navigation chords first so they win the (keyCode, modifiers)
         // dedupe over the generic letter/search block below.
         if tabDrillActive {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -747,13 +747,16 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     private func pushHotkeyConfig() {
-        let app = Self.hotkeyTrigger(for: .switchApps, defaultKey: 48)
-        let window = Self.hotkeyTrigger(for: .switchWindows, defaultKey: 50)
+        let app = Self.hotkeyTrigger(for: .switchApps)
+        let window = Self.hotkeyTrigger(for: .switchWindows)
+        // A disabled trigger pushes a nil key: the tap matches nothing for it and
+        // ⌘Tab/⌘` falls through to the OS. The modifier is irrelevant then (the
+        // tap gates the match on the key being present), so default it to empty.
         hotkey.updateConfig(HotkeyTap.Config(
-            appModifier: app.modifier,
-            appKey: app.key,
-            windowModifier: window.modifier,
-            windowKey: window.key
+            appModifier: app?.modifier ?? [],
+            appKey: app?.key,
+            windowModifier: window?.modifier ?? [],
+            windowKey: window?.key
         ))
         syncNativeHotkeyOverride()
     }
@@ -825,23 +828,29 @@ final class SwitcherController: SwitcherViewDelegate {
             applyOverridePlan(NativeOverridePlan(symbolicKeysToDisable: [], carbonChords: []))
             return
         }
-        let app = Self.carbonTrigger(for: .switchApps, defaultKey: 48)
-        let window = Self.carbonTrigger(for: .switchWindows, defaultKey: 50)
+        // `nil` = the user cleared that shortcut, so the trigger is disabled and
+        // reserves no native chord (the plan drops its symbolic disable + chords).
+        let app = Self.carbonTrigger(for: .switchApps)
+        let window = Self.carbonTrigger(for: .switchWindows)
         let spec = TriggerSpec(
-            appKeyCode: app.keyCode,
-            appCarbonModifiers: app.carbonModifiers,
-            appIsCommandOnly: app.isCommandOnly,
-            windowKeyCode: window.keyCode,
-            windowCarbonModifiers: window.carbonModifiers,
-            windowIsCommandOnly: window.isCommandOnly
+            appEnabled: app != nil,
+            appKeyCode: app?.keyCode ?? 0,
+            appCarbonModifiers: app?.carbonModifiers ?? 0,
+            appIsCommandOnly: app?.isCommandOnly ?? false,
+            windowEnabled: window != nil,
+            windowKeyCode: window?.keyCode ?? 0,
+            windowCarbonModifiers: window?.carbonModifiers ?? 0,
+            windowIsCommandOnly: window?.isCommandOnly ?? false
         )
         let panelOpen = phase != .idle
         // The hold-modifier poller detects ⌘-release (no event is delivered for
         // it under secure input) and supplies the live hold state that gates the
         // in-panel chords. Needed only while the panel is open under secure input.
+        // Poll whichever trigger is live (app wins when both exist).
         if secureInputActive && panelOpen {
             if !holdMonitorRunning {
-                holdMonitor.start(mask: Self.holdMask(for: app.carbonModifiers), assumeHeld: true)
+                let holdMods = app?.carbonModifiers ?? window?.carbonModifiers ?? UInt32(cmdKey)
+                holdMonitor.start(mask: Self.holdMask(for: holdMods), assumeHeld: true)
                 holdMonitorRunning = true
             }
         } else if holdMonitorRunning {
@@ -904,12 +913,13 @@ final class SwitcherController: SwitcherViewDelegate {
     /// Live check of `releaseAlreadyMissed` against the current physical modifier
     /// state (`CGEventSource.flagsState` keeps reporting under Secure Event Input).
     private func holdReleaseAlreadyMissed() -> Bool {
-        let appTrigger = Self.carbonTrigger(for: .switchApps, defaultKey: 48)
-        let windowTrigger = Self.carbonTrigger(for: .switchWindows, defaultKey: 50)
+        // A disabled trigger contributes an empty mask (holds nothing).
+        let appTrigger = Self.carbonTrigger(for: .switchApps)
+        let windowTrigger = Self.carbonTrigger(for: .switchWindows)
         return Self.releaseAlreadyMissed(
             flags: CGEventSource.flagsState(.combinedSessionState),
-            appMask: Self.holdMask(for: appTrigger.carbonModifiers),
-            windowMask: Self.holdMask(for: windowTrigger.carbonModifiers)
+            appMask: Self.holdMask(for: appTrigger?.carbonModifiers ?? 0),
+            windowMask: Self.holdMask(for: windowTrigger?.carbonModifiers ?? 0)
         )
     }
 
@@ -1095,15 +1105,17 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     /// Decompose a recorded shortcut into a held modifier mask + tap keycode for
-    /// the CGEvent tap. Falls back to Command + `defaultKey` when unset. Shift is
-    /// dropped (reserved for reverse stepping); a hold modifier is guaranteed
-    /// because the recorder rejects shortcuts without one.
+    /// the CGEvent tap. Returns `nil` when the user *cleared* the shortcut, so the
+    /// trigger is disabled rather than re-armed on the default chord — `getShortcut`
+    /// already resolves the declared default for a never-set shortcut, so a `nil`
+    /// here means an explicit disable. Shift is dropped (reserved for reverse
+    /// stepping); a hold modifier is guaranteed because the recorder rejects
+    /// shortcuts without one.
     private static func hotkeyTrigger(
-        for name: BetterShortcuts.Name,
-        defaultKey: Int64
-    ) -> (modifier: CGEventFlags, key: Int64) {
+        for name: BetterShortcuts.Name
+    ) -> (modifier: CGEventFlags, key: Int64)? {
         guard let shortcut = BetterShortcuts.getShortcut(for: name) else {
-            return (.maskCommand, defaultKey)
+            return nil
         }
         var flags: CGEventFlags = []
         let modifiers = shortcut.modifiers
@@ -1115,9 +1127,10 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     /// Carbon view of a configured trigger, for `RegisterEventHotKey` and native
-    /// symbolic-hotkey matching. Mirrors `hotkeyTrigger(for:defaultKey:)` but in
-    /// Carbon terms: a Carbon keycode + Carbon modifier mask, plus whether the
-    /// hold modifier is exactly Command (used to decide symbolic-hotkey overlap).
+    /// symbolic-hotkey matching. Mirrors `hotkeyTrigger(for:)` but in Carbon
+    /// terms: a Carbon keycode + Carbon modifier mask, plus whether the hold
+    /// modifier is exactly Command (used to decide symbolic-hotkey overlap).
+    /// `nil` when the user cleared the shortcut (the trigger is disabled).
     private struct CarbonTrigger {
         let keyCode: UInt32
         let carbonModifiers: UInt32
@@ -1125,11 +1138,10 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     private static func carbonTrigger(
-        for name: BetterShortcuts.Name,
-        defaultKey: UInt32
-    ) -> CarbonTrigger {
+        for name: BetterShortcuts.Name
+    ) -> CarbonTrigger? {
         guard let shortcut = BetterShortcuts.getShortcut(for: name) else {
-            return CarbonTrigger(keyCode: defaultKey, carbonModifiers: UInt32(cmdKey), isCommandOnly: true)
+            return nil
         }
         let modifiers = shortcut.modifiers
         var carbon: UInt32 = 0

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -845,9 +845,10 @@ final class SwitcherController: SwitcherViewDelegate {
         let panelOpen = phase != .idle
         // The hold-modifier poller detects ⌘-release (no event is delivered for
         // it under secure input) and supplies the live hold state that gates the
-        // in-panel chords. Needed only while the panel is open under secure input.
-        // Poll whichever trigger is live (app wins when both exist).
-        if secureInputActive && panelOpen {
+        // in-panel chords. Needed only while the panel is open under secure input
+        // with at least one live trigger — both cleared reserves no chord, so
+        // there is nothing to poll for. Poll whichever trigger is live (app wins).
+        if secureInputActive && panelOpen && (app != nil || window != nil) {
             if !holdMonitorRunning {
                 let holdMods = app?.carbonModifiers ?? window?.carbonModifiers ?? UInt32(cmdKey)
                 holdMonitor.start(mask: Self.holdMask(for: holdMods), assumeHeld: true)
@@ -905,21 +906,25 @@ final class SwitcherController: SwitcherViewDelegate {
     /// would open with nothing left to dismiss it. Re-reading the live modifier
     /// state on the main thread recovers that dropped release; this isolates the
     /// decision so it stays unit-testable.
-    nonisolated static func releaseAlreadyMissed(flags: CGEventFlags, appMask: CGEventFlags, windowMask: CGEventFlags) -> Bool {
-        !(HoldModifierMonitor.holdState(flags: flags, mask: appMask)
-            || HoldModifierMonitor.holdState(flags: flags, mask: windowMask))
+    /// A `nil` mask is a disabled trigger (the user cleared that shortcut): it
+    /// contributes nothing and never counts as held — otherwise a phantom mask
+    /// would let an incidentally-held modifier mask a real release.
+    nonisolated static func releaseAlreadyMissed(flags: CGEventFlags, appMask: CGEventFlags?, windowMask: CGEventFlags?) -> Bool {
+        let appHeld = appMask.map { HoldModifierMonitor.holdState(flags: flags, mask: $0) } ?? false
+        let windowHeld = windowMask.map { HoldModifierMonitor.holdState(flags: flags, mask: $0) } ?? false
+        return !(appHeld || windowHeld)
     }
 
     /// Live check of `releaseAlreadyMissed` against the current physical modifier
     /// state (`CGEventSource.flagsState` keeps reporting under Secure Event Input).
     private func holdReleaseAlreadyMissed() -> Bool {
-        // A disabled trigger contributes an empty mask (holds nothing).
+        // A disabled trigger (nil) contributes no mask, so it never counts as held.
         let appTrigger = Self.carbonTrigger(for: .switchApps)
         let windowTrigger = Self.carbonTrigger(for: .switchWindows)
         return Self.releaseAlreadyMissed(
             flags: CGEventSource.flagsState(.combinedSessionState),
-            appMask: Self.holdMask(for: appTrigger?.carbonModifiers ?? 0),
-            windowMask: Self.holdMask(for: windowTrigger?.carbonModifiers ?? 0)
+            appMask: appTrigger.map { Self.holdMask(for: $0.carbonModifiers) },
+            windowMask: windowTrigger.map { Self.holdMask(for: $0.carbonModifiers) }
         )
     }
 

--- a/BetterCmdTabTests/NativeOverridePlanTests.swift
+++ b/BetterCmdTabTests/NativeOverridePlanTests.swift
@@ -238,4 +238,50 @@ struct NativeOverridePlanTests {
             #expect(unique.count == pairs.count)
         }
     }
+
+    // MARK: Disabled trigger (Issue #21 — a cleared shortcut must free the chord)
+
+    /// ⌘Tab app cleared, ⌘` window still native.
+    static func appDisabled() -> TriggerSpec {
+        TriggerSpec(appEnabled: false, appKeyCode: 48, appCarbonModifiers: cmd, appIsCommandOnly: true,
+                    windowEnabled: true, windowKeyCode: 50, windowCarbonModifiers: cmd, windowIsCommandOnly: true)
+    }
+    /// ⌘` window cleared, ⌘Tab app still native.
+    static func windowDisabled() -> TriggerSpec {
+        TriggerSpec(appEnabled: true, appKeyCode: 48, appCarbonModifiers: cmd, appIsCommandOnly: true,
+                    windowEnabled: false, windowKeyCode: 50, windowCarbonModifiers: cmd, windowIsCommandOnly: true)
+    }
+
+    @Test func appDisabled_freesNativeCommandTab_keepsWindow() {
+        let plan = computeNativeOverridePlan(trigger: Self.appDisabled(), secureInputActive: false,
+                                             panelOpen: false, holdModifierDown: false)
+        // The native ⌘Tab / ⌘⇧Tab symbolic hotkeys are NOT disabled — they go back
+        // to the OS. The window chord (⌘`, id 6) is still claimed.
+        #expect(plan.symbolicKeysToDisable == [6])
+        // No app switching chords; the window pair survives.
+        #expect(!plan.carbonChords.contains { $0.kind == .nextApp || $0.kind == .prevApp })
+        #expect(plan.carbonChords.contains { $0.kind == .nextWindow })
+        #expect(plan.carbonChords.contains { $0.kind == .prevWindow })
+    }
+
+    @Test func windowDisabled_freesNativeBacktick_keepsApp() {
+        let plan = computeNativeOverridePlan(trigger: Self.windowDisabled(), secureInputActive: false,
+                                             panelOpen: false, holdModifierDown: false)
+        #expect(plan.symbolicKeysToDisable == [1, 2])
+        #expect(plan.carbonChords.contains { $0.kind == .nextApp })
+        #expect(plan.carbonChords.contains { $0.kind == .prevApp })
+        #expect(!plan.carbonChords.contains { $0.kind == .nextWindow || $0.kind == .prevWindow })
+    }
+
+    @Test func bothDisabled_emptyPlan_evenUnderSecureInputWithPanelOpen() {
+        // Nothing reserved, nothing registered — the native switcher is fully
+        // restored, and no in-panel parity chords leak in under secure input.
+        let trigger = TriggerSpec(appEnabled: false, appKeyCode: 48, appCarbonModifiers: Self.cmd, appIsCommandOnly: true,
+                                  windowEnabled: false, windowKeyCode: 50, windowCarbonModifiers: Self.cmd, windowIsCommandOnly: true)
+        let plan = computeNativeOverridePlan(trigger: trigger, secureInputActive: true,
+                                             panelOpen: true, holdModifierDown: true,
+                                             panelActions: Self.panelActions)
+        #expect(plan.symbolicKeysToDisable.isEmpty)
+        #expect(plan.carbonChords.isEmpty)
+    }
 }

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -69,4 +69,14 @@ struct SwitcherReleaseMissedTests {
         // a hold modifier).
         #expect(SwitcherController.releaseAlreadyMissed(flags: [.maskShift], appMask: .maskCommand, windowMask: .maskAlternate))
     }
+
+    @Test func disabledTrigger_contributesNoHold() {
+        // A cleared shortcut passes a nil mask: it must never count as held, so an
+        // incidentally-held ⌘ can't mask the real (Control) window hold modifier.
+        #expect(SwitcherController.releaseAlreadyMissed(flags: [.maskCommand], appMask: nil, windowMask: .maskControl))
+        // The live window modifier still down → not missed.
+        #expect(!SwitcherController.releaseAlreadyMissed(flags: [.maskControl], appMask: nil, windowMask: .maskControl))
+        // Both triggers disabled → nothing to hold, so the release is always missed.
+        #expect(SwitcherController.releaseAlreadyMissed(flags: [.maskCommand], appMask: nil, windowMask: nil))
+    }
 }


### PR DESCRIPTION
## What

Clearing the Cmd+Tab (or Cmd+\`) shortcut so the recorder reads **"Record Shortcut"** now actually **disables** the trigger and hands the chord back to the native macOS switcher.

Fixes #21.

## Why it was broken

`BetterShortcuts.getShortcut` already returns the declared **default** for a *never-set* shortcut and `nil` **only** when the user *explicitly clears* it. But `hotkeyTrigger`/`carbonTrigger` treated that `nil` as *"fall back to Command + default key"* — re-arming the very chord the user just cleared. And because the CGEvent tap matches on modifier **containment** (`flags.contains(.maskCommand)`), the re-armed default fired on *any* Command-plus-Tab combination while suppressing the native switcher. Exactly the two symptoms in the issue.

## The fix

Treat a cleared shortcut as a real disabled state, end to end — and handle the app (Cmd+Tab) and window (Cmd+\`) triggers **independently**, so clearing one leaves the other fully working.

- `hotkeyTrigger` / `carbonTrigger` return `nil` on an explicit clear; the bogus `defaultKey` fallback is gone (`getShortcut` already owns default resolution).
- `HotkeyTap.Config.appKey` / `windowKey` are now optional. A `nil` key matches nothing **and** is excluded from the held-modifier state, so the event falls through to the OS and native Cmd+Tab works again.
- `TriggerSpec` carries `appEnabled` / `windowEnabled`; `computeNativeOverridePlan` drops the symbolic-hotkey disable and the Carbon survivor chords for a disabled trigger.

## Tests

Added `NativeOverridePlan` cases for **app-disabled**, **window-disabled**, and **both-disabled** (asserts the right symbolic ids and chords are freed/kept).

## Verification

- `xcodebuild -scheme "BetterCmdTab Debug" build` — clean, no new warnings.
- Full suite passes (**183 tests / 25 suites**).
- Key-event suppression needs a live WindowServer, so it also wants a manual smoke test before release: clear Cmd+Tab → confirm the macOS switcher returns; set it back → confirm the app takes over again.

## Pull request checklist

- [x] Builds clean with no new warnings.
- [x] All existing tests pass.
- [x] New pure-logic behavior ships with tests (`NativeOverridePlanTests`).
- [x] No commented-out code, dead branches, or leftover `print` (logging via `Log.*`).
- [x] Conventional commit; body explains *why*.
- [x] One logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)