### PR TITLE
fix: pre-release i18n + nonisolated-metric cleanup

### DIFF
--- a/BetterCmdTab/App/SettingsPortability.swift
+++ b/BetterCmdTab/App/SettingsPortability.swift
@@ -45,9 +45,9 @@ extension Preferences {
         var errorDescription: String? {
             switch self {
             case .malformed:
-                return "This file isn't a valid BetterCmdTab settings export."
+                return String(localized: "This file isn't a valid BetterCmdTab settings export.")
             case .unsupportedVersion(let v):
-                return "This settings file uses a newer format (version \(v)) than this version of BetterCmdTab can read. Update the app and try again."
+                return String(localized: "This settings file uses a newer format (version \(v)) than this version of BetterCmdTab can read. Update the app and try again.")
             }
         }
     }

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -7577,6 +7577,62 @@
         }
       }
     },
+    "This file isn't a valid BetterCmdTab settings export." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Datei ist kein gültiger BetterCmdTab-Einstellungsexport."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este archivo no es una exportación de ajustes de BetterCmdTab válida."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier n'est pas un export de réglages BetterCmdTab valide."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten plik nie jest prawidłowym eksportem ustawień BetterCmdTab."
+          }
+        }
+      }
+    },
+    "This settings file uses a newer format (version %lld) than this version of BetterCmdTab can read. Update the app and try again." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Einstellungsdatei verwendet ein neueres Format (Version %lld), als diese Version von BetterCmdTab lesen kann. Aktualisiere die App und versuche es erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este archivo de ajustes usa un formato más reciente (versión %lld) del que esta versión de BetterCmdTab puede leer. Actualiza la app e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier de réglages utilise un format plus récent (version %lld) que celui que cette version de BetterCmdTab peut lire. Mettez l'app à jour et réessayez."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten plik ustawień używa nowszego formatu (wersja %lld), niż potrafi odczytać ta wersja BetterCmdTab. Zaktualizuj aplikację i spróbuj ponownie."
+          }
+        }
+      }
+    },
     "Three-finger swipe" : {
       "localizations" : {
         "de" : {

--- a/BetterCmdTab/Switcher/HoverActionBar.swift
+++ b/BetterCmdTab/Switcher/HoverActionBar.swift
@@ -16,8 +16,8 @@ final class HoverActionBar: NSView {
     /// Base dot diameter at scale 1.0; the live diameter scales with the
     /// switcher's current size so the buttons read at the same relative
     /// weight on every panel size.
-    static let baseDotSize: CGFloat = 14
-    private static let baseSpacing: CGFloat = 5
+    nonisolated static let baseDotSize: CGFloat = 14
+    nonisolated private static let baseSpacing: CGFloat = 5
 
     /// Live scale factor; set by the host item view from `metrics.scale`.
     private var scaleFactor: CGFloat = 1.0


### PR DESCRIPTION
Pre-release production-readiness pass. Two fixes surfaced by a full-app audit + build.

### Fixed
- **Localize settings-import error alerts** — `SettingsImportError.errorDescription` returned raw English for `.malformed` / `.unsupportedVersion`, shown verbatim in an `NSAlert` on a failed Import. de/es/fr/pl users saw English while the rest of the app is fully localized. Wrapped in `String(localized:)` + added both keys (incl. the `%lld` version interpolation) to `Localizable.xcstrings` with de/es/fr/pl.
- **`HoverActionBar` base metrics `nonisolated`** — `contentWidth(visibleCount:scale:)` is `nonisolated` so `SwitcherMetrics` can reserve the action-bar column off the main thread, but it read main-actor-isolated statics `baseDotSize`/`baseSpacing` → Swift 6 future-error warning + a real off-main read of actor state. Both are immutable `Sendable` `CGFloat` constants, so marked `nonisolated`. Restores the 0-warning build, no behavior change.

### Verification
- Build: `BetterCmdTab Debug` — **0 warnings / 0 errors**
- Tests: **223/223 pass** (27 suites), incl. `Settings portability` round-trip

### Context
Audit (35-agent fan-out across 10 subsystem units → 3-lens adversarial verify) found **no blockers**. The one alleged crash (`refreshDisplay` empty-rows) was rejected as a false alarm — the empty state is the designed "No results" search panel. Three low/nit hygiene items deferred post-ship (`zoomWindow` result discard, `AppCatalogCache.deinit` observer-removal symmetry, `axBounds` messaging timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)