### PR TITLE
fix: anchor window-management AX↔Cocoa flip to the origin-zero display

### DIFF
--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -787,7 +787,12 @@ enum Activator {
 
     private static func applyArrangement(window: AXUIElement, arrangement: WindowArrangement) {
         guard !NSScreen.screens.isEmpty else { return }
-        let mainHeight = NSScreen.screens[0].frame.maxY
+        // Anchor the AX↔Cocoa flip to the origin-zero "Main display": NSScreen
+        // .screens order is not guaranteed primary-first, so picking screens[0]
+        // would flip against the wrong height when displays are reordered. (The
+        // empty case is already excluded by the guard above.)
+        let mainHeight = (NSScreen.screens.first(where: { $0.frame.origin == .zero })
+            ?? NSScreen.screens[0]).frame.maxY
 
         var posRef: AnyObject?
         var sizeRef: AnyObject?
@@ -857,7 +862,12 @@ enum Activator {
         guard !NSScreen.screens.isEmpty else { return }
         // AX coordinates are top-left origin (y down) anchored at the main screen;
         // Cocoa screen frames are bottom-left origin. `mainHeight` bridges them.
-        let mainHeight = NSScreen.screens[0].frame.maxY
+        // Anchor the AX↔Cocoa flip to the origin-zero "Main display": NSScreen
+        // .screens order is not guaranteed primary-first, so picking screens[0]
+        // would flip against the wrong height when displays are reordered. (The
+        // empty case is already excluded by the guard above.)
+        let mainHeight = (NSScreen.screens.first(where: { $0.frame.origin == .zero })
+            ?? NSScreen.screens[0]).frame.maxY
 
         var posRef: AnyObject?
         var sizeRef: AnyObject?
@@ -934,7 +944,12 @@ enum Activator {
             _ = AXUIElementSetAttributeValue(window, "AXFullScreen" as CFString, kCFBooleanFalse)
         }
 
-        let mainHeight = NSScreen.screens[0].frame.maxY
+        // Anchor the AX↔Cocoa flip to the origin-zero "Main display": NSScreen
+        // .screens order is not guaranteed primary-first, so picking screens[0]
+        // would flip against the wrong height when displays are reordered. (The
+        // empty case is already excluded by the guard above.)
+        let mainHeight = (NSScreen.screens.first(where: { $0.frame.origin == .zero })
+            ?? NSScreen.screens[0]).frame.maxY
         let target = saved.cocoaRect
         var newSize = CGSize(width: target.width, height: target.height)
         if let sizeValue = AXValueCreate(.cgSize, &newSize) {


### PR DESCRIPTION
## What & why

`applyArrangement`, `repositionToAdjacentDisplay`, and `applyRestore` in `Activator.swift` used `NSScreen.screens[0].frame.maxY` as the primary-display height for the AX (top-left, y-down) → Cocoa (bottom-left, y-up) coordinate flip. `NSScreen.screens` order is **not guaranteed primary-first**, so when displays are reordered in System Settings the flip ran against the wrong height — window **move-to-display / tile / restore** actions placed the window on the wrong display or off-screen.

Fix: resolve the primary by `frame.origin == .zero` (the "Main display"), matching the existing `SwitcherPanel.cgGlobalFrame` and `mainDisplayScreen()` helpers. Each function already guards `!NSScreen.screens.isEmpty`, so the `?? NSScreen.screens[0]` fallback stays crash-safe.

## Scope / origin

Pre-existing on `main` (commits b8c73c8 / a1dadf0 / 505a2c2 — the window-management feature batches), **independent of PR #26**. Surfaced during the #26 production-readiness audit: PR #26 already applied the same origin-zero fix to the switcher-open geometry (`SwitcherController.screen(forAXBounds:)`); this carries it to the orthogonal window-management actions.

## Testing

- `xcodebuild ... test` — clean, **207 unit tests pass**, no new warnings.
- Pure window-positioning math is exercised manually (needs a live WindowServer + multi-display arrangement + AX permission, per `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)