### PR TITLE
fix: stop whole-system freeze on Accessibility revoke (+ Privacy reactive row, perf, l10n)

### DIFF
--- a/BetterCmdTab.xcodeproj/project.pbxproj
+++ b/BetterCmdTab.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AA0000000000000000000003 /* BetterShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = AA0000000000000000000002 /* BetterShortcuts */; };
+		BP0000000000000000000003 /* BetterPermissions in Frameworks */ = {isa = PBXBuildFile; productRef = BP0000000000000000000002 /* BetterPermissions */; };
 		BS0000000000000000000003 /* BetterSettings in Frameworks */ = {isa = PBXBuildFile; productRef = BS0000000000000000000002 /* BetterSettings */; };
 		BU0000000000000000000003 /* BetterUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = BU0000000000000000000002 /* BetterUpdater */; };
 /* End PBXBuildFile section */
@@ -61,6 +62,7 @@
 				AA0000000000000000000003 /* BetterShortcuts in Frameworks */,
 				BU0000000000000000000003 /* BetterUpdater in Frameworks */,
 				BS0000000000000000000003 /* BetterSettings in Frameworks */,
+				BP0000000000000000000003 /* BetterPermissions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,6 +117,7 @@
 				AA0000000000000000000002 /* BetterShortcuts */,
 				BU0000000000000000000002 /* BetterUpdater */,
 				BS0000000000000000000002 /* BetterSettings */,
+				BP0000000000000000000002 /* BetterPermissions */,
 			);
 			productName = BetterCmdTab;
 			productReference = 7559A7572FC06FD5004D97B7 /* BetterCmdTab.app */;
@@ -179,6 +182,7 @@
 				AA0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterShortcuts" */,
 				BU0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterUpdater" */,
 				BS0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterSettings" */,
+				BP0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterPermissions" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 7559A7582FC06FD5004D97B7 /* Products */;
@@ -558,6 +562,14 @@
 				minimumVersion = 0.1.1;
 			};
 		};
+		BP0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterPermissions" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rokartur/BetterPermissions.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		BS0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterSettings" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rokartur/BetterSettings.git";
@@ -581,6 +593,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterShortcuts" */;
 			productName = BetterShortcuts;
+		};
+		BP0000000000000000000002 /* BetterPermissions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BP0000000000000000000001 /* XCRemoteSwiftPackageReference "BetterPermissions" */;
+			productName = BetterPermissions;
 		};
 		BS0000000000000000000002 /* BetterSettings */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BetterCmdTab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BetterCmdTab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "a1d7e9213f98a019aadcd4a351d87ba47a4d680c19e375256b8d17738b629a26",
+  "originHash" : "1e7ea82aa96283e536a735944797722e409c3f942bc5f33a843dc5dcff726efb",
   "pins" : [
+    {
+      "identity" : "betterpermissions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rokartur/BetterPermissions.git",
+      "state" : {
+        "revision" : "0679549a2bb9b5989a2f9975aed222a93af35616",
+        "version" : "1.0.1"
+      }
+    },
     {
       "identity" : "bettersettings",
       "kind" : "remoteSourceControl",

--- a/BetterCmdTab/App/AppDelegate.swift
+++ b/BetterCmdTab/App/AppDelegate.swift
@@ -162,17 +162,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func notifyAccessibilityRevoked() {
         guard !accessibilityLostShown else { return }
         accessibilityLostShown = true
-        NSApp.activate(ignoringOtherApps: true)
+
         let alert = NSAlert()
         alert.messageText = String(localized: "Accessibility access was turned off")
         alert.informativeText = String(localized: "BetterCmdTab needs Accessibility permission to handle ⌘Tab. Re-enable it in System Settings and the switcher reactivates automatically.")
         alert.addButton(withTitle: String(localized: "Open Accessibility Settings"))
         alert.addButton(withTitle: String(localized: "Later"))
-        let response = alert.runModal()
-        // Re-arm the prompt for the next revoke regardless of choice; if trust is
-        // still off, the next poll won't re-fire (no transition), so clearing the
-        // flag here is safe and only matters after a future re-grant cycle.
-        if response == .alertFirstButtonReturn {
+
+        // Center on screen: a standalone `runModal()` alert is screen-centered by
+        // AppKit (a sheet, by contrast, hangs off a host window's titlebar and needs
+        // a window to exist at all). Safe to run modally here: the tap teardown
+        // already ran in `handleAccessibilityRevoked()` BEFORE this, and the one-shot
+        // `accessibilityLostShown` guard blocks a nested/re-entrant modal — so the
+        // earlier runModal freeze (a nested modal spun under the live revoke cascade)
+        // can't recur. We're `.accessory`, so activate first or the centered alert
+        // could open behind other apps.
+        NSApp.activate(ignoringOtherApps: true)
+        if alert.runModal() == .alertFirstButtonReturn {
             AccessibilityCheck.openSystemSettings()
         }
     }

--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -188,7 +188,19 @@ final class AppCatalogCache {
                 // pids don't pay a needless re-sweep.
                 self.pidCoverage = self.pidCoverage.filter { fresh.keys.contains($0.key) }
                 self.pendingRefresh = false
-                IconCache.prewarm(pids: Array(fresh.keys))
+                // Warm the most-recently-used app icons off the show path so the
+                // first reveal doesn't flatten them synchronously on main (see
+                // IconCache.prewarm). MRU order first so the apps most likely to
+                // top the panel warm first. Skip while the panel is up: its
+                // visible rows are already cached, so this would only flatten
+                // off-screen apps and compete with the live session.
+                if !self.panelVisible {
+                    let mruOrder = self.mru?.order ?? []
+                    let inMru = Set(mruOrder)
+                    let ordered = mruOrder.filter { fresh.keys.contains($0) }
+                        + fresh.keys.filter { !inMru.contains($0) }
+                    IconCache.prewarm(pids: ordered)
+                }
                 let pending = self.pendingOneShotCompletions
                 self.pendingOneShotCompletions.removeAll()
                 for cb in pending { cb() }

--- a/BetterCmdTab/Catalog/IconCache.swift
+++ b/BetterCmdTab/Catalog/IconCache.swift
@@ -68,15 +68,55 @@ enum IconCache {
         bundleCache.removeAllObjects()
     }
 
-    /// Kept as a no-op for callers that used to eagerly populate the cache.
-    /// Eager prewarm was both an autolayout-thread hazard (Tahoe restyles
-    /// bundle icons via lazily-initialized AppKit views, which writes to the
-    /// layout engine when `NSImage.draw` runs off the main thread) and the
-    /// single biggest contributor to the post-launch RSS spike (~12 MB for a
-    /// 30-app system). On-demand flatten covers every icon a user actually
-    /// sees with negligible first-paint cost (≤1 ms per icon on M-series).
+    /// Number of most-recent app icons to flatten ahead of the first reveal.
+    /// Bounded well under `capacity` so prewarm can never inflate RSS toward
+    /// the cache ceiling (~3 MB at 12 × 262 KB) — only the apps most likely to
+    /// be on the first panel are warmed.
+    private static let prewarmLimit = 12
+    /// Icons flattened per run-loop turn. The flatten must stay on the main
+    /// actor (it touches the AutoLayout engine under Tahoe — see `flattened`),
+    /// so it is chunked across turns to keep any single main-thread slice short.
+    private static let prewarmChunkSize = 3
+
+    /// Flatten the most-recent app icons OFF the switcher show path so the first
+    /// reveal doesn't pay a synchronous `flattened()` per uncached app — the
+    /// dominant cause of the intermittent "switcher shows late" spike on a cold
+    /// cache (first open after launch, after a layout-mode change, or after >32
+    /// apps evicted the cache). Runs on the main actor — the flatten cannot go
+    /// off-main without tripping the AutoLayout-engine assertion that retired
+    /// the original *eager* prewarm — but in small `.common`-mode chunks, so it
+    /// never stalls the run loop and RSS rises gradually instead of spiking ~12
+    /// MB at once. Called from `AppCatalogCache`'s background-refresh main
+    /// completion, where the freshest MRU order is known; already-cached pids
+    /// are skipped, so a warm cache makes this a near-no-op.
     static func prewarm(pids: [pid_t]) {
-        _ = pids
+        var targets: [pid_t] = []
+        targets.reserveCapacity(prewarmLimit)
+        for pid in pids {
+            if targets.count >= prewarmLimit { break }
+            if cache.object(forKey: NSNumber(value: pid)) == nil { targets.append(pid) }
+        }
+        guard !targets.isEmpty else { return }
+        warmChunk(targets, from: 0)
+    }
+
+    /// Flatten one chunk of `pids` on the main actor, then yield the run loop
+    /// and schedule the next chunk in `.common` mode so a chord landing mid-
+    /// prewarm runs its reveal ahead of the remaining flattens.
+    private static func warmChunk(_ pids: [pid_t], from start: Int) {
+        guard start < pids.count else { return }
+        let end = min(start + prewarmChunkSize, pids.count)
+        for i in start..<end {
+            let key = NSNumber(value: pids[i])
+            guard cache.object(forKey: key) == nil,
+                  let source = NSRunningApplication(processIdentifier: pids[i])?.icon else { continue }
+            let flat = flattened(source) ?? source
+            cache.setObject(flat, forKey: key, cost: bytesPerImage)
+        }
+        guard end < pids.count else { return }
+        RunLoop.main.perform(inModes: [.common]) {
+            MainActor.assumeIsolated { warmChunk(pids, from: end) }
+        }
     }
 
     /// Rasterize an app icon into a fixed-size, immutable bitmap.

--- a/BetterCmdTab/Input/CarbonHotkeyTrigger.swift
+++ b/BetterCmdTab/Input/CarbonHotkeyTrigger.swift
@@ -179,9 +179,12 @@ final class CarbonHotkeyTrigger {
                     return OSStatus(eventNotHandledErr)
                 }
                 let id = hotKeyID.id
-                // Carbon dispatches on the main run loop, but hop explicitly so
-                // we touch MainActor state safely and match HotkeyTap's pattern.
-                DispatchQueue.main.async {
+                // Carbon dispatches hot-key events on the main run loop, so we
+                // are already on the main thread — touch MainActor state inline
+                // instead of deferring a whole run-loop turn through
+                // DispatchQueue.main.async. (HotkeyTap needs that hop because its
+                // tap runs on a dedicated background thread; this path does not.)
+                MainActor.assumeIsolated {
                     let me = Unmanaged<CarbonHotkeyTrigger>.fromOpaque(userData).takeUnretainedValue()
                     me.dispatch(id: id)
                 }

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -66,6 +66,12 @@ final class HotkeyTap {
     /// never fires, then hands the captured event to the recorder.
     var onRecordingKeyDown: (CGEvent) -> Void = { _ in }
 
+    /// Fired on the MAIN thread when the tap is being disabled repeatedly in a
+    /// tight burst (the re-enable storm — see `handle`). The owner tears the tap
+    /// down and re-arms it on a backoff (or leaves it down if Accessibility was
+    /// revoked). Set by `SwitcherController`.
+    var onTapDisabledStorm: () -> Void = {}
+
     /// Wraps a CGEvent so it can cross the tap-thread → main hop. CGEvent is a
     /// thread-safe CF reference; the box just silences Sendable checking.
     private final class EventBox: @unchecked Sendable {
@@ -113,6 +119,29 @@ final class HotkeyTap {
     }
     private let ports = OSAllocatedUnfairLock<TapPorts>(initialState: TapPorts())
     private var layoutObserver: NSObjectProtocol?
+
+    /// Storm guard for the tap-disabled re-enable path. An active session tap
+    /// whose owning process loses Accessibility trust (or that keeps timing out)
+    /// is disabled by the WindowServer; re-enabling it then fails and it is
+    /// disabled again, delivering another `tapDisabled` callback. Re-enabling
+    /// unconditionally in that callback spins the tap thread in synchronous
+    /// WindowServer IPC — and because the WindowServer blocks ALL input on this
+    /// active tap until the callback returns, the whole system freezes. So cap
+    /// rapid consecutive re-enables (see `handle`): re-enable the first few (a
+    /// genuine one-off `tapDisabledByTimeout` recovers immediately), but once a
+    /// burst is detected stop re-enabling on the tap thread and hand off to
+    /// `onTapDisabledStorm`. Guarded by the same unfair-lock discipline as the
+    /// rest of the cross-thread tap state.
+    private struct DisableGate {
+        var count = 0
+        var lastNs: UInt64 = 0
+    }
+    private let disableGate = OSAllocatedUnfairLock<DisableGate>(initialState: DisableGate())
+    /// Max rapid consecutive re-enables before bailing to main-thread recovery.
+    private static let maxRapidReenables = 3
+    /// Consecutive disables closer together than this count as one burst; a gap
+    /// longer than this resets the counter so isolated timeouts always recover.
+    private static let disableBurstWindowNs: UInt64 = 1_000_000_000 // 1s
 
     private let switchingFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
     /// True only while the switcher panel is actually on screen (`phase ==
@@ -247,6 +276,14 @@ final class HotkeyTap {
     var onReservedLettersChanged: ((Set<Character>) -> Void)?
 
     func install() -> Bool {
+        // Idempotent: if a tap is already live, do NOT overwrite the port/thread
+        // handles — that would orphan the existing tap and its run-loop thread (a
+        // leaked, still-ENABLED session tap = the exact freeze/double-delivery
+        // class this type exists to prevent). A stale `scheduleHotkeyTapRetry`
+        // firing after a re-arm hits this and no-ops. Re-arm paths call
+        // `uninstall()` first, so they still get a fresh tap. Return `true`
+        // because a live tap is the success postcondition the callers want.
+        if ports.withLock({ $0.tap }) != nil { return true }
         // Always-on tap: only the events we must catch from idle — the trigger
         // chord (keyDown) and modifier tracking (flagsChanged). Keeping this
         // mask minimal means a closed switcher's only system-wide event traffic
@@ -265,6 +302,24 @@ final class HotkeyTap {
             (1 << CGEventType.rightMouseDown.rawValue) |
             (1 << CGEventType.otherMouseDown.rawValue)
 
+        // Fresh tap → fresh storm counter, so a re-arm after a prior storm (or
+        // after an Accessibility re-grant) starts with a clean re-enable budget.
+        disableGate.withLock { $0 = DisableGate() }
+
+        // Under a debugger an ACTIVE (`.defaultTap`) session tap can HARD-freeze
+        // the WindowServer (see `DebuggerCheck`): LLDB can suspend this callback
+        // thread (a breakpoint, a caught signal, or the instant Accessibility is
+        // revoked) and the WindowServer then blocks ALL input forever, with no way
+        // to reach Xcode's Stop button — a hard reboot. While debugging, fall back
+        // to a non-blocking `.listenOnly` tap: it can't swallow events, but it
+        // can't freeze the machine either. Native ⌘Tab is still suppressed via the
+        // symbolic-hotkey API and panel nav still works. Production builds (no
+        // debugger) keep the active tap and full suppression.
+        let tapOptions: CGEventTapOptions = DebuggerCheck.isAttached ? .listenOnly : .defaultTap
+        if DebuggerCheck.isAttached {
+            Log.hotkey.warning("Debugger attached — CGEvent taps created .listenOnly (no event suppression) to avoid a WindowServer freeze")
+        }
+
         let opaqueSelf = Unmanaged.passUnretained(self).toOpaque()
 
         let callback: CGEventTapCallBack = { _, type, cgEvent, refcon in
@@ -276,7 +331,7 @@ final class HotkeyTap {
         guard let port = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .defaultTap,
+            options: tapOptions,
             eventsOfInterest: keyMask,
             callback: callback,
             userInfo: opaqueSelf
@@ -301,7 +356,7 @@ final class HotkeyTap {
         if let auxPort = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .defaultTap,
+            options: tapOptions,
             eventsOfInterest: pointerMask,
             callback: callback,
             userInfo: opaqueSelf
@@ -602,14 +657,77 @@ final class HotkeyTap {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            // Copy the ports into locals under the lock, release, then re-enable
-            // on the locals — the strong `let`s keep them alive across the call
-            // even if `uninstall()` nils the shared state concurrently.
-            let (tap, auxTap) = ports.withLockUnchecked { ($0.tap, $0.auxTap) }
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
-            // Re-arm the pointer tap only if it should currently be live (i.e.
-            // the switcher is open); otherwise it stays disabled as intended.
-            if let auxTap, isSwitchingNow() { CGEvent.tapEnable(tap: auxTap, enable: true) }
+            // Accessibility revoked is the common disable cause, and it's the one
+            // that freezes the whole machine: an active session tap whose process
+            // is no longer AX-trusted can NEVER be durably re-enabled, so every
+            // re-enable attempt is a synchronous WindowServer IPC that stalls
+            // while the WindowServer refuses — and because the WindowServer blocks
+            // all system input on this active tap, those stalls are a system-wide
+            // freeze. Don't even try once: a cheap local trust check (no XPC) lets
+            // us bail on the first disable and hand off to main, which tears the
+            // tap down. The storm gate below is the backstop for the AX-trusted
+            // timeout-loop case (main thread wedged) and for the brief race where
+            // the trust cache hasn't flipped yet.
+            if !AccessibilityCheck.isTrusted {
+                Log.hotkey.error("CGEventTap disabled and Accessibility not trusted — tearing down (no re-enable)")
+                let handler = onTapDisabledStorm
+                DispatchQueue.main.async { handler() }
+                return Unmanaged.passUnretained(event)
+            }
+            // Storm guard: count rapid consecutive disables. Re-enabling an active
+            // session tap that the WindowServer keeps disabling (a sustained
+            // timeout with AX still granted) pins THIS tap thread in synchronous
+            // WindowServer IPC — and the WindowServer blocks all system input on
+            // it, freezing the whole machine. Once a burst is seen, stop the tight
+            // re-enable loop and hand off to a main-thread recovery that tears the
+            // tap down / re-arms on a backoff.
+            let now = DispatchTime.now().uptimeNanoseconds
+            let storming = disableGate.withLock { gate -> Bool in
+                if now &- gate.lastNs > Self.disableBurstWindowNs { gate.count = 0 }
+                gate.lastNs = now
+                gate.count += 1
+                return gate.count > Self.maxRapidReenables
+            }
+            if storming {
+                // Return WITHOUT re-enabling so the tap thread stops spinning in
+                // WindowServer IPC; recovery happens on main (uninstall + re-arm,
+                // or stay down if AX was revoked).
+                Log.hotkey.error("CGEventTap disabled repeatedly (storm) — bailing to main-thread recovery")
+                let handler = onTapDisabledStorm
+                DispatchQueue.main.async { handler() }
+                return Unmanaged.passUnretained(event)
+            }
+            // Final trust re-check immediately before the re-enable closes the
+            // TOCTOU window: AX can be revoked in the tiny gap since the check
+            // above (the storm-gate lock op), and `tapEnable` on a just-untrusted
+            // active tap is itself a WindowServer-stalling IPC. This keeps even a
+            // single stray re-enable off an untrusted tap. Cold path (disables are
+            // rare), so the extra local trust read costs nothing measurable.
+            guard AccessibilityCheck.isTrusted else {
+                let handler = onTapDisabledStorm
+                DispatchQueue.main.async { handler() }
+                return Unmanaged.passUnretained(event)
+            }
+            // Re-enable INSIDE the ports lock so a concurrent `uninstall()` (which
+            // nils the ports under the same lock, then disables on its snapshot)
+            // can't race us into re-enabling a tap it just tore down: either we win
+            // the lock and enable before uninstall nils it — and uninstall's own
+            // tapEnable(false) on the snapshot then wins the end state — or
+            // uninstall wins, we observe `tap == nil`, and bail. `isSwitchingNow()`
+            // is read BEFORE taking the lock to avoid nesting the two locks.
+            // Holding the ports lock across `tapEnable` is fine on this cold path:
+            // the WindowServer IPC never re-enters this lock, and we only reach
+            // here when AX is trusted (so the call returns promptly).
+            let switchingNow = isSwitchingNow()
+            ports.withLockUnchecked { state in
+                guard let tap = state.tap else { return }
+                CGEvent.tapEnable(tap: tap, enable: true)
+                // Re-arm the pointer tap only if it should currently be live (i.e.
+                // the switcher is open); otherwise it stays disabled as intended.
+                if let auxTap = state.auxTap, switchingNow {
+                    CGEvent.tapEnable(tap: auxTap, enable: true)
+                }
+            }
             Log.hotkey.warning("CGEventTap disabled, re-enabling")
             return Unmanaged.passUnretained(event)
         }

--- a/BetterCmdTab/Input/SpaceSwipeSuppressor.swift
+++ b/BetterCmdTab/Input/SpaceSwipeSuppressor.swift
@@ -33,6 +33,31 @@ final class SpaceSwipeSuppressor {
     }
     private let ports = OSAllocatedUnfairLock<TapPorts>(initialState: TapPorts())
 
+    /// Fired on the MAIN thread when the tap is being disabled repeatedly in a
+    /// tight burst (Accessibility revoked, or a sustained timeout). The owner
+    /// (`SwitcherController`) tears this non-essential tap down; it re-arms on
+    /// AX re-grant, gated on the swipe pref. Set before `setEnabled(true)`.
+    var onTapDisabledStorm: () -> Void = {}
+
+    /// Storm guard for the tap-disabled re-enable path — identical rationale to
+    /// `HotkeyTap.DisableGate`. An active session tap whose process loses
+    /// Accessibility trust is disabled by the WindowServer; re-enabling it then
+    /// fails and it's disabled again. Re-enabling unconditionally spins this tap
+    /// thread in synchronous WindowServer IPC, and because the WindowServer
+    /// blocks ALL input on an active tap until the callback returns, the whole
+    /// system freezes. So cap rapid consecutive re-enables and bail to the owner
+    /// once a burst is seen (see `handle`).
+    private struct DisableGate {
+        var count = 0
+        var lastNs: UInt64 = 0
+    }
+    private let disableGate = OSAllocatedUnfairLock<DisableGate>(initialState: DisableGate())
+    /// Max rapid consecutive re-enables before bailing to main-thread recovery.
+    private static let maxRapidReenables = 3
+    /// Consecutive disables closer together than this count as one burst; a gap
+    /// longer than this resets the counter so isolated timeouts always recover.
+    private static let disableBurstWindowNs: UInt64 = 1_000_000_000 // 1s
+
     /// Undocumented CGS gesture event types and fields (from the IOHID/CGS
     /// private headers; same constants InstantSpaceSwitcher uses).
     private enum CGS {
@@ -50,9 +75,24 @@ final class SpaceSwipeSuppressor {
 
     private func install() {
         guard ports.withLock({ $0.tap }) == nil else { return }
+        // Never create an active session tap while AX is untrusted — it can't be
+        // durably enabled and would immediately storm. The owner re-arms via
+        // SwitcherController.reinstallHotkeyTap on AX re-grant per the persisted
+        // swipe pref, so the desired state is not lost.
+        guard AccessibilityCheck.isTrusted else { return }
 
         let mask: CGEventMask =
             (1 << UInt64(CGS.eventGesture)) | (1 << UInt64(CGS.eventDockControl))
+
+        // Fresh tap → fresh storm counter, so a re-arm after a prior storm (or
+        // after an Accessibility re-grant) starts with a clean re-enable budget.
+        disableGate.withLock { $0 = DisableGate() }
+
+        // Under a debugger, use a non-blocking listen-only tap so a suspended
+        // callback thread can't hard-freeze the WindowServer (see DebuggerCheck /
+        // HotkeyTap). Suppression is a no-op while debugging — acceptable.
+        let tapOptions: CGEventTapOptions = DebuggerCheck.isAttached ? .listenOnly : .defaultTap
+
         let opaqueSelf = Unmanaged.passUnretained(self).toOpaque()
 
         let callback: CGEventTapCallBack = { _, type, event, refcon in
@@ -64,7 +104,7 @@ final class SpaceSwipeSuppressor {
         guard let port = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .defaultTap,
+            options: tapOptions,
             eventsOfInterest: mask,
             callback: callback,
             userInfo: opaqueSelf
@@ -103,10 +143,51 @@ final class SpaceSwipeSuppressor {
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        // Re-enable if the watchdog or a user-input burst disabled the tap.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap = ports.withLock({ $0.tap }) {
-                CGEvent.tapEnable(tap: tap, enable: true)
+            // Accessibility revoked → an active session tap can't be durably
+            // re-enabled; re-enabling spins this thread in synchronous
+            // WindowServer IPC, and the WindowServer blocks ALL input on the tap
+            // until the callback returns, so the whole system freezes. Bail on
+            // the first disable (cheap local trust check, no XPC) and let the
+            // owner tear the tap down — never attempt a single re-enable.
+            if !AccessibilityCheck.isTrusted {
+                Log.priv.error("Space-swipe tap disabled and Accessibility not trusted — tearing down (no re-enable)")
+                let handler = onTapDisabledStorm
+                DispatchQueue.main.async { handler() }
+                return Unmanaged.passUnretained(event)
+            }
+            // Backstop for the AX-trusted timeout-loop case (and the brief race
+            // where the trust cache hasn't flipped yet): re-enable the first few
+            // disables, but once a burst is detected stop spinning and hand off.
+            let now = DispatchTime.now().uptimeNanoseconds
+            let storming = disableGate.withLock { gate -> Bool in
+                if now &- gate.lastNs > Self.disableBurstWindowNs { gate.count = 0 }
+                gate.lastNs = now
+                gate.count += 1
+                return gate.count > Self.maxRapidReenables
+            }
+            if storming {
+                Log.priv.error("Space-swipe tap disabled repeatedly (storm) — bailing to main-thread recovery")
+                let handler = onTapDisabledStorm
+                DispatchQueue.main.async { handler() }
+                return Unmanaged.passUnretained(event)
+            }
+            // Final trust re-check immediately before the re-enable closes the
+            // TOCTOU window since the check above (see HotkeyTap for the rationale):
+            // calling tapEnable on a just-untrusted active tap is itself a
+            // WindowServer-stalling IPC.
+            guard AccessibilityCheck.isTrusted else {
+                let handler = onTapDisabledStorm
+                DispatchQueue.main.async { handler() }
+                return Unmanaged.passUnretained(event)
+            }
+            // Re-enable inside the lock so a concurrent uninstall() (which nils the
+            // ports under the same lock) can't race us into re-enabling a tap it
+            // just tore down — see HotkeyTap.handle for the full rationale.
+            ports.withLock { state in
+                if let tap = state.tap {
+                    CGEvent.tapEnable(tap: tap, enable: true)
+                }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -1,370 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Choose which monitor the switcher opens on when you have more than one display." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lege fest, auf welchem Bildschirm sich der Umschalter öffnet, wenn du mehrere Bildschirme verwendest."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige en qué pantalla se abre el selector cuando tienes más de una pantalla."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez sur quel écran le sélecteur s’ouvre lorsque vous avez plusieurs écrans."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybierz, na którym ekranie ma się otwierać przełącznik, gdy masz więcej niż jeden ekran."
-          }
-        }
-      }
-    },
-    "Main display" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hauptbildschirm"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pantalla principal"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Écran principal"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekran główny"
-          }
-        }
-      }
-    },
-    "Monitor with the active window" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirm mit dem aktiven Fenster"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pantalla con la ventana activa"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Écran avec la fenêtre active"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekran z aktywnym oknem"
-          }
-        }
-      }
-    },
-    "Monitor with the cursor" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildschirm mit dem Zeiger"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pantalla con el puntero"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Écran avec le pointeur"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekran ze wskaźnikiem"
-          }
-        }
-      }
-    },
-    "Show switcher on" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umschalter anzeigen auf"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar el selector en"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher le sélecteur sur"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokaż przełącznik na"
-          }
-        }
-      }
-    },
-    "Apps kept visible: %lld." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sichtbar gehaltene Apps: %lld."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps que permanecen visibles: %lld."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps gardées visibles : %lld."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widoczne aplikacje: %lld."
-          }
-        }
-      }
-    },
-    "Chosen apps stay visible when you trigger Hide all windows." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählte Apps bleiben sichtbar, wenn du „Alle Fenster ausblenden“ auslöst."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las apps elegidas permanecen visibles al activar «Ocultar todas las ventanas»."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les apps choisies restent visibles lorsque vous déclenchez « Masquer toutes les fenêtres »."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybrane aplikacje pozostają widoczne po uruchomieniu „Ukryj wszystkie okna”."
-          }
-        }
-      }
-    },
-    "Hide all windows hides every app, Finder included. Pick apps to keep visible." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "„Alle Fenster ausblenden“ blendet jede App aus, auch den Finder. Wähle Apps, die sichtbar bleiben."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "«Ocultar todas las ventanas» oculta todas las apps, incluido el Finder. Elige apps que permanezcan visibles."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "« Masquer toutes les fenêtres » masque toutes les apps, Finder compris. Choisissez les apps à garder visibles."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "„Ukryj wszystkie okna” ukrywa każdą aplikację, łącznie z Finderem. Wybierz aplikacje, które mają pozostać widoczne."
-          }
-        }
-      }
-    },
-    "Keep apps visible" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps sichtbar lassen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantener apps visibles"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Garder des apps visibles"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozostaw aplikacje widoczne"
-          }
-        }
-      }
-    },
-    "Bring every hidden app back." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle ausgeblendeten Apps zurückholen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recupera todas las apps ocultas."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rétablir toutes les apps masquées."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przywróć wszystkie ukryte aplikacje."
-          }
-        }
-      }
-    },
-    "Hide all windows" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Fenster ausblenden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocultar todas las ventanas"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masquer toutes les fenêtres"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukryj wszystkie okna"
-          }
-        }
-      }
-    },
-    "Hide every app to reveal the desktop. Works system-wide." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Apps ausblenden, um den Schreibtisch anzuzeigen. Funktioniert systemweit."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oculta todas las apps para mostrar el escritorio. Funciona en todo el sistema."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masquer toutes les apps pour afficher le bureau. Fonctionne sur tout le système."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukryj wszystkie aplikacje, aby pokazać pulpit. Działa w całym systemie."
-          }
-        }
-      }
-    },
-    "Show all windows" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Fenster einblenden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar todas las ventanas"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher toutes les fenêtres"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokaż wszystkie okna"
-          }
-        }
-      }
-    },
     " — always shown first." : {
       "localizations" : {
         "de" : {
@@ -955,6 +591,34 @@
         }
       }
     },
+    "Applications only" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur Apps"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo aplicaciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applications uniquement"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tylko aplikacje"
+          }
+        }
+      }
+    },
     "Applies to the Grid and Previews layouts." : {
       "localizations" : {
         "de" : {
@@ -1007,6 +671,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aplikacje"
+          }
+        }
+      }
+    },
+    "Apps kept visible: %lld." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichtbar gehaltene Apps: %lld."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apps que permanecen visibles: %lld."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apps gardées visibles : %lld."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widoczne aplikacje: %lld."
           }
         }
       }
@@ -1204,6 +896,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niebieski"
+          }
+        }
+      }
+    },
+    "Bring every hidden app back." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle ausgeblendeten Apps zurückholen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recupera todas las apps ocultas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rétablir toutes les apps masquées."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przywróć wszystkie ukryte aplikacje."
           }
         }
       }
@@ -1603,6 +1323,34 @@
         }
       }
     },
+    "Choose which monitor the switcher opens on when you have more than one display." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lege fest, auf welchem Bildschirm sich der Umschalter öffnet, wenn du mehrere Bildschirme verwendest."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige en qué pantalla se abre el selector cuando tienes más de una pantalla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez sur quel écran le sélecteur s’ouvre lorsque vous avez plusieurs écrans."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz, na którym ekranie ma się otwierać przełącznik, gdy masz więcej niż jeden ekran."
+          }
+        }
+      }
+    },
     "Choose…" : {
       "localizations" : {
         "de" : {
@@ -1627,6 +1375,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wybierz…"
+          }
+        }
+      }
+    },
+    "Chosen apps stay visible when you trigger Hide all windows." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausgewählte Apps bleiben sichtbar, wenn du „Alle Fenster ausblenden“ auslöst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las apps elegidas permanecen visibles al activar «Ocultar todas las ventanas»."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les apps choisies restent visibles lorsque vous déclenchez « Masquer toutes les fenêtres »."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybrane aplikacje pozostają widoczne po uruchomieniu „Ukryj wszystkie okna”."
           }
         }
       }
@@ -1711,62 +1487,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kliknij na zewnątrz, aby zamknąć"
-          }
-        }
-      }
-    },
-    "Use h / j / k / l like the arrow keys while the switcher is open. h overrides the Hide binding and j / k / l override letter-jump; search mode still types those letters." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwende h / j / k / l wie die Pfeiltasten, während der Umschalter geöffnet ist. h überschreibt die Ausblenden-Belegung und j / k / l überschreiben den Buchstabensprung; im Suchmodus werden diese Buchstaben weiterhin eingegeben."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usa h / j / k / l como las teclas de flecha mientras el conmutador está abierto. h anula la asignación Ocultar y j / k / l anulan el salto por letra; el modo de búsqueda sigue escribiendo esas letras."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez h / j / k / l comme les touches fléchées lorsque le sélecteur est ouvert. h remplace le raccourci Masquer et j / k / l remplacent le saut de lettre ; le mode recherche saisit toujours ces lettres."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Używaj h / j / k / l jak klawiszy strzałek, gdy przełącznik jest otwarty. h zastępuje przypisanie Ukryj, a j / k / l zastępują skok literowy; tryb wyszukiwania nadal wpisuje te litery."
-          }
-        }
-      }
-    },
-    "Vim keys (h j k l)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vim-Tasten (h j k l)"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teclas vim (h j k l)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Touches vim (h j k l)"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klawisze vim (h j k l)"
           }
         }
       }
@@ -2947,6 +2667,62 @@
         }
       }
     },
+    "Hide all windows" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Fenster ausblenden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar todas las ventanas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer toutes les fenêtres"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukryj wszystkie okna"
+          }
+        }
+      }
+    },
+    "Hide all windows hides every app, Finder included. Pick apps to keep visible." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Alle Fenster ausblenden“ blendet jede App aus, auch den Finder. Wähle Apps, die sichtbar bleiben."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Ocultar todas las ventanas» oculta todas las apps, incluido el Finder. Elige apps que permanezcan visibles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "« Masquer toutes les fenêtres » masque toutes les apps, Finder compris. Choisissez les apps à garder visibles."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Ukryj wszystkie okna” ukrywa każdą aplikację, łącznie z Finderem. Wybierz aplikacje, które mają pozostać widoczne."
+          }
+        }
+      }
+    },
     "Hide app" : {
       "localizations" : {
         "de" : {
@@ -2971,6 +2747,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukryj aplikację"
+          }
+        }
+      }
+    },
+    "Hide every app to reveal the desktop. Works system-wide." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Apps ausblenden, um den Schreibtisch anzuzeigen. Funktioniert systemweit."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oculta todas las apps para mostrar el escritorio. Funciona en todo el sistema."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer toutes les apps pour afficher le bureau. Fonctionne sur tout le système."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukryj wszystkie aplikacje, aby pokazać pulpit. Działa w całym systemie."
           }
         }
       }
@@ -3027,6 +2831,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukryj ikonę ⌘. Otwórz to okno ponownie z poziomu Spotlight."
+          }
+        }
+      }
+    },
+    "Hide the app name in every layout; identify apps by their icon." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blendet den App-Namen in allen Layouts aus; Apps werden am Symbol erkannt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oculta el nombre de la aplicación en todas las disposiciones; identifica las apps por su icono."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masque le nom de l’application dans toutes les dispositions ; identifiez les apps par leur icône."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukrywa nazwę aplikacji we wszystkich układach; rozpoznawaj aplikacje po ikonie."
           }
         }
       }
@@ -3563,6 +3395,34 @@
         }
       }
     },
+    "Keep apps visible" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apps sichtbar lassen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener apps visibles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garder des apps visibles"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozostaw aplikacje widoczne"
+          }
+        }
+      }
+    },
     "Large" : {
       "localizations" : {
         "de" : {
@@ -4040,6 +3900,34 @@
         }
       }
     },
+    "Main display" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hauptbildschirm"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla principal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran principal"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran główny"
+          }
+        }
+      }
+    },
     "Manage apps" : {
       "localizations" : {
         "de" : {
@@ -4233,6 +4121,62 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zminimalizowane okna"
+          }
+        }
+      }
+    },
+    "Monitor with the active window" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm mit dem aktiven Fenster"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla con la ventana activa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran avec la fenêtre active"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran z aktywnym oknem"
+          }
+        }
+      }
+    },
+    "Monitor with the cursor" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm mit dem Zeiger"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla con el puntero"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran avec le pointeur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran ze wskaźnikiem"
           }
         }
       }
@@ -4601,34 +4545,6 @@
         }
       }
     },
-    "Orders the list by when you last focused each window, across all apps." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordnet die Liste danach, wann du jedes Fenster zuletzt fokussiert hast – über alle Apps hinweg."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordena la lista según cuándo enfocaste por última vez cada ventana, en todas las apps."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trie la liste selon le moment où vous avez activé chaque fenêtre pour la dernière fois, toutes apps confondues."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Porządkuje listę według tego, kiedy ostatnio aktywowano każde okno, we wszystkich aplikacjach."
-          }
-        }
-      }
-    },
     "Only current Space" : {
       "localizations" : {
         "de" : {
@@ -4715,6 +4631,7 @@
       }
     },
     "Open Settings" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -4850,6 +4767,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pomarańczowy"
+          }
+        }
+      }
+    },
+    "Orders the list by when you last focused each window, across all apps." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordnet die Liste danach, wann du jedes Fenster zuletzt fokussiert hast – über alle Apps hinweg."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordena la lista según cuándo enfocaste por última vez cada ventana, en todas las apps."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trie la liste selon le moment où vous avez activé chaque fenêtre pour la dernière fois, toutes apps confondues."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porządkuje listę według tego, kiedy ostatnio aktywowano każde okno, we wszystkich aplikacjach."
           }
         }
       }
@@ -6427,6 +6372,62 @@
         }
       }
     },
+    "Show all windows" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Fenster einblenden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar todas las ventanas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher toutes les fenêtres"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż wszystkie okna"
+          }
+        }
+      }
+    },
+    "Show application names" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Namen anzeigen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar nombres de aplicaciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les noms des applications"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuj nazwy aplikacji"
+          }
+        }
+      }
+    },
     "Show apps without windows" : {
       "localizations" : {
         "de" : {
@@ -6451,62 +6452,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pokazuj aplikacje bez okien"
-          }
-        }
-      }
-    },
-    "Applications only" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur Apps"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solo aplicaciones"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applications uniquement"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tylko aplikacje"
-          }
-        }
-      }
-    },
-    "Show one row per app instead of one per window — classic ⌘Tab." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine Zeile pro App statt pro Fenster – klassisches ⌘Tab."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra una fila por app en vez de una por ventana: ⌘Tab clásico."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affiche une ligne par app au lieu d’une par fenêtre — ⌘Tab classique."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokazuj jeden wiersz na aplikację zamiast na okno — klasyczny ⌘Tab."
           }
         }
       }
@@ -6651,6 +6596,34 @@
         }
       }
     },
+    "Show one row per app instead of one per window — classic ⌘Tab." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Zeile pro App statt pro Fenster – klassisches ⌘Tab."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra una fila por app en vez de una por ventana: ⌘Tab clásico."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche une ligne par app au lieu d’une par fenêtre — ⌘Tab classique."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuj jeden wiersz na aplikację zamiast na okno — klasyczny ⌘Tab."
+          }
+        }
+      }
+    },
     "Show only windows on the Space you're currently viewing." : {
       "localizations" : {
         "de" : {
@@ -6703,6 +6676,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pokazuj ostatnio zamknięte aplikacje"
+          }
+        }
+      }
+    },
+    "Show switcher on" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umschalter anzeigen auf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar el selector en"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le sélecteur sur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż przełącznik na"
           }
         }
       }
@@ -7886,6 +7887,34 @@
         }
       }
     },
+    "Use h / j / k / l like the arrow keys while the switcher is open. h overrides the Hide binding and j / k / l override letter-jump; search mode still types those letters." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwende h / j / k / l wie die Pfeiltasten, während der Umschalter geöffnet ist. h überschreibt die Ausblenden-Belegung und j / k / l überschreiben den Buchstabensprung; im Suchmodus werden diese Buchstaben weiterhin eingegeben."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa h / j / k / l como las teclas de flecha mientras el conmutador está abierto. h anula la asignación Ocultar y j / k / l anulan el salto por letra; el modo de búsqueda sigue escribiendo esas letras."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisez h / j / k / l comme les touches fléchées lorsque le sélecteur est ouvert. h remplace le raccourci Masquer et j / k / l remplacent le saut de lettre ; le mode recherche saisit toujours ces lettres."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Używaj h / j / k / l jak klawiszy strzałek, gdy przełącznik jest otwarty. h zastępuje przypisanie Ukryj, a j / k / l zastępują skok literowy; tryb wyszukiwania nadal wpisuje te litery."
+          }
+        }
+      }
+    },
     "v%@ — View Update" : {
       "localizations" : {
         "de" : {
@@ -7910,6 +7939,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "v%@ — Wyświetl aktualizację"
+          }
+        }
+      }
+    },
+    "Vim keys (h j k l)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vim-Tasten (h j k l)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teclas vim (h j k l)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touches vim (h j k l)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klawisze vim (h j k l)"
           }
         }
       }
@@ -8190,62 +8247,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Powiększ okno"
-          }
-        }
-      }
-    },
-    "Show application names" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Namen anzeigen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar nombres de aplicaciones"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher les noms des applications"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokazuj nazwy aplikacji"
-          }
-        }
-      }
-    },
-    "Hide the app name in every layout; identify apps by their icon." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blendet den App-Namen in allen Layouts aus; Apps werden am Symbol erkannt."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oculta el nombre de la aplicación en todas las disposiciones; identifica las apps por su icono."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masque le nom de l’application dans toutes les dispositions ; identifiez les apps par leur icône."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukrywa nazwę aplikacji we wszystkich układach; rozpoznawaj aplikacje po ikonie."
           }
         }
       }

--- a/BetterCmdTab/Settings/PrivacySettingsViewController.swift
+++ b/BetterCmdTab/Settings/PrivacySettingsViewController.swift
@@ -1,6 +1,6 @@
 import AppKit
+import BetterPermissions
 import BetterSettings
-import Combine
 
 @MainActor
 final class PrivacySettingsViewController: SettingsTabViewController {
@@ -12,8 +12,7 @@ final class PrivacySettingsViewController: SettingsTabViewController {
 
     private let restoreShortcutsButton = NSButton(title: "", target: nil, action: nil)
 
-    private var cancellables = Set<AnyCancellable>()
-    private var axTimer: Timer?
+    private var observationTask: Task<Void, Never>?
 
     override func setupContent() {
         // Screen-sharing section — hide the switcher panel from screen recording
@@ -42,7 +41,7 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         permissionButton.bezelStyle = .rounded
         permissionButton.controlSize = .small
         permissionButton.target = self
-        permissionButton.action = #selector(openSystemSettings)
+        permissionButton.action = #selector(grantAccess)
 
         let permissionAccessory = NSStackView()
         permissionAccessory.orientation = .horizontal
@@ -92,28 +91,43 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         super.viewWillAppear()
 
         hideFromScreenSharingSwitch.state = Preferences.shared.hideFromScreenSharing ? .on : .off
-        refreshAccessibilityStatus()
 
-        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
-            .sink { [weak self] _ in self?.refreshAccessibilityStatus() }
-            .store(in: &cancellables)
-
-        startAccessibilityPolling()
+        // Reactive accessibility status via BetterPermissions: yields the current value
+        // immediately, then every change (TCC notification / app activation / adaptive
+        // poll), replacing the hand-rolled 1 Hz timer + didBecomeActive observer. The
+        // engine disarms when this task is cancelled on disappear / memory release.
+        observationTask?.cancel() // never leak a second armed observation
+        observationTask = Task { @MainActor [weak self] in
+            for await snapshot in BetterPermissions.changes(.accessibility) {
+                self?.refreshAccessibilityStatus(isUsable: snapshot.status.isUsable)
+            }
+        }
     }
 
     override func viewWillDisappear() {
         super.viewWillDisappear()
-        stopAccessibilityPolling()
-        cancellables.removeAll()
+        observationTask?.cancel()
+        observationTask = nil
+    }
+
+    // BetterSettings can tear down the active tab (window close / memory eviction)
+    // without a matching viewWillDisappear, which would orphan the observation Task and
+    // leave the BetterPermissions accessibility detector armed for the process lifetime.
+    override func prepareForMemoryRelease() {
+        observationTask?.cancel()
+        observationTask = nil
+        super.prepareForMemoryRelease()
     }
 
     @objc private func toggleHideFromScreenSharing(_ sender: NSSwitch) {
         Preferences.shared.hideFromScreenSharing = (sender.state == .on)
     }
 
-    @objc private func openSystemSettings() {
-        AccessibilityCheck.promptIfNeeded()
-        AccessibilityCheck.openSystemSettings()
+    @objc private func grantAccess() {
+        Task { @MainActor in
+            let outcome = await BetterPermissions.request(.accessibility)
+            if outcome.needsSettings { BetterPermissions.openSettings(for: .accessibility) }
+        }
     }
 
     @objc private func restoreNativeShortcuts() {
@@ -123,41 +137,17 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         NotificationCenter.default.post(name: Notification.Name("BetterCmdTab_restoreNativeShortcuts"), object: nil)
     }
 
-    private func refreshAccessibilityStatus() {
-        if AccessibilityCheck.isTrusted {
+    private func refreshAccessibilityStatus(isUsable: Bool) {
+        if isUsable {
+            // Granted: show the state only — no actionable button.
             permissionIcon.image = NSImage(systemSymbolName: "checkmark.circle.fill", accessibilityDescription: String(localized: "Granted"))
             permissionIcon.contentTintColor = .systemGreen
-            permissionButton.title = String(localized: "Open Settings")
+            permissionButton.isHidden = true
         } else {
             permissionIcon.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: String(localized: "Required"))
             permissionIcon.contentTintColor = .systemOrange
+            permissionButton.isHidden = false
             permissionButton.title = String(localized: "Grant Access")
         }
-    }
-
-    private func startAccessibilityPolling() {
-        axTimer?.invalidate()
-        // Only the not-yet-granted state can change without re-activating the app
-        // (the user flips the toggle in System Settings while this pane stays up).
-        // Once trusted, stop the poll — `didBecomeActiveNotification` covers any
-        // later revoke-and-return — so we don't wake the main run loop at 1 Hz for
-        // the entire time the pane is parked open.
-        let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.refreshAndStopIfTrusted() }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        axTimer = timer
-    }
-
-    /// Refresh the permission badge and, once the permission is granted, stop the
-    /// poll — leaving the steady state driven only by `didBecomeActive`.
-    private func refreshAndStopIfTrusted() {
-        refreshAccessibilityStatus()
-        if AccessibilityCheck.isTrusted { stopAccessibilityPolling() }
-    }
-
-    private func stopAccessibilityPolling() {
-        axTimer?.invalidate()
-        axTimer = nil
     }
 }

--- a/BetterCmdTab/Switcher/HoverActionBar.swift
+++ b/BetterCmdTab/Switcher/HoverActionBar.swift
@@ -48,8 +48,22 @@ final class HoverActionBar: NSView {
         Spec(action: .forceQuit, symbol: "xmark.octagon.fill", color: .systemRed, tooltip: String(localized: "Force quit app")),
     ]
 
+    /// Whether the six dots have been materialized yet. Deferred so the
+    /// off-by-default hover-actions feature costs the pooled item views nothing:
+    /// building the dots means 6 `TrafficLightDot`s, each a constraint set + an
+    /// SF-Symbol render, on every newly-allocated row. With every dot empty the
+    /// bar's `contentSize` is `.zero` and it is never shown (the host item view
+    /// gates on `hasAnyEnabledButton`), so we only pay this once the user
+    /// actually enables an action — see `buildDotsIfNeeded`.
+    private var dotsBuilt = false
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
+    }
+
+    private func buildDotsIfNeeded() {
+        guard !dotsBuilt else { return }
+        dotsBuilt = true
         for spec in Self.specs {
             let dot = TrafficLightDot(action: spec.action, color: spec.color, symbol: spec.symbol, tooltip: spec.tooltip)
             dotsByAction[spec.action] = dot
@@ -128,6 +142,11 @@ final class HoverActionBar: NSView {
 
     /// Show/hide each dot per the user's per-action preferences.
     func applyEnabledButtons() {
+        // Don't materialize the dots for the off-by-default case: an unbuilt bar
+        // has zero `contentSize` and is never shown. Only build once at least one
+        // action is enabled.
+        guard hasAnyEnabledButton else { return }
+        buildDotsIfNeeded()
         let prefs = Preferences.shared
         dotsByAction[.close]?.isHidden = !prefs.hoverShowClose
         dotsByAction[.minimize]?.isHidden = !prefs.hoverShowMinimize

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -427,6 +427,27 @@ final class SwitcherController: SwitcherViewDelegate {
     /// drives the trigger meanwhile).
     private var hotkeyTapRetries = 0
     private static let maxHotkeyTapRetries = 5
+    /// Guards `handleTapDisabledStorm` against re-entry: a burst can post several
+    /// storm callbacks to main before the first one tears the tap down, and
+    /// without this each would schedule its own re-arm — leaking taps/threads.
+    /// Cleared once a tap install succeeds (`reinstallHotkeyTap` / retry).
+    private var tapStormRecovering = false
+    /// The pending `scheduleHotkeyTapRetry` work, held so a revoke (or a
+    /// successful re-arm) can CANCEL an in-flight retry before it fires. Without
+    /// this a stale retry can install a second tap over a freshly re-armed one,
+    /// orphaning the first — a leaked, still-enabled session tap + its thread.
+    private var hotkeyTapRetryWork: DispatchWorkItem?
+    /// Latches `handleAccessibilityRevoked` so the 2 s waiter poll and the tap
+    /// storm callback (which can both observe the same revoke) collapse to ONE
+    /// teardown instead of repeating the WindowServer re-enable IPC + the
+    /// UserDefaults write. Cleared on the next successful re-arm.
+    private var accessibilityRevoked = false
+    /// Pending bounded re-arm of the space-swipe suppressor after a transient
+    /// (AX-trusted) storm; cancellable on revoke/re-grant. See
+    /// `handleSwipeSuppressorStorm`.
+    private var swipeSuppressorReArmWork: DispatchWorkItem?
+    private var swipeSuppressorReArmRetries = 0
+    private static let maxSwipeSuppressorReArms = 3
 
     func start() {
         // The crash-safety guard install + stale symbolic-hotkey heal moved to
@@ -481,6 +502,11 @@ final class SwitcherController: SwitcherViewDelegate {
         // recomputed on every binding/layout change) into RowLabels so hint
         // generation never assigns a letter that's bound to an action.
         hotkey.onReservedLettersChanged = { letters in RowLabels.setReserved(letters) }
+        // The tap reported a re-enable storm (it keeps getting disabled — most
+        // often because Accessibility was revoked under an active session tap).
+        // Recover on main so the spinning tap thread can't keep freezing the
+        // whole system on WindowServer IPC.
+        hotkey.onTapDisabledStorm = { [weak self] in self?.handleTapDisabledStorm() }
         // The Carbon fallback drives the same handler as the tap.
         carbonTrigger.onEvent = { [weak self] event in self?.handle(event) }
         // Scoped-shortcut triggers open the switcher pre-filtered (#3).
@@ -560,13 +586,23 @@ final class SwitcherController: SwitcherViewDelegate {
         swipeTrigger.setOneShot(Preferences.shared.swipeMode != .openSwitcher)
         swipeTrigger.setEnabled(Preferences.shared.experimentalSwipeTrigger)
         // The swipe takes over three-finger horizontal Spaces navigation, so
-        // suppress the system Space-swipe whenever the swipe is enabled.
+        // suppress the system Space-swipe whenever the swipe is enabled. Wire the
+        // storm callback before installing the tap so a disable burst (e.g. on AX
+        // revoke) tears it down instead of freezing the system.
+        spaceSwipeSuppressor.onTapDisabledStorm = { [weak self] in self?.handleSwipeSuppressorStorm() }
         spaceSwipeSuppressor.setEnabled(Preferences.shared.experimentalSwipeTrigger)
         Preferences.shared.$experimentalSwipeTrigger
             .receive(on: DispatchQueue.main)
             .sink { [weak self] enabled in
                 self?.swipeTrigger.setEnabled(enabled)
-                self?.spaceSwipeSuppressor.setEnabled(enabled)
+                // Never install the suppressor's active session tap while AX is
+                // untrusted (it can't be durably enabled and would storm). The
+                // persisted pref is re-applied by reinstallHotkeyTap on re-grant.
+                if enabled && AccessibilityCheck.isTrusted {
+                    self?.spaceSwipeSuppressor.setEnabled(true)
+                } else {
+                    self?.spaceSwipeSuppressor.setEnabled(false)
+                }
             }
             .store(in: &cancellables)
         Preferences.shared.$swipeReverseDirection
@@ -625,7 +661,13 @@ final class SwitcherController: SwitcherViewDelegate {
             .sink { [weak self] _ in self?.updateTriggerSuppression() }
             .store(in: &cancellables)
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+        // Warm the item-view pool, glass layer and autolayout now (start() runs
+        // only after AX trust, so this panel machinery is the only cold thing
+        // left) rather than 0.5s later — a chord fired inside that first half
+        // second otherwise pays the first-use NSVisualEffect/glass + autolayout
+        // allocation spike synchronously on the show path. Deferred one run-loop
+        // turn so start() returns first; the warm completes long before any chord.
+        DispatchQueue.main.async { [weak self] in
             self?.prewarmPanel()
         }
     }
@@ -1003,9 +1045,25 @@ final class SwitcherController: SwitcherViewDelegate {
     /// and create a fresh one. Trigger config, panel keymaps and the Carbon
     /// fallback already live on the instance, so nothing else needs re-pushing.
     func reinstallHotkeyTap() {
+        // A re-grant ENDS the revoke episode — clear the latch here, NOT on install
+        // success: if this install fails into the retry chain, the latch must
+        // already be open so a fresh revoke during the retry window still tears the
+        // tap down and restores native ⌘Tab (else: dead switcher).
+        accessibilityRevoked = false
+        // A re-grant is an authoritative recovery boundary: cancel any pending
+        // storm/boot retry so it can't fire after this and double-install.
+        hotkeyTapRetryWork?.cancel()
+        hotkeyTapRetryWork = nil
+        swipeSuppressorReArmWork?.cancel()
+        swipeSuppressorReArmWork = nil
+        swipeSuppressorReArmRetries = 0
         hotkey.uninstall()
+        // Re-arm the space-swipe suppressor too (torn down on revoke), gated on
+        // the swipe pref so it only comes back if the experimental swipe is on.
+        spaceSwipeSuppressor.setEnabled(Preferences.shared.experimentalSwipeTrigger)
         if hotkey.install() {
             hotkeyTapRetries = 0
+            tapStormRecovering = false
             Log.switcher.log("CGEventTap re-armed after Accessibility re-grant")
         } else {
             Log.switcher.error("CGEventTap re-arm failed after Accessibility re-grant; retrying")
@@ -1021,12 +1079,97 @@ final class SwitcherController: SwitcherViewDelegate {
     /// switcher works until trust returns; `reassertNativeOverrideAfterRegrant()`
     /// re-disables it once AX is back.
     func handleAccessibilityRevoked() {
+        // Collapse the fan-in: the 2 s waiter poll and the tap storm callback can
+        // both observe the same revoke. Run the teardown once per revoke episode
+        // (`reinstallHotkeyTap` clears this latch on re-grant).
+        guard !accessibilityRevoked else { return }
+        accessibilityRevoked = true
+        // Revoke is an authoritative recovery boundary: kill any in-flight tap
+        // install retry and reset its budget so a stale retry can't resurrect a
+        // tap mid-revoke or double-install after the next re-grant, and so a
+        // future storm (post re-grant) starts with a clean retry budget.
+        hotkeyTapRetryWork?.cancel()
+        hotkeyTapRetryWork = nil
+        hotkeyTapRetries = 0
+        tapStormRecovering = false
+        swipeSuppressorReArmWork?.cancel()
+        swipeSuppressorReArmWork = nil
+        swipeSuppressorReArmRetries = 0
+        // If the switcher panel is on-screen when AX is revoked, the dead tap can
+        // no longer deliver its dismissal keys (Cmd-release / commit / Esc), so the
+        // panel would be stranded with no input path and the re-armed tap would
+        // later start out of phase with the controller. Force the UI to idle first
+        // — `cancel()` needs no AX and no live tap: it pushes the idle flags onto
+        // the (still-present) hotkey instance and dismisses the panel.
+        if phase != .idle { cancel() }
+        // Tear down the now-useless CGEvent tap. An active session tap whose
+        // process is no longer AX-trusted cannot be durably re-enabled — the
+        // WindowServer keeps disabling it — so leaving it installed lets its
+        // re-enable path storm and freeze all system input. `reinstallHotkeyTap()`
+        // re-arms it on re-grant; the Carbon + native symbolic ⌘Tab cover the
+        // trigger meanwhile.
+        hotkey.uninstall()
+        // The space-swipe suppressor is a SECOND active session tap with the same
+        // failure mode — left installed it storms on revoke and freezes the whole
+        // system too. Tear it down here; `reinstallHotkeyTap()` re-arms it (gated
+        // on the swipe pref) once Accessibility returns.
+        spaceSwipeSuppressor.setEnabled(false)
         let toReEnable: [PrivateAPI.SymbolicHotKey] = disabledSymbolicKeys.isEmpty
             ? [.commandTab, .commandShiftTab, .commandKeyAboveTab]
             : disabledSymbolicKeys
         PrivateAPI.setNativeCommandTabEnabled(true, toReEnable)
         disabledSymbolicKeys = []
         persistDisabledSymbolicKeys([])
+    }
+
+    /// The tap signalled a re-enable storm (the WindowServer keeps disabling it).
+    /// Runs on main. Tear the tap down so its thread stops spinning in
+    /// WindowServer IPC, then either leave it down (Accessibility revoked — the
+    /// waiter re-arms on re-grant) or re-arm it on a backoff (a transient
+    /// WindowServer / timeout storm with AX still granted).
+    private func handleTapDisabledStorm() {
+        guard !tapStormRecovering else { return }
+        tapStormRecovering = true
+        if AccessibilityCheck.isTrusted {
+            Log.switcher.error("CGEventTap storm with Accessibility trusted — re-arming on backoff")
+            hotkey.uninstall()
+            scheduleHotkeyTapRetry()
+        } else {
+            Log.switcher.error("CGEventTap storm — Accessibility revoked; tap torn down, native ⌘Tab restored")
+            // Restores the native symbolic ⌘Tab and tears the tap down (it calls
+            // `hotkey.uninstall()`), so the user keeps a working switcher and the
+            // storm cannot resume. The waiter re-arms our tap on re-grant.
+            handleAccessibilityRevoked()
+        }
+    }
+
+    /// The space-swipe suppressor tap signalled a re-enable storm. Runs on main.
+    /// The tap is non-essential, so just tear it down (its thread stops spinning
+    /// in WindowServer IPC). It re-arms on Accessibility re-grant via
+    /// `reinstallHotkeyTap()`, gated on the swipe pref. Idempotent — safe to call
+    /// from several storm callbacks queued before the first teardown lands.
+    private func handleSwipeSuppressorStorm() {
+        Log.switcher.error("Space-swipe suppressor tap storm — tearing it down")
+        spaceSwipeSuppressor.setEnabled(false)
+        // Asymmetry fix: if AX is still trusted this is a TRANSIENT storm, not a
+        // revoke (the suppressor's own !isTrusted bail handles revoke). Re-arm on
+        // a bounded backoff so a transient storm doesn't silently kill swipe
+        // suppression for the rest of the run. Capped to avoid teardown/re-arm
+        // thrash on a persistent storm; the cap resets on the next AX re-grant.
+        // Gated on the swipe pref so it never resurrects a disabled feature.
+        guard AccessibilityCheck.isTrusted,
+              Preferences.shared.experimentalSwipeTrigger,
+              swipeSuppressorReArmRetries < Self.maxSwipeSuppressorReArms else { return }
+        swipeSuppressorReArmRetries += 1
+        swipeSuppressorReArmWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.swipeSuppressorReArmWork = nil
+            guard AccessibilityCheck.isTrusted, Preferences.shared.experimentalSwipeTrigger else { return }
+            self.spaceSwipeSuppressor.setEnabled(true)
+        }
+        swipeSuppressorReArmWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
     }
 
     /// Accessibility was re-granted at runtime. After `reinstallHotkeyTap()`
@@ -1037,27 +1180,57 @@ final class SwitcherController: SwitcherViewDelegate {
         syncNativeHotkeyOverride()
     }
 
-    /// Retry a failed `hotkey.install()` on a short backoff. Only reached after an
-    /// install that left the tap uncreated, so a plain `install()` (not a
-    /// reinstall) is safe — there is no live tap to leak. Gives up after
-    /// `maxHotkeyTapRetries`; the Carbon fallback keeps the trigger working
-    /// regardless, and a later Accessibility re-grant re-arms via the waiter.
+    /// Retry a failed `hotkey.install()` on a short backoff. The work is held in
+    /// `hotkeyTapRetryWork` so a revoke / re-grant can cancel it, the closure
+    /// bails if AX dropped meanwhile, and `HotkeyTap.install()` is itself
+    /// idempotent — three independent guards against a stale retry installing a
+    /// second tap over a live one. Gives up after `maxHotkeyTapRetries` (resetting
+    /// the recovery state so a future storm can retry); the Carbon fallback keeps
+    /// the trigger working regardless, and a later Accessibility re-grant re-arms
+    /// via the waiter.
     private func scheduleHotkeyTapRetry() {
         guard hotkeyTapRetries < Self.maxHotkeyTapRetries else {
             Log.switcher.error("CGEventTap still failing after \(Self.maxHotkeyTapRetries) retries; relying on the Carbon fallback")
+            // Recovery is no longer in flight: clear the storm guard and reset the
+            // budget so a FUTURE storm can re-attempt recovery. Without this,
+            // `tapStormRecovering` sticks true forever and every later storm is a
+            // permanent no-op while AX stays trusted (the waiter only re-arms on an
+            // untrusted→trusted transition, which never fires if AX never dropped).
+            tapStormRecovering = false
+            hotkeyTapRetries = 0
+            hotkeyTapRetryWork = nil
             return
         }
         hotkeyTapRetries += 1
         let attempt = hotkeyTapRetries
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+        let work = DispatchWorkItem { [weak self] in
             guard let self else { return }
+            self.hotkeyTapRetryWork = nil
+            // AX revoked while this retry was pending? Stop the chain — the waiter's
+            // re-grant path (`reinstallHotkeyTap`) is the correct re-arm trigger and
+            // resets the budget itself. Prevents installing an active tap while
+            // untrusted (which would only storm).
+            guard AccessibilityCheck.isTrusted else {
+                self.hotkeyTapRetries = 0
+                self.tapStormRecovering = false
+                return
+            }
             if self.hotkey.install() {
                 self.hotkeyTapRetries = 0
+                self.tapStormRecovering = false
+                self.accessibilityRevoked = false
+                // A shared-WindowServer storm takes BOTH session taps down
+                // together, but only the hotkey tap has a retry — re-arm the
+                // suppressor alongside on success, gated on the swipe pref.
+                self.swipeSuppressorReArmRetries = 0
+                self.spaceSwipeSuppressor.setEnabled(Preferences.shared.experimentalSwipeTrigger)
                 Log.switcher.log("CGEventTap installed on retry \(attempt)")
             } else {
                 self.scheduleHotkeyTapRetry()
             }
         }
+        hotkeyTapRetryWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
     }
 
     func shutdown() {
@@ -1749,9 +1922,12 @@ final class SwitcherController: SwitcherViewDelegate {
         prewarmBrowserTabs()
         revealTimer?.invalidate()
         let timer = Timer(timeInterval: revealDelay, repeats: false) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.reveal()
-            }
+            // The timer already fires on the main run loop (added below), so run
+            // reveal() inline instead of bouncing through `Task { @MainActor }`:
+            // that hop cost an extra executor turn and, under a main-thread
+            // notification storm, queued reveal() behind every other pending
+            // MainActor task at the exact moment the panel should appear.
+            MainActor.assumeIsolated { self?.reveal() }
         }
         RunLoop.main.add(timer, forMode: .common)
         revealTimer = timer

--- a/BetterCmdTab/System/DebuggerCheck.swift
+++ b/BetterCmdTab/System/DebuggerCheck.swift
@@ -1,0 +1,31 @@
+import Darwin
+
+/// Whether a debugger (LLDB / Xcode) is currently attached to this process.
+///
+/// This matters for the CGEvent taps. An ACTIVE session tap (`.defaultTap`)
+/// makes the WindowServer block ALL system input until the tap callback returns.
+/// Under the debugger the callback thread can be suspended at any moment — at a
+/// breakpoint, on a caught signal, or the instant Accessibility is revoked (LLDB
+/// stops the process) — and the WindowServer then waits forever for a callback
+/// that never returns, hard-freezing the whole machine with no way to reach
+/// Xcode's Stop button (hard reboot required). So while a debugger is attached we
+/// create the taps `.listenOnly` instead: a listen-only tap is delivered copies
+/// of events, can neither modify nor delay them, and never blocks the
+/// WindowServer — a suspended callback thread can no longer freeze input. The
+/// only cost is that event *swallowing* (return `nil`) is a no-op while debugging
+/// (native ⌘Tab is still suppressed via the symbolic-hotkey API, and panel
+/// navigation still works), which is an acceptable debug-only degradation.
+enum DebuggerCheck {
+    /// Apple Technical Q&A QA1361: a process is being traced when its
+    /// `kinfo_proc` carries the `P_TRACED` flag. Cheap local `sysctl`, no IPC.
+    /// Evaluated once — a debugger is attached at launch (Xcode Run) and the
+    /// tap-install paths read it at install time.
+    static let isAttached: Bool = {
+        var info = kinfo_proc()
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        var size = MemoryLayout<kinfo_proc>.stride
+        let result = sysctl(&mib, u_int(mib.count), &info, &size, nil, 0)
+        guard result == 0 else { return false }
+        return (info.kp_proc.p_flag & P_TRACED) != 0
+    }()
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,29 @@ Signing/notarization needs the `Developer ID Application: Artur Rok (N529W98U62)
 and the `BetterCmdTabNotarization` notarytool keychain profile (see the script header).
 `.github/workflows/sign-release.yml` runs signing in CI.
 
+### Changelog format (the release body)
+
+The changelog *is* the GitHub Release body (no `CHANGELOG.md`). Pass it to
+`build_release.sh --auto-release --notes notes.md`, or write it after the fact with
+`gh release create <tag> -R rokartur/BetterCmdTab --title "BetterCmdTab <version>" --notes-file notes.md`.
+Tags carry a `v` prefix for stable releases (`v26.4.3`) and a bare `MAJOR.MINOR-beta.N` for
+prereleases (`26.0-beta.1`, published with `--prerelease`); `MAJOR` tracks the macOS year.
+
+Match the established BetterCmdTab body shape — this is an end-user app, so bullets are
+**user-facing and outcome-first**, not internal symbol names:
+
+- **First line** is `## Highlights` — a one/two-sentence summary of what the release delivers.
+- Then `### Added`, `### Changed`, `### Fixed`, `### Removed` as they apply (omit empty sections).
+- Each bullet describes the observable behavior change for the user — what now works / changed,
+  not which type was renamed. Exclude `chore`/`refactor`/`build`/`test`/`ci`/`docs`-only changes.
+- End with a compare footer for any release with a predecessor (blank line before it):
+  ```
+  **Full changelog:** https://github.com/rokartur/BetterCmdTab/compare/<prev-tag>...<tag>
+  ```
+
+(Library packages in the `Better*` family — `BetterSettings`, `BetterUpdater`, etc. — use the same
+structure but with technical, API-level bullets; see their `CLAUDE.md`.)
+
 ## Architecture
 
 macOS menu-bar (`.accessory`) app, **AppKit only** — no SwiftUI, no Catalyst, no


### PR DESCRIPTION
## Summary

Bundles the pending uncommitted work, headlined by a fix for a whole-system input freeze on Accessibility revoke.

### Fixed
- **Whole-system freeze on Accessibility revoke.** Two active `.cgSessionEventTap` taps (`HotkeyTap`, `SpaceSwipeSuppressor`) make the WindowServer block all input until their callback returns. On revoke the WindowServer disabled the tap and the callback re-enabled it unconditionally, pinning the tap thread in synchronous WindowServer IPC → whole-machine freeze; under the Xcode debugger the suspended callback thread froze it hard (reboot required).
  - `DisableGate` storm gate caps rapid re-enables, then bails to a main-thread teardown.
  - Taps are created `.listenOnly` while a debugger is attached (`DebuggerCheck`, `sysctl` `P_TRACED`) so a suspended callback can't block the WindowServer; production stays `.defaultTap` with full suppression.
  - Both taps torn down on revoke, re-armed on re-grant.
  - Lifecycle hardening: idempotent `HotkeyTap.install()`, cancellable install retry, `accessibilityRevoked` latch (collapses waiter + storm fan-in), give-up-branch resets, re-enable inside the ports lock (closes an uninstall/handle race).
  - Revoke alert now centered (`NSAlert.runModal` after activating the accessory app) instead of a titlebar sheet.

### Changed
- Privacy pane's Accessibility row is now reactive via `BetterPermissions` (`changes`/`request`/`openSettings`), replacing the hand-rolled timer/observer. Adds the remote `rokartur/BetterPermissions` SPM dependency.

### Performance
- Prewarm top MRU app icons off the show path (bounded, chunked on the main actor) so the first reveal doesn't flatten icons synchronously.
- Defer building `HoverActionBar`'s dots until an action is enabled.
- Dispatch Carbon hot-key events inline (already on the main run loop) instead of an extra hop.

## Verification
- Release build (Liquid Glass) + Debug build: succeed.
- Test suite: **223 tests, 27 suites, all pass.**
- Known accepted behavior: the Privacy row updates on grant but not on a runtime revoke (cached `AXIsProcessTrusted` stays stale-true on revoke); the app stays stable on revoke regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
