### PR TITLE
feat: choose which display the switcher opens on (#22)

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -25,6 +25,24 @@ enum SwitcherLayoutMode: String, CaseIterable {
     }
 }
 
+/// Which display the switcher panel opens on (#22).
+enum SwitcherDisplayMode: String, CaseIterable {
+    /// Screen under the mouse pointer. Default — matches pre-#22 behavior.
+    case mouseCursor
+    /// Screen of the window focused when ⌘Tab fired.
+    case activeWindow
+    /// "Main display" from System Settings → Displays (the origin-zero screen).
+    case mainDisplay
+
+    var displayName: String {
+        switch self {
+        case .mouseCursor:  return String(localized: "Monitor with the cursor")
+        case .activeWindow: return String(localized: "Monitor with the active window")
+        case .mainDisplay:  return String(localized: "Main display")
+        }
+    }
+}
+
 /// What keeps the switcher open once fuzzy-search has been activated with `/`.
 enum SearchDismissMode: String, CaseIterable {
     /// Keep holding the switcher modifier (⌘); releasing it commits the
@@ -455,12 +473,22 @@ final class Preferences: ObservableObject {
         static let hoverShowForceQuit = "Switcher.hoverShowForceQuit"
         static let hideFromScreenSharing = "Switcher.hideFromScreenSharing"
         static let vimNavigationEnabled = "Switcher.vimNavigationEnabled"
+        static let switcherDisplayMode = "Switcher.displayMode"
     }
 
     @Published var switcherLayoutMode: SwitcherLayoutMode {
         didSet {
             guard oldValue != switcherLayoutMode else { return }
             UserDefaults.standard.set(switcherLayoutMode.rawValue, forKey: Keys.switcherLayoutMode)
+        }
+    }
+
+    /// Which monitor the switcher panel appears on (#22). Default `.mouseCursor`
+    /// preserves the pre-#22 behavior for existing users.
+    @Published var switcherDisplayMode: SwitcherDisplayMode {
+        didSet {
+            guard oldValue != switcherDisplayMode else { return }
+            UserDefaults.standard.set(switcherDisplayMode.rawValue, forKey: Keys.switcherDisplayMode)
         }
     }
 
@@ -1084,6 +1112,8 @@ final class Preferences: ObservableObject {
 
         let layoutRaw = defaults.string(forKey: Keys.switcherLayoutMode)
         self.switcherLayoutMode = layoutRaw.flatMap(SwitcherLayoutMode.init(rawValue:)) ?? .gridView
+        self.switcherDisplayMode = defaults.string(forKey: Keys.switcherDisplayMode)
+            .flatMap(SwitcherDisplayMode.init(rawValue:)) ?? .mouseCursor
 
         let sortRaw = defaults.string(forKey: Keys.sortOrder)
         self.sortOrder = sortRaw.flatMap(SwitcherSortOrder.init(rawValue:)) ?? .mru
@@ -1199,6 +1229,8 @@ final class Preferences: ObservableObject {
         let defaults = UserDefaults.standard
 
         switcherLayoutMode = defaults.string(forKey: Keys.switcherLayoutMode).flatMap(SwitcherLayoutMode.init(rawValue:)) ?? .gridView
+        switcherDisplayMode = defaults.string(forKey: Keys.switcherDisplayMode)
+            .flatMap(SwitcherDisplayMode.init(rawValue:)) ?? .mouseCursor
         sortOrder = defaults.string(forKey: Keys.sortOrder).flatMap(SwitcherSortOrder.init(rawValue:)) ?? .mru
         revealDelayMs = Self.clampDelay(defaults.object(forKey: Keys.revealDelayMs) as? Int ?? Self.defaultRevealDelayMs)
         letterChainTimeoutMs = Self.clampLetterChainTimeout(defaults.object(forKey: Keys.letterChainTimeoutMs) as? Int ?? Self.defaultLetterChainTimeoutMs)

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -2,19 +2,144 @@
   "sourceLanguage" : "en",
   "strings" : {
     "Choose which monitor the switcher opens on when you have more than one display." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lege fest, auf welchem Bildschirm sich der Umschalter öffnet, wenn du mehrere Bildschirme verwendest."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige en qué pantalla se abre el selector cuando tienes más de una pantalla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez sur quel écran le sélecteur s’ouvre lorsque vous avez plusieurs écrans."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz, na którym ekranie ma się otwierać przełącznik, gdy masz więcej niż jeden ekran."
+          }
+        }
+      }
     },
     "Main display" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hauptbildschirm"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla principal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran principal"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran główny"
+          }
+        }
+      }
     },
     "Monitor with the active window" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm mit dem aktiven Fenster"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla con la ventana activa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran avec la fenêtre active"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran z aktywnym oknem"
+          }
+        }
+      }
     },
     "Monitor with the cursor" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm mit dem Zeiger"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla con el puntero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran avec le pointeur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran ze wskaźnikiem"
+          }
+        }
+      }
     },
     "Show switcher on" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umschalter anzeigen auf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar el selector en"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le sélecteur sur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż przełącznik na"
+          }
+        }
+      }
     },
     "Apps kept visible: %lld." : {
       "localizations" : {

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -1,6 +1,21 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Choose which monitor the switcher opens on when you have more than one display." : {
+
+    },
+    "Main display" : {
+
+    },
+    "Monitor with the active window" : {
+
+    },
+    "Monitor with the cursor" : {
+
+    },
+    "Show switcher on" : {
+
+    },
     "Apps kept visible: %lld." : {
       "localizations" : {
         "de" : {

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -16,6 +16,8 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
     private let mruWindowsSortSwitch = NSSwitch()
+    private let displayMonitorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let displayModes: [SwitcherDisplayMode] = SwitcherDisplayMode.allCases
 
     override func setupContent() {
         // Experimental section — off by default, clearly flagged as unstable.
@@ -65,6 +67,18 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: experimental, title: String(localized: "Most recent (windows) sort order"),
                subtitle: String(localized: "Orders the list by when you last focused each window, across all apps."),
                accessory: mruWindowsSortSwitch, searchItemID: SearchID.mruWindowsSort)
+
+        addDivider(to: experimental)
+        displayMonitorPopup.controlSize = .small
+        displayMonitorPopup.translatesAutoresizingMaskIntoConstraints = false
+        displayMonitorPopup.setContentHuggingPriority(.required, for: .horizontal)
+        displayMonitorPopup.removeAllItems()
+        displayMonitorPopup.addItems(withTitles: displayModes.map(\.displayName))
+        displayMonitorPopup.target = self
+        displayMonitorPopup.action = #selector(displayModeChanged)
+        addRow(to: experimental, title: String(localized: "Show switcher on"),
+               subtitle: String(localized: "Choose which monitor the switcher opens on when you have more than one display."),
+               accessory: displayMonitorPopup, searchItemID: SearchID.displayMonitor)
         // Tab drill-in (the `\` peek) + tab expansion graduated to the Switcher
         // tab's "Tabs" section — they are stable, on by default, and belong with
         // the other content options.
@@ -115,6 +129,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
         mruWindowsSortSwitch.state = prefs.sortOrder == .mruWindows ? .on : .off
+        if let i = displayModes.firstIndex(of: prefs.switcherDisplayMode) { displayMonitorPopup.selectItem(at: i) }
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -151,6 +166,12 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleInstantSpace(_ sender: NSSwitch) {
         Preferences.shared.experimentalInstantSpaceSwitch = (sender.state == .on)
+    }
+
+    @objc private func displayModeChanged() {
+        let idx = displayMonitorPopup.indexOfSelectedItem
+        guard displayModes.indices.contains(idx) else { return }
+        Preferences.shared.switcherDisplayMode = displayModes[idx]
     }
 
     @objc private func toggleMRUWindowsSort(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -82,6 +82,7 @@ enum SearchID {
     static let showBadges = "switcher.showBadges"
     static let currentSpaceOnly = "switcher.currentSpaceOnly"
     static let sortOrder = "switcher.sortOrder"
+    static let displayMonitor = "switcher.displayMonitor"
     static let showRecentlyClosed = "switcher.showRecentlyClosed"
     static let recentlyClosedLimit = "switcher.recentlyClosedLimit"
     static let tabDrill = "switcher.tabDrill"
@@ -305,6 +306,8 @@ enum SettingsCatalog {
              String(localized: "Click outside to dismiss"), ["click", "outside", "dismiss", "cancel", "spotlight"]),
         item(SearchID.vimNavigation, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
              String(localized: "Vim keys (h j k l)"), ["vim", "hjkl", "h j k l", "keyboard", "arrows", "navigation"]),
+        item(SearchID.displayMonitor, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
+             String(localized: "Show switcher on"), ["display", "monitor", "screen", "multi monitor", "cursor", "main display", "active window"]),
         // Switcher · Actions
         item(SearchID.hoverActions, .switcher, SettingsAnchor.actions, "Switcher", "Hover actions",
              String(localized: "Action buttons on hover"), ["hover", "buttons", "close", "minimize", "maximize", "hide", "quit", "actions"]),

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -82,7 +82,6 @@ enum SearchID {
     static let showBadges = "switcher.showBadges"
     static let currentSpaceOnly = "switcher.currentSpaceOnly"
     static let sortOrder = "switcher.sortOrder"
-    static let displayMonitor = "switcher.displayMonitor"
     static let showRecentlyClosed = "switcher.showRecentlyClosed"
     static let recentlyClosedLimit = "switcher.recentlyClosedLimit"
     static let tabDrill = "switcher.tabDrill"
@@ -119,6 +118,7 @@ enum SearchID {
     static let sensitivity = "experimental.sensitivity"
     static let instantSpace = "experimental.instantSpace"
     static let mruWindowsSort = "experimental.mruWindowsSort"
+    static let displayMonitor = "experimental.displayMonitor"
 }
 
 @MainActor
@@ -306,8 +306,6 @@ enum SettingsCatalog {
              String(localized: "Click outside to dismiss"), ["click", "outside", "dismiss", "cancel", "spotlight"]),
         item(SearchID.vimNavigation, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
              String(localized: "Vim keys (h j k l)"), ["vim", "hjkl", "h j k l", "keyboard", "arrows", "navigation"]),
-        item(SearchID.displayMonitor, .switcher, SettingsAnchor.navigation, "Switcher", "Navigation",
-             String(localized: "Show switcher on"), ["display", "monitor", "screen", "multi monitor", "cursor", "main display", "active window"]),
         // Switcher · Actions
         item(SearchID.hoverActions, .switcher, SettingsAnchor.actions, "Switcher", "Hover actions",
              String(localized: "Action buttons on hover"), ["hover", "buttons", "close", "minimize", "maximize", "hide", "quit", "actions"]),
@@ -354,6 +352,8 @@ enum SettingsCatalog {
              String(localized: "Switch Spaces without animation"), ["spaces", "space", "animation", "instant", "full screen"]),
         item(SearchID.mruWindowsSort, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
              String(localized: "Most recent (windows) sort order"), ["sort", "window", "recent", "order", "mru", "windows"]),
+        item(SearchID.displayMonitor, .experimental, SettingsAnchor.experimental, "Experimental", "Experimental",
+             String(localized: "Show switcher on"), ["display", "monitor", "screen", "multi monitor", "cursor", "main display", "active window"]),
     ]
 
     private static func item(

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -42,8 +42,6 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let scrollReverseSwitch = NSSwitch()
     private let clickDismissSwitch = NSSwitch()
     private let vimNavSwitch = NSSwitch()
-    private let displayMonitorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
-    private let displayModes: [SwitcherDisplayMode] = SwitcherDisplayMode.allCases
 
     // Hover actions
     private let hoverSwitch = NSSwitch()
@@ -202,17 +200,6 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
                subtitle: String(localized: "Use h / j / k / l like the arrow keys while the switcher is open. h overrides the Hide binding and j / k / l override letter-jump; search mode still types those letters."),
                accessory: vimNavSwitch, searchItemID: SearchID.vimNavigation)
 
-        displayMonitorPopup.controlSize = .small
-        displayMonitorPopup.translatesAutoresizingMaskIntoConstraints = false
-        displayMonitorPopup.setContentHuggingPriority(.required, for: .horizontal)
-        displayMonitorPopup.removeAllItems()
-        displayMonitorPopup.addItems(withTitles: displayModes.map(\.displayName))
-        displayMonitorPopup.target = self
-        displayMonitorPopup.action = #selector(displayModeChanged)
-        addRow(to: navigation, title: String(localized: "Show switcher on"),
-               subtitle: String(localized: "Choose which monitor the switcher opens on when you have more than one display."),
-               accessory: displayMonitorPopup, searchItemID: SearchID.displayMonitor)
-
         // Hover actions section — buttons revealed on a row under the pointer.
         let actions = addSection(title: String(localized: "Hover actions"), anchor: SettingsAnchor.actions)
         configureSwitch(hoverSwitch, action: #selector(toggleHover(_:)))
@@ -266,7 +253,6 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         selectRecentlyClosedLimit(prefs.recentlyClosedLimit)
         recentlyClosedLimitPopup.isEnabled = prefs.showRecentlyClosed
         selectSearchMode(prefs.searchDismissMode)
-        selectDisplayMode(prefs.switcherDisplayMode)
         scrollSwitch.state = prefs.scrollToSwitch ? .on : .off
         scrollReverseSwitch.state = prefs.scrollReverseDirection ? .on : .off
         scrollReverseSwitch.isEnabled = prefs.scrollToSwitch
@@ -284,10 +270,6 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         prefs.$searchDismissMode
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.selectSearchMode($0) }
-            .store(in: &cancellables)
-        prefs.$switcherDisplayMode
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.selectDisplayMode($0) }
             .store(in: &cancellables)
         // Keep the slider in sync if the value changes underneath us (e.g. a
         // settings import calls reloadFromDefaults while this pane is open).
@@ -489,15 +471,5 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
 
     private func selectSearchMode(_ mode: SearchDismissMode) {
         if let i = searchDismissModes.firstIndex(of: mode) { searchModePopup.selectItem(at: i) }
-    }
-
-    @objc private func displayModeChanged() {
-        let idx = displayMonitorPopup.indexOfSelectedItem
-        guard displayModes.indices.contains(idx) else { return }
-        Preferences.shared.switcherDisplayMode = displayModes[idx]
-    }
-
-    private func selectDisplayMode(_ mode: SwitcherDisplayMode) {
-        if let i = displayModes.firstIndex(of: mode) { displayMonitorPopup.selectItem(at: i) }
     }
 }

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -42,6 +42,8 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let scrollReverseSwitch = NSSwitch()
     private let clickDismissSwitch = NSSwitch()
     private let vimNavSwitch = NSSwitch()
+    private let displayMonitorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let displayModes: [SwitcherDisplayMode] = SwitcherDisplayMode.allCases
 
     // Hover actions
     private let hoverSwitch = NSSwitch()
@@ -200,6 +202,17 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
                subtitle: String(localized: "Use h / j / k / l like the arrow keys while the switcher is open. h overrides the Hide binding and j / k / l override letter-jump; search mode still types those letters."),
                accessory: vimNavSwitch, searchItemID: SearchID.vimNavigation)
 
+        displayMonitorPopup.controlSize = .small
+        displayMonitorPopup.translatesAutoresizingMaskIntoConstraints = false
+        displayMonitorPopup.setContentHuggingPriority(.required, for: .horizontal)
+        displayMonitorPopup.removeAllItems()
+        displayMonitorPopup.addItems(withTitles: displayModes.map(\.displayName))
+        displayMonitorPopup.target = self
+        displayMonitorPopup.action = #selector(displayModeChanged)
+        addRow(to: navigation, title: String(localized: "Show switcher on"),
+               subtitle: String(localized: "Choose which monitor the switcher opens on when you have more than one display."),
+               accessory: displayMonitorPopup, searchItemID: SearchID.displayMonitor)
+
         // Hover actions section — buttons revealed on a row under the pointer.
         let actions = addSection(title: String(localized: "Hover actions"), anchor: SettingsAnchor.actions)
         configureSwitch(hoverSwitch, action: #selector(toggleHover(_:)))
@@ -253,6 +266,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         selectRecentlyClosedLimit(prefs.recentlyClosedLimit)
         recentlyClosedLimitPopup.isEnabled = prefs.showRecentlyClosed
         selectSearchMode(prefs.searchDismissMode)
+        selectDisplayMode(prefs.switcherDisplayMode)
         scrollSwitch.state = prefs.scrollToSwitch ? .on : .off
         scrollReverseSwitch.state = prefs.scrollReverseDirection ? .on : .off
         scrollReverseSwitch.isEnabled = prefs.scrollToSwitch
@@ -270,6 +284,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         prefs.$searchDismissMode
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.selectSearchMode($0) }
+            .store(in: &cancellables)
+        prefs.$switcherDisplayMode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.selectDisplayMode($0) }
             .store(in: &cancellables)
         // Keep the slider in sync if the value changes underneath us (e.g. a
         // settings import calls reloadFromDefaults while this pane is open).
@@ -471,5 +489,15 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
 
     private func selectSearchMode(_ mode: SearchDismissMode) {
         if let i = searchDismissModes.firstIndex(of: mode) { searchModePopup.selectItem(at: i) }
+    }
+
+    @objc private func displayModeChanged() {
+        let idx = displayMonitorPopup.indexOfSelectedItem
+        guard displayModes.indices.contains(idx) else { return }
+        Preferences.shared.switcherDisplayMode = displayModes[idx]
+    }
+
+    private func selectDisplayMode(_ mode: SwitcherDisplayMode) {
+        if let i = displayModes.firstIndex(of: mode) { displayMonitorPopup.selectItem(at: i) }
     }
 }

--- a/BetterCmdTab/Switcher/ScreenSelection.swift
+++ b/BetterCmdTab/Switcher/ScreenSelection.swift
@@ -1,0 +1,28 @@
+import CoreGraphics
+import Foundation
+
+/// Pure screen-picking geometry, split out from `NSScreen` so it is unit
+/// testable without a live WindowServer. All rects share one coordinate space
+/// (Cocoa, bottom-left origin) supplied by the caller.
+enum ScreenSelection {
+
+    /// Index of the screen frame with the greatest area of overlap with `rect`.
+    /// Returns nil when `screenFrames` is empty or nothing overlaps `rect`.
+    static func indexOfMaxOverlap(rect: CGRect, screenFrames: [CGRect]) -> Int? {
+        var best: (index: Int, area: CGFloat)?
+        for (i, frame) in screenFrames.enumerated() {
+            let inter = frame.intersection(rect)
+            guard !inter.isNull else { continue }
+            let area = max(0, inter.width) * max(0, inter.height)
+            guard area > 0 else { continue }
+            if best == nil || area > best!.area { best = (i, area) }
+        }
+        return best?.index
+    }
+
+    /// Index of the "Main display" — the screen whose frame origin is (0, 0),
+    /// matching System Settings → Displays. Returns nil when none is at origin.
+    static func mainDisplayIndex(screenFrames: [CGRect]) -> Int? {
+        screenFrames.firstIndex { $0.origin == .zero }
+    }
+}

--- a/BetterCmdTab/Switcher/ScreenSelection.swift
+++ b/BetterCmdTab/Switcher/ScreenSelection.swift
@@ -25,4 +25,19 @@ enum ScreenSelection {
     static func mainDisplayIndex(screenFrames: [CGRect]) -> Int? {
         screenFrames.firstIndex { $0.origin == .zero }
     }
+
+    /// Flip a rect from Accessibility coordinates (top-left origin of the primary
+    /// display, y-down) into Cocoa coordinates (bottom-left origin, y-up).
+    /// `primaryMaxY` is the primary ("Main display") height; both spaces are
+    /// anchored to that screen's corner, so this one flip is correct for windows
+    /// on every display — including secondaries above/below (Cocoa y past the
+    /// primary's range) or to the left (negative x, carried through unchanged).
+    static func cocoaRect(forAXBounds ax: CGRect, primaryMaxY: CGFloat) -> CGRect {
+        CGRect(
+            x: ax.minX,
+            y: primaryMaxY - ax.minY - ax.height,
+            width: ax.width,
+            height: ax.height
+        )
+    }
 }

--- a/BetterCmdTab/Switcher/ScreenSelection.swift
+++ b/BetterCmdTab/Switcher/ScreenSelection.swift
@@ -28,10 +28,11 @@ enum ScreenSelection {
 
     /// Flip a rect from Accessibility coordinates (top-left origin of the primary
     /// display, y-down) into Cocoa coordinates (bottom-left origin, y-up).
-    /// `primaryMaxY` is the primary ("Main display") height; both spaces are
-    /// anchored to that screen's corner, so this one flip is correct for windows
-    /// on every display — including secondaries above/below (Cocoa y past the
-    /// primary's range) or to the left (negative x, carried through unchanged).
+    /// `primaryMaxY` is the primary ("Main display") height — pass the origin-zero
+    /// screen's `frame.maxY`, which equals its height since its `minY` is 0. Both
+    /// spaces are anchored to that screen's corner, so this one flip is correct
+    /// for windows on every display — including secondaries above/below (Cocoa y
+    /// past the primary's range) or to the left (negative x, carried unchanged).
     static func cocoaRect(forAXBounds ax: CGRect, primaryMaxY: CGFloat) -> CGRect {
         CGRect(
             x: ax.minX,

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1794,16 +1794,16 @@ final class SwitcherController: SwitcherViewDelegate {
     /// Convert AX (top-left) window bounds to Cocoa and pick the max-overlap
     /// screen. Main-actor only (`NSScreen.screens`). nil if no screen overlaps.
     private func screen(forAXBounds ax: CGRect) -> NSScreen? {
-        guard let primaryMaxY = NSScreen.screens.first?.frame.maxY else { return nil }
-        let cocoa = CGRect(
-            x: ax.minX,
-            y: primaryMaxY - ax.minY - ax.height,
-            width: ax.width,
-            height: ax.height
-        )
-        let frames = NSScreen.screens.map(\.frame)
-        guard let i = ScreenSelection.indexOfMaxOverlap(rect: cocoa, screenFrames: frames) else { return nil }
-        return NSScreen.screens[i]
+        let screens = NSScreen.screens
+        // The AX↔Cocoa flip is anchored to the "Main display". `NSScreen.screens`
+        // order is not guaranteed primary-first, so resolve it by origin (mirrors
+        // `mainDisplayScreen()` / `cgGlobalFrame`) — using `screens.first` here
+        // would flip against the wrong height when displays are reordered.
+        guard let primaryMaxY = (screens.first(where: { $0.frame.origin == .zero })
+            ?? screens.first)?.frame.maxY else { return nil }
+        let cocoa = ScreenSelection.cocoaRect(forAXBounds: ax, primaryMaxY: primaryMaxY)
+        guard let i = ScreenSelection.indexOfMaxOverlap(rect: cocoa, screenFrames: screens.map(\.frame)) else { return nil }
+        return screens[i]
     }
 
     /// Resolve the frontmost app's focused window off the main thread during the

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -415,10 +415,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // `baseRows`, not `rows`: in fuzzy-search mode an empty filtered result
         // is still a visible panel that must track screen changes.
         guard phase == .visible, !baseRows.isEmpty else { return }
-        let sessionScreen = resolveSessionScreen()
-        panel.targetScreen = sessionScreen
-        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
-        refreshDisplay()
+        applySessionScreen(resolveSessionScreen())
     }
 
     /// UserDefaults key recording which symbolic-hotkey ids we left disabled, so
@@ -1764,10 +1761,34 @@ final class SwitcherController: SwitcherViewDelegate {
     /// two never disagree. Mouse/main resolve live; active-window uses the
     /// off-main capture (`openTargetScreen`) with the panel's fallback chain.
     private func resolveSessionScreen() -> NSScreen {
-        SwitcherPanel.preferredScreen(
+        // Map the captured active-window screen to a still-connected screen by
+        // frame (NSScreen instances are recreated on reconfig; a disconnected
+        // display has no frame match → nil → graceful cursor/main fallback).
+        let active = openTargetScreen.flatMap { captured in
+            NSScreen.screens.first { $0.frame == captured.frame }
+        }
+        return SwitcherPanel.preferredScreen(
             mode: Preferences.shared.switcherDisplayMode,
-            activeWindowScreen: openTargetScreen
+            activeWindowScreen: active
         )
+    }
+
+    /// Re-position/re-size the visible panel for `screen`. Mirrors the recompute
+    /// in `handleScreenParametersChange()`; `refreshDisplay()` re-presents.
+    private func applySessionScreen(_ screen: NSScreen) {
+        panel.targetScreen = screen
+        currentMetrics = SwitcherMetrics.forScreen(screen, layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
+        refreshDisplay()
+    }
+
+    /// After a late `.activeWindow` screen capture lands, move the already-shown
+    /// panel to it — but only if the screen actually changed, to avoid needless
+    /// relayout/flicker when the fallback already matched the active window.
+    private func reapplySessionScreenIfChanged() {
+        guard phase == .visible else { return }
+        let resolved = resolveSessionScreen()
+        guard resolved.frame != panel.targetScreen?.frame else { return }
+        applySessionScreen(resolved)
     }
 
     /// Convert AX (top-left) window bounds to Cocoa and pick the max-overlap
@@ -1853,6 +1874,24 @@ final class SwitcherController: SwitcherViewDelegate {
         prefetchedFocusedWindow = nil
         openTargetScreen = prefetchedTargetScreen
         prefetchedTargetScreen = nil
+        // Mode may have flipped to .activeWindow after the primed prefetch (which
+        // then captured the window but not the screen). Resolve the screen now
+        // from the already-captured window so active-window mode still applies.
+        if Preferences.shared.switcherDisplayMode == .activeWindow,
+           openTargetScreen == nil, let capturedWindow = openFocusedWindow {
+            focusedWindowCaptureGen &+= 1
+            let gen = focusedWindowCaptureGen
+            DispatchQueue.global(qos: .userInteractive).async {
+                let axBounds = Activator.axBounds(of: capturedWindow)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, gen == self.focusedWindowCaptureGen, self.phase == .visible else { return }
+                    if let axBounds, let resolved = self.screen(forAXBounds: axBounds) {
+                        self.openTargetScreen = resolved
+                        self.reapplySessionScreenIfChanged()
+                    }
+                }
+            }
+        }
         if openFocusedWindow == nil, let pid = front?.processIdentifier, pid != getpid() {
             let wantScreen = Preferences.shared.switcherDisplayMode == .activeWindow
             focusedWindowCaptureGen &+= 1
@@ -1864,7 +1903,10 @@ final class SwitcherController: SwitcherViewDelegate {
                     guard let self, gen == self.focusedWindowCaptureGen,
                           self.phase == .visible, self.openFocusedWindow == nil else { return }
                     self.openFocusedWindow = window
-                    if let axBounds { self.openTargetScreen = self.screen(forAXBounds: axBounds) }
+                    if let axBounds, let resolved = self.screen(forAXBounds: axBounds) {
+                        self.openTargetScreen = resolved
+                        self.reapplySessionScreenIfChanged()
+                    }
                 }
             }
         }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1798,7 +1798,9 @@ final class SwitcherController: SwitcherViewDelegate {
         // The AX↔Cocoa flip is anchored to the "Main display". `NSScreen.screens`
         // order is not guaranteed primary-first, so resolve it by origin (mirrors
         // `mainDisplayScreen()` / `cgGlobalFrame`) — using `screens.first` here
-        // would flip against the wrong height when displays are reordered.
+        // would flip against the wrong height when displays are reordered. The
+        // `?? screens.first` is an unreachable default (a live system always has
+        // an origin-zero display); an empty `screens` yields nil and bails.
         guard let primaryMaxY = (screens.first(where: { $0.frame.origin == .zero })
             ?? screens.first)?.frame.maxY else { return nil }
         let cocoa = ScreenSelection.cocoaRect(forAXBounds: ax, primaryMaxY: primaryMaxY)

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -108,6 +108,10 @@ final class SwitcherController: SwitcherViewDelegate {
     /// highlighted row and not a live `frontmostApplication` read (which returns
     /// BetterCmdTab once our key panel is on screen). Cleared on teardown.
     private var openFocusedWindow: AXUIElement?
+    /// Screen of the window focused when the switcher opened, resolved off-main
+    /// for `.activeWindow` display mode (#22). nil for other modes or until the
+    /// async read lands. Cleared on teardown with `openFocusedWindow`.
+    private var openTargetScreen: NSScreen?
     /// The app that was frontmost when the switcher opened. On open we activate
     /// BetterCmdTab so the WindowServer renders the Liquid Glass backdrop as
     /// active (an `.accessory`/non-activating app's in-process `appearsActive`
@@ -275,6 +279,9 @@ final class SwitcherController: SwitcherViewDelegate {
     /// (overlapping the reveal delay) so `reveal()` doesn't block its critical
     /// path on the synchronous AX read. Consumed and cleared by `reveal()`.
     private var prefetchedFocusedWindow: AXUIElement?
+    /// `.activeWindow` target screen resolved during the primed prefetch, copied
+    /// into `openTargetScreen` by `reveal()` (mirrors `prefetchedFocusedWindow`).
+    private var prefetchedTargetScreen: NSScreen?
     /// Token bumped per primed chord so a stale off-main focused-window capture
     /// from an earlier chord can't land on a newer one.
     private var focusedWindowCaptureGen: UInt64 = 0
@@ -408,7 +415,9 @@ final class SwitcherController: SwitcherViewDelegate {
         // `baseRows`, not `rows`: in fuzzy-search mode an empty filtered result
         // is still a visible panel that must track screen changes.
         guard phase == .visible, !baseRows.isEmpty else { return }
-        currentMetrics = SwitcherMetrics.forScreen(SwitcherPanel.preferredScreen(), layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
+        let sessionScreen = resolveSessionScreen()
+        panel.targetScreen = sessionScreen
+        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
         refreshDisplay()
     }
 
@@ -1751,6 +1760,31 @@ final class SwitcherController: SwitcherViewDelegate {
         revealTimer = timer
     }
 
+    /// The one screen this open session uses for positioning AND metrics, so the
+    /// two never disagree. Mouse/main resolve live; active-window uses the
+    /// off-main capture (`openTargetScreen`) with the panel's fallback chain.
+    private func resolveSessionScreen() -> NSScreen {
+        SwitcherPanel.preferredScreen(
+            mode: Preferences.shared.switcherDisplayMode,
+            activeWindowScreen: openTargetScreen
+        )
+    }
+
+    /// Convert AX (top-left) window bounds to Cocoa and pick the max-overlap
+    /// screen. Main-actor only (`NSScreen.screens`). nil if no screen overlaps.
+    private func screen(forAXBounds ax: CGRect) -> NSScreen? {
+        guard let primaryMaxY = NSScreen.screens.first?.frame.maxY else { return nil }
+        let cocoa = CGRect(
+            x: ax.minX,
+            y: primaryMaxY - ax.minY - ax.height,
+            width: ax.width,
+            height: ax.height
+        )
+        let frames = NSScreen.screens.map(\.frame)
+        guard let i = ScreenSelection.indexOfMaxOverlap(rect: cocoa, screenFrames: frames) else { return nil }
+        return NSScreen.screens[i]
+    }
+
     /// Resolve the frontmost app's focused window off the main thread during the
     /// primed phase so the work overlaps the reveal delay instead of stalling
     /// `reveal()`. `openFocusedWindow` is what window-management chords act on
@@ -1761,14 +1795,17 @@ final class SwitcherController: SwitcherViewDelegate {
     /// skips the primed timer).
     private func prefetchOpenFocusedWindow() {
         prefetchedFocusedWindow = nil
+        prefetchedTargetScreen = nil
         let selfPid = getpid()
         guard let front = NSWorkspace.shared.frontmostApplication,
               front.processIdentifier != selfPid else { return }
         let pid = front.processIdentifier
+        let wantScreen = Preferences.shared.switcherDisplayMode == .activeWindow
         focusedWindowCaptureGen &+= 1
         let gen = focusedWindowCaptureGen
         DispatchQueue.global(qos: .userInteractive).async {
             let window = Activator.focusedWindow(pid: pid)
+            let axBounds = (wantScreen && window != nil) ? Activator.axBounds(of: window!) : nil
             DispatchQueue.main.async { [weak self] in
                 // `.primed` only: reveal() consumes + nils this and flips to
                 // `.visible`, so a landing after reveal (or after a cancel to
@@ -1777,6 +1814,7 @@ final class SwitcherController: SwitcherViewDelegate {
                 // skip the primed prefetch) would adopt.
                 guard let self, gen == self.focusedWindowCaptureGen, self.phase == .primed else { return }
                 self.prefetchedFocusedWindow = window
+                if let axBounds { self.prefetchedTargetScreen = self.screen(forAXBounds: axBounds) }
             }
         }
     }
@@ -1813,15 +1851,20 @@ final class SwitcherController: SwitcherViewDelegate {
         // above, before `panel.present()` makes our key panel frontmost.
         openFocusedWindow = prefetchedFocusedWindow
         prefetchedFocusedWindow = nil
+        openTargetScreen = prefetchedTargetScreen
+        prefetchedTargetScreen = nil
         if openFocusedWindow == nil, let pid = front?.processIdentifier, pid != getpid() {
+            let wantScreen = Preferences.shared.switcherDisplayMode == .activeWindow
             focusedWindowCaptureGen &+= 1
             let gen = focusedWindowCaptureGen
             DispatchQueue.global(qos: .userInteractive).async {
                 let window = Activator.focusedWindow(pid: pid)
+                let axBounds = (wantScreen && window != nil) ? Activator.axBounds(of: window!) : nil
                 DispatchQueue.main.async { [weak self] in
                     guard let self, gen == self.focusedWindowCaptureGen,
                           self.phase == .visible, self.openFocusedWindow == nil else { return }
                     self.openFocusedWindow = window
+                    if let axBounds { self.openTargetScreen = self.screen(forAXBounds: axBounds) }
                 }
             }
         }
@@ -1909,7 +1952,9 @@ final class SwitcherController: SwitcherViewDelegate {
         }
         guard !rows.isEmpty else { cancel(); return }
 
-        currentMetrics = SwitcherMetrics.forScreen(SwitcherPanel.preferredScreen(), layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
+        let sessionScreen = resolveSessionScreen()
+        panel.targetScreen = sessionScreen
+        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, highlightPrefix: letterBuffer)
         panel.present()
         phase = .visible
@@ -2002,7 +2047,9 @@ final class SwitcherController: SwitcherViewDelegate {
         let delta = windowsOnlyPrimedDelta
         index = count > 0 ? ((delta % count) + count) % count : 0
 
-        currentMetrics = SwitcherMetrics.forScreen(SwitcherPanel.preferredScreen(), layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
+        let sessionScreen = resolveSessionScreen()
+        panel.targetScreen = sessionScreen
+        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: Preferences.shared.switcherLayoutMode, userScale: Preferences.shared.panelSize.scale, letterHints: Preferences.shared.letterHintsEnabled, showAppNames: Preferences.shared.showApplicationNames, showWindowTitles: Preferences.shared.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: Preferences.shared.expandBrowserTabsAsWindows && !Preferences.shared.applicationsOnly)
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, highlightPrefix: letterBuffer)
         panel.present()
         phase = .visible
@@ -2566,6 +2613,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // session and be adopted by a gesture/scoped open that skips the primed
         // prefetch (those call reveal() directly).
         prefetchedFocusedWindow = nil
+        prefetchedTargetScreen = nil
         // We picked a target — `pendingActivation` activates it, so there's
         // nothing to restore. Drop the captured previous app.
         previousFrontmostApp = nil
@@ -2607,6 +2655,8 @@ final class SwitcherController: SwitcherViewDelegate {
         resetSearch()
         openFocusedWindow = nil
         prefetchedFocusedWindow = nil
+        openTargetScreen = nil
+        prefetchedTargetScreen = nil
         view.releaseIdleResources()
         // Dismissing without picking: undo the self-activation `present()` did for
         // the glass backdrop and put the user back in the app they came from.

--- a/BetterCmdTab/Switcher/SwitcherPanel.swift
+++ b/BetterCmdTab/Switcher/SwitcherPanel.swift
@@ -7,6 +7,11 @@ import os
 final class SwitcherPanel: NSPanel {
     private var prefCancellable: AnyCancellable?
 
+    /// The screen the owning controller resolved for this open session. Set
+    /// before `present()` so positioning matches the metrics the controller
+    /// computed for the same screen. Cleared on `dismiss()`. Nil → resolve live.
+    var targetScreen: NSScreen?
+
     /// Invoked whenever the panel is shown or relayed out (with its frame in
     /// CGEvent global / top-left-origin coordinates) and when it's hidden (with
     /// `nil`). SwitcherController forwards this to the hotkey tap so an outside
@@ -206,6 +211,7 @@ final class SwitcherPanel: NSPanel {
         // `present()` un-hides it.
         contentView?.isHidden = true
         orderOut(nil)
+        targetScreen = nil
         CATransaction.commit()
         onFrameDidChange?(nil)
     }
@@ -227,12 +233,38 @@ final class SwitcherPanel: NSPanel {
     }
 
     private func activeScreen() -> NSScreen {
-        Self.preferredScreen()
+        targetScreen ?? Self.preferredScreen()
     }
 
-    static func preferredScreen() -> NSScreen {
-        if let mouseScreen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) {
-            return mouseScreen
+    /// Resolve the screen for `mode`. `mouseCursor`/`mainDisplay` are cheap live
+    /// reads; `activeWindow` is supplied by the controller (`activeWindowScreen`),
+    /// captured before our key panel stole frontmost — it falls back to cursor →
+    /// main when unavailable (no focused window, or capture not yet landed).
+    static func preferredScreen(mode: SwitcherDisplayMode? = nil,
+                                activeWindowScreen: NSScreen? = nil) -> NSScreen {
+        switch mode ?? Preferences.shared.switcherDisplayMode {
+        case .mouseCursor:
+            return mouseScreen() ?? mainDisplayScreen()
+        case .mainDisplay:
+            return mainDisplayScreen()
+        case .activeWindow:
+            return activeWindowScreen ?? mouseScreen() ?? mainDisplayScreen()
+        }
+    }
+
+    /// Screen under the mouse pointer, or nil if the pointer is off all screens.
+    static func mouseScreen() -> NSScreen? {
+        NSScreen.screens.first { $0.frame.contains(NSEvent.mouseLocation) }
+    }
+
+    /// "Main display" from System Settings → Displays — the origin-zero screen.
+    /// `NSScreen.main` is intentionally only a fallback: it means "screen with
+    /// the key window", which is the active screen, not the primary.
+    static func mainDisplayScreen() -> NSScreen {
+        // "Main display" = the origin-zero screen. Found directly (no [CGRect]
+        // allocation); ScreenSelection.mainDisplayIndex stays for unit tests.
+        if let main = NSScreen.screens.first(where: { $0.frame.origin == .zero }) {
+            return main
         }
         return NSScreen.main ?? NSScreen.screens.first ?? NSScreen()
     }

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -592,7 +592,10 @@ final class SwitcherView: NSView, TabStripDelegate {
     /// `preferredScreen()` when ordered out, because `NSWindow.screen` is
     /// frame-based and would otherwise return the screen from the previous open.
     private func layoutScreenFrame() -> NSRect {
-        let screen = (window?.isVisible == true ? window?.screen : nil) ?? SwitcherPanel.preferredScreen()
+        let panelTarget = (window as? SwitcherPanel)?.targetScreen
+        let screen = (window?.isVisible == true ? window?.screen : nil)
+            ?? panelTarget
+            ?? SwitcherPanel.preferredScreen()
         return screen.visibleFrame
     }
 

--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -735,6 +735,25 @@ enum Activator {
         return (windowValue as! AXUIElement)
     }
 
+    /// The window's bounds in **Accessibility coordinates** (top-left origin of
+    /// the primary display, y-down) read synchronously via the AX API. Returns
+    /// nil if the attributes are missing/typed wrong. Call OFF the main thread —
+    /// `AXUIElementCopyAttributeValue` can block up to the messaging timeout on a
+    /// busy app. The caller converts to Cocoa coordinates and picks a screen.
+    static func axBounds(of window: AXUIElement) -> CGRect? {
+        var posRef: AnyObject?
+        var sizeRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &posRef) == .success,
+              AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRef) == .success,
+              CFGetTypeID(posRef as CFTypeRef) == AXValueGetTypeID(),
+              CFGetTypeID(sizeRef as CFTypeRef) == AXValueGetTypeID() else { return nil }
+        var pos = CGPoint.zero
+        var size = CGSize.zero
+        AXValueGetValue(posRef as! AXValue, .cgPoint, &pos)
+        AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+        return CGRect(origin: pos, size: size)
+    }
+
     /// Arrange an explicit window on its current screen. Used by the switcher
     /// for the window it captured at open time (see `openFocusedWindow`).
     /// Always on main: `applyArrangement` reads `NSScreen.screens` (documented

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -48,6 +48,18 @@ struct PreferencesEnumTests {
         #expect(SearchDismissMode(rawValue: "nonsense") == nil)
     }
 
+    @Test("SwitcherDisplayMode raw values round-trip and unknown falls back")
+    func switcherDisplayModeRoundTrip() {
+        for mode in SwitcherDisplayMode.allCases {
+            #expect(SwitcherDisplayMode(rawValue: mode.rawValue) == mode)
+        }
+        #expect(SwitcherDisplayMode(rawValue: "garbage") == nil)
+        // Stable raw values (persisted to UserDefaults / exported settings).
+        #expect(SwitcherDisplayMode.mouseCursor.rawValue == "mouseCursor")
+        #expect(SwitcherDisplayMode.activeWindow.rawValue == "activeWindow")
+        #expect(SwitcherDisplayMode.mainDisplay.rawValue == "mainDisplay")
+    }
+
     @Test("HideWindowsMode / IgnoreShortcutsMode round-trip through raw values")
     func exceptionModeRawValues() {
         for mode in HideWindowsMode.allCases {

--- a/BetterCmdTabTests/ScreenSelectionTests.swift
+++ b/BetterCmdTabTests/ScreenSelectionTests.swift
@@ -61,4 +61,46 @@ struct ScreenSelectionTests {
         let win = CGRect(x: 1000, y: 200, width: 500, height: 300)
         #expect(ScreenSelection.indexOfMaxOverlap(rect: win, screenFrames: [screenA, screenB]) == 1)
     }
+
+    // AX bounds are top-left origin / y-down, anchored at the primary display's
+    // top; Cocoa is bottom-left / y-up. Primary here is 1000pt tall (maxY=1000).
+    @Test("AX→Cocoa flip mirrors y for a window on the primary display")
+    func axFlipOnPrimary() {
+        // 100pt below the primary's top, 300pt tall: Cocoa bottom = 1000-100-300.
+        let cocoa = ScreenSelection.cocoaRect(forAXBounds: CGRect(x: 200, y: 100, width: 400, height: 300), primaryMaxY: 1000)
+        #expect(cocoa == CGRect(x: 200, y: 600, width: 400, height: 300))
+    }
+
+    @Test("AX→Cocoa flip carries x through for a right-hand secondary")
+    func axFlipOnRightSecondary() {
+        // Secondary to the right shares the y-axis; only x differs. Top-aligned:
+        // Cocoa bottom = 1000-0-500.
+        let cocoa = ScreenSelection.cocoaRect(forAXBounds: CGRect(x: 1200, y: 0, width: 400, height: 500), primaryMaxY: 1000)
+        #expect(cocoa == CGRect(x: 1200, y: 500, width: 400, height: 500))
+    }
+
+    @Test("AX→Cocoa flip yields y above the primary for a top secondary")
+    func axFlipOnTopSecondary() {
+        // Display ABOVE primary → negative AX y. Cocoa bottom = 1000-(-400)-300 =
+        // 1100, i.e. past the primary's top edge.
+        let cocoa = ScreenSelection.cocoaRect(forAXBounds: CGRect(x: 0, y: -400, width: 200, height: 300), primaryMaxY: 1000)
+        #expect(cocoa == CGRect(x: 0, y: 1100, width: 200, height: 300))
+    }
+
+    @Test("AX→Cocoa flip yields negative y for a bottom secondary")
+    func axFlipOnBottomSecondary() {
+        // Display BELOW primary → AX y past the primary's height. Cocoa bottom =
+        // 1000-1100-300 = -400.
+        let cocoa = ScreenSelection.cocoaRect(forAXBounds: CGRect(x: 0, y: 1100, width: 200, height: 300), primaryMaxY: 1000)
+        #expect(cocoa == CGRect(x: 0, y: -400, width: 200, height: 300))
+    }
+
+    @Test("flip then max-overlap picks the secondary a reordered window sits on")
+    func axFlipComposedPicksCorrectScreen() {
+        // End-to-end of the pure half: AX (1200,0,400,500) on the right secondary
+        // B flips to Cocoa (1200,500,400,500) and resolves to B (index 1) — the
+        // result is independent of which screen happened to be `screens.first`.
+        let cocoa = ScreenSelection.cocoaRect(forAXBounds: CGRect(x: 1200, y: 0, width: 400, height: 500), primaryMaxY: 1000)
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: cocoa, screenFrames: [screenA, screenB]) == 1)
+    }
 }

--- a/BetterCmdTabTests/ScreenSelectionTests.swift
+++ b/BetterCmdTabTests/ScreenSelectionTests.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import BetterCmdTab
+
+@Suite("ScreenSelection")
+struct ScreenSelectionTests {
+
+    // Two side-by-side 1000x1000 displays: A at origin, B to its right.
+    private let screenA = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+    private let screenB = CGRect(x: 1000, y: 0, width: 1000, height: 1000)
+
+    @Test("window fully on the second screen picks that screen")
+    func fullyOnSecond() {
+        let win = CGRect(x: 1200, y: 200, width: 400, height: 300)
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: win, screenFrames: [screenA, screenB]) == 1)
+    }
+
+    @Test("straddling window picks the screen with the larger overlap")
+    func straddlePicksLargerOverlap() {
+        // 600 wide window from x=800: 200pt on A (800..1000), 400pt on B (1000..1400).
+        let win = CGRect(x: 800, y: 200, width: 600, height: 300)
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: win, screenFrames: [screenA, screenB]) == 1)
+    }
+
+    @Test("window matching no screen returns nil")
+    func noOverlapIsNil() {
+        let win = CGRect(x: 5000, y: 5000, width: 100, height: 100)
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: win, screenFrames: [screenA, screenB]) == nil)
+    }
+
+    @Test("empty screen list returns nil")
+    func emptyScreensIsNil() {
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: screenA, screenFrames: []) == nil)
+    }
+
+    @Test("main display is the origin-zero screen regardless of array order")
+    func mainDisplayIsOriginZero() {
+        // B (non-zero origin) listed first; A (origin zero) second.
+        #expect(ScreenSelection.mainDisplayIndex(screenFrames: [screenB, screenA]) == 1)
+    }
+
+    @Test("main display nil when no screen sits at the origin")
+    func mainDisplayNilWhenNoOrigin() {
+        let offset = CGRect(x: 10, y: 10, width: 1000, height: 1000)
+        #expect(ScreenSelection.mainDisplayIndex(screenFrames: [screenB, offset]) == nil)
+    }
+}

--- a/BetterCmdTabTests/ScreenSelectionTests.swift
+++ b/BetterCmdTabTests/ScreenSelectionTests.swift
@@ -45,4 +45,20 @@ struct ScreenSelectionTests {
         let offset = CGRect(x: 10, y: 10, width: 1000, height: 1000)
         #expect(ScreenSelection.mainDisplayIndex(screenFrames: [screenB, offset]) == nil)
     }
+
+    @Test("equal overlap on two screens picks the first one")
+    func equalOverlapPicksFirstScreen() {
+        // 600 wide window from x=700: 300pt on A (700..1000), 300pt on B (1000..1300).
+        // Equal area → the strict `>` keeps the earliest max, so A (index 0) wins.
+        let win = CGRect(x: 700, y: 200, width: 600, height: 300)
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: win, screenFrames: [screenA, screenB]) == 0)
+    }
+
+    @Test("a screen touched only on its edge with zero area is not chosen")
+    func edgeTouchingScreenIsNotChosen() {
+        // Window lies entirely on B (1000..1500); its left edge touches A at x=1000
+        // with a zero-width intersection. A's zero-area touch is skipped, B wins.
+        let win = CGRect(x: 1000, y: 200, width: 500, height: 300)
+        #expect(ScreenSelection.indexOfMaxOverlap(rect: win, screenFrames: [screenA, screenB]) == 1)
+    }
 }

--- a/BetterCmdTabTests/SettingsPortabilityTests.swift
+++ b/BetterCmdTabTests/SettingsPortabilityTests.swift
@@ -62,6 +62,36 @@ struct SettingsPortabilityTests {
         #expect(prefs.pinnedBundleIDs == ["com.apple.finder", "com.apple.Safari"])
     }
 
+    @Test("round-trip: switcherDisplayMode survives export/import")
+    func displayModeRoundTrip() throws {
+        let prefs = Preferences.shared
+        let saved = prefs.switcherDisplayMode
+        defer {
+            try? prefs.importSettings(from: envelope([
+                Preferences.Keys.switcherDisplayMode: saved.rawValue
+            ]))
+        }
+        // Set a non-default value, export, flip live, then import the export back.
+        prefs.switcherDisplayMode = .activeWindow
+        let data = try prefs.exportedJSONData()
+        prefs.switcherDisplayMode = .mainDisplay
+        try prefs.importSettings(from: data)
+        #expect(prefs.switcherDisplayMode == .activeWindow)
+    }
+
+    @Test("import missing switcherDisplayMode leaves the current value untouched")
+    func displayModePartialImport() throws {
+        let prefs = Preferences.shared
+        let saved = prefs.switcherDisplayMode
+        defer { prefs.switcherDisplayMode = saved }
+        prefs.switcherDisplayMode = .activeWindow
+        // Envelope without the display-mode key (partial-import contract).
+        try prefs.importSettings(from: envelope([
+            Preferences.Keys.panelOpacity: 100
+        ]))
+        #expect(prefs.switcherDisplayMode == .activeWindow)
+    }
+
     @Test("malformed JSON is rejected")
     func malformedRejected() {
         let prefs = Preferences.shared


### PR DESCRIPTION
## What & why

Closes #22. On a multi-monitor setup the switcher always opened on the screen under the pointer, which isn't always where you want it. This adds a **"Show switcher on"** picker so you can choose where the panel appears:

- **Monitor with the cursor** — default; matches the previous (pre-#22) behavior, so nothing changes unless you opt in.
- **Monitor with the active window** — the screen of the window that was focused when ⌘Tab fired.
- **Main display** — the "Main display" from System Settings → Displays.

The screen is resolved per switcher session and the panel re-measures against the chosen screen, so it stays correct across display reconfiguration and after dismiss.

## Where it lives

The picker sits in the **Experimental** pane (off-by-default home for new/unstable features, per `CLAUDE.md`/CONTRIBUTING), alongside the swipe and MRU-windows-sort options. Its default keeps the legacy cursor behavior, so the feature is genuinely opt-in.

## Implementation notes

- `ScreenSelection.swift` — pure geometry helpers for picking a screen (max-overlap with first-wins tie-breaking); fully unit-tested.
- `SwitcherPanel.preferredScreen()` is display-mode aware; `SwitcherController` resolves and pins a session target screen and re-applies it on screen-parameter changes.
- `Activator.axBounds(of:)` reads the active window frame off the main thread via the AX API (hot-path friendly).
- AppKit only, deployment target unchanged, no new dependencies or network.

## Testing

- `xcodebuild ... build` — clean, no new warnings.
- Pure-logic suites pass: `ScreenSelectionTests` (8 edge cases incl. equal-overlap ties and zero-area edge touch), `SettingsPortabilityTests` (display-mode export/import + partial import), `PreferencesEnumTests`, `SettingsLifecycleTests`.
- Multi-monitor switching behavior verified manually (needs a live WindowServer + AX permission).

Rebased onto latest `main`; merges cleanly with the new vim-navigation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)