### PR TITLE
fix: remember each app's last-used window on switch (#30)

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -2294,17 +2294,23 @@ final class SwitcherController: SwitcherViewDelegate {
         refreshDisplay()
     }
 
-    /// Apply the flat cross-app window-recency sort when `.mruWindows` is the
-    /// active order; a no-op otherwise so the default ⌘Tab path stays untouched.
+    /// Apply window-recency ordering. In `.mruWindows` the whole list is sorted
+    /// by flat cross-app window recency; in the app-grouped orders (`.mru`,
+    /// `.alphabetical`, `.launchOrder`) the app order is left alone but each
+    /// app's windows are floated into most-recently-used order, so the window
+    /// that collapses to the app's row — or that a per-window list opens on —
+    /// is the one last focused in that app, not its catalog z-order head (#30).
     /// Runs after hide/scope filtering and before browser-tab expansion, so tabs
-    /// inherit their parent window's global rank and move together as a block.
+    /// inherit their parent window's rank and move together as a block.
     ///
     /// The recency sort reorders the whole list, discarding the pin-to-front
     /// ordering `filteredRows` applied upstream, so re-pin afterwards: pinned
     /// apps stay at the front and their windows keep recency order within the
     /// pin block (the partition is stable on offset).
     private func applyWindowMRUSort(_ rows: [SwitcherRow]) -> [SwitcherRow] {
-        guard Preferences.shared.sortOrder == .mruWindows else { return rows }
+        guard Preferences.shared.sortOrder == .mruWindows else {
+            return windowMRU.sortWindowsWithinApps(rows)
+        }
         // Re-base onto a frontmost-independent order before the recency sort.
         // The incoming rows are app-MRU ordered, so the *currently active* app's
         // windows lead the list; windows the tracker has never seen would then
@@ -2691,18 +2697,21 @@ final class SwitcherController: SwitcherViewDelegate {
         return candidates[target]
     }
 
-    /// The row the visible switcher would activate for `app`: its frontmost
-    /// catalogued window. The catalog gives an app either one windowless row or
-    /// one row per window (windowed rows sort first), so the first windowed row
-    /// for the pid is the frontmost — matching reveal()'s `firstIndex(by: pid)`
-    /// pick. Reads the warm cache ONLY: this runs inside commit() on the main
-    /// actor (the hottest path), so it must never trigger a synchronous
-    /// cross-process AppCatalog.snapshot(). nil — a windowless app, or the brief
-    /// cold-cache window at boot/AX-regrant — makes the caller fall back to the
-    /// cheap, main-safe `activateApp`.
+    /// The row the visible switcher would activate for `app`: its most-recently-
+    /// used window. The catalog orders an app's windows by z-order, which lags
+    /// real focus recency, so picking the first windowed row forgot which window
+    /// you last used when you switched away and back (#30). Sort the pid's
+    /// windowed rows through the window-MRU tracker (the same pick reveal() lands
+    /// on after `applyWindowMRUSort`) and take its head. Reads the warm cache
+    /// ONLY: this runs inside commit() on the main actor (the hottest path), so
+    /// it must never trigger a synchronous cross-process AppCatalog.snapshot().
+    /// nil — a windowless app, or the brief cold-cache window at boot/AX-regrant
+    /// — makes the caller fall back to the cheap, main-safe `activateApp`.
     private func primedAppTargetRow(for app: NSRunningApplication) -> SwitcherRow? {
         let pid = app.processIdentifier
-        return cache.rows(orderedBy: mru.order).first(where: { $0.pid == pid && $0.window != nil })
+        let candidates = cache.rows(orderedBy: mru.order).filter { $0.pid == pid && $0.window != nil }
+        guard !candidates.isEmpty else { return nil }
+        return windowMRU.sortRows(candidates, forPid: pid).first
     }
 
     /// The window row a `.mruWindows` fast tap-release should activate: the
@@ -3537,7 +3546,7 @@ final class SwitcherController: SwitcherViewDelegate {
                 // Collapse to one row per app when "Applications only" is on — the
                 // reveal paths do this; without it the first in-panel window action's
                 // refresh would re-expand the panel to one row per window.
-                self.baseRows = self.expandBrowserTabs(self.applyApplicationsOnly(fresh))
+                self.baseRows = self.expandBrowserTabs(self.applyApplicationsOnly(self.applyWindowMRUSort(fresh)))
                 self.baseLabels = RowLabels.labels(for: self.baseRows)
                 self.refreshDisplay()
                 self.scheduleBrowserTabExpansion()

--- a/BetterCmdTab/Windows/WindowMRUTracker.swift
+++ b/BetterCmdTab/Windows/WindowMRUTracker.swift
@@ -98,6 +98,77 @@ final class WindowMRUTracker {
         return sorted
     }
 
+    /// Reorder `rows` so each app's windows lead in most-recently-used order
+    /// while the apps themselves — and any windowless / pid-less rows — keep
+    /// their incoming relative position. The app-grouped sort orders (`.mru`,
+    /// `.alphabetical`, `.launchOrder`) leave an app's windows in catalog
+    /// z-order, which lags real focus recency, so the window that collapses to
+    /// the app's row (and the window a per-window list opens on) was the wrong
+    /// one — switching away from an app and back forgot the last window you used
+    /// (#30). Float each app's last-focused window to the head of its group so
+    /// that pick is correct. Windows the tracker has never seen keep their
+    /// incoming order, so untouched apps are never disturbed.
+    func sortWindowsWithinApps(_ rows: [SwitcherRow]) -> [SwitcherRow] {
+        guard !order.isEmpty, rows.count > 1 else { return rows }
+        let pids = rows.map(\.pid)
+        let wids = rows.map { row -> CGWindowID in
+            row.cgWindowID != 0 ? row.cgWindowID : (row.window.map { PrivateAPI.cgWindowId(of: $0) } ?? 0)
+        }
+        return Self.windowOrderWithinApps(pids: pids, wids: wids, order: order).map { rows[$0] }
+    }
+
+    /// Pure index-level core of `sortWindowsWithinApps`, split out so it can be
+    /// unit-tested without constructing `NSRunningApplication`s. Returns the row
+    /// indices in their reordered position. Reordering happens ONLY within a
+    /// *contiguous* run of same-pid rows: within a run windows lead by their rank
+    /// in `order[pid]` (windowless / unseen windows fall to the run's back at
+    /// `Int.max`, stable on offset); the runs themselves stay put. Restricting to
+    /// contiguous runs preserves the caller's global status bucketing — incoming
+    /// rows arrive grouped as normal → minimized → hidden, so an app's normal and
+    /// minimized windows sit in separate runs and never merge — while still
+    /// floating the most-recently-used window to the head of the run that the
+    /// app's row collapses from. pid-less rows (launchables / recently-closed)
+    /// are each their own one-element run and hold their slot.
+    static func windowOrderWithinApps(
+        pids: [pid_t?],
+        wids: [CGWindowID],
+        order: [pid_t: [CGWindowID]]
+    ) -> [Int] {
+        let n = pids.count
+        // Group key = start offset of the contiguous run this row belongs to. A
+        // run continues only while the pid is the same non-nil value as the row
+        // before it, so non-contiguous occurrences of a pid (split across status
+        // buckets) and every pid-less row start fresh runs.
+        var runStart = [Int](repeating: 0, count: n)
+        var start = 0
+        for i in 0..<n {
+            if i == 0 || pids[i] == nil || pids[i] != pids[i - 1] { start = i }
+            runStart[i] = start
+        }
+        // Per-pid wid→rank lookup, built lazily the first time a pid is seen.
+        var rankByPid: [pid_t: [CGWindowID: Int]] = [:]
+        func winRank(pid: pid_t, wid: CGWindowID) -> Int {
+            guard wid != 0 else { return Int.max }
+            if rankByPid[pid] == nil {
+                var ranks: [CGWindowID: Int] = [:]
+                if let list = order[pid] {
+                    for (idx, w) in list.enumerated() { ranks[w] = idx }
+                }
+                rankByPid[pid] = ranks
+            }
+            return rankByPid[pid]?[wid] ?? Int.max
+        }
+        let ranks = (0..<n).map { i -> Int in
+            guard let pid = pids[i] else { return Int.max }
+            return winRank(pid: pid, wid: wids[i])
+        }
+        return (0..<n).sorted { a, b in
+            if runStart[a] != runStart[b] { return runStart[a] < runStart[b] }
+            if ranks[a] != ranks[b] { return ranks[a] < ranks[b] }
+            return a < b
+        }
+    }
+
     /// Re-orders `rows` by flat cross-app window recency (the `.mruWindows`
     /// sort): each window sorts by its rank in `globalOrder`, newest first,
     /// interleaving windows of different apps. Windowless rows (`cgWindowID == 0`)

--- a/BetterCmdTab/Windows/WindowMRUTracker.swift
+++ b/BetterCmdTab/Windows/WindowMRUTracker.swift
@@ -129,7 +129,7 @@ final class WindowMRUTracker {
     /// floating the most-recently-used window to the head of the run that the
     /// app's row collapses from. pid-less rows (launchables / recently-closed)
     /// are each their own one-element run and hold their slot.
-    static func windowOrderWithinApps(
+    nonisolated static func windowOrderWithinApps(
         pids: [pid_t?],
         wids: [CGWindowID],
         order: [pid_t: [CGWindowID]]

--- a/BetterCmdTabTests/WindowMRUTrackerTests.swift
+++ b/BetterCmdTabTests/WindowMRUTrackerTests.swift
@@ -110,3 +110,88 @@ struct WindowMRUTrackerTests {
         #expect(sorted.map(\.cgWindowID) == [10, 0])
     }
 }
+
+/// Covers the per-app within-group ordering (`sortWindowsWithinApps`) that backs
+/// the app-grouped sort orders — the fix for #30, where switching away from an
+/// app and back forgot which window you last used. Exercised through the pure
+/// index core `windowOrderWithinApps`, which takes `(pid, wid)` arrays so it can
+/// span multiple apps without constructing `NSRunningApplication`s.
+@Suite("WindowMRUTracker within-app sort")
+struct WindowMRUTrackerWithinAppTests {
+    private func order(_ pairs: [pid_t: [CGWindowID]]) -> [pid_t: [CGWindowID]] { pairs }
+
+    @Test("floats each app's most-recent window to its group head")
+    func floatsRecentWindowToHead() {
+        // App 1 last focused window 11 (after 10); app 2 last focused 20.
+        let o = order([1: [11, 10], 2: [20, 21]])
+        // Incoming catalog order has 10 ahead of 11 (z-order lag).
+        let pids: [pid_t?] = [1, 1, 2, 2]
+        let wids: [CGWindowID] = [10, 11, 21, 20]
+        let result = WindowMRUTracker.windowOrderWithinApps(pids: pids, wids: wids, order: o)
+        // App order preserved (app 1 then app 2); within each, MRU window leads.
+        #expect(result == [1, 0, 3, 2])
+    }
+
+    @Test("preserves app order even when a later app was focused more recently")
+    func keepsAppOrder() {
+        // App 2's window was focused most recently, but app order must not change
+        // — only windows within an app reorder.
+        let o = order([1: [10], 2: [20]])
+        let pids: [pid_t?] = [1, 2]
+        let wids: [CGWindowID] = [10, 20]
+        let result = WindowMRUTracker.windowOrderWithinApps(pids: pids, wids: wids, order: o)
+        #expect(result == [0, 1])
+    }
+
+    @Test("unseen windows sink to the back of their group, stable on offset")
+    func unseenWindowsToBackOfGroup() {
+        // Only 11 is tracked for app 1; 10 and 12 were never focused.
+        let o = order([1: [11]])
+        let pids: [pid_t?] = [1, 1, 1]
+        let wids: [CGWindowID] = [10, 11, 12]
+        let result = WindowMRUTracker.windowOrderWithinApps(pids: pids, wids: wids, order: o)
+        // 11 leads; 10 and 12 keep their incoming relative order behind it.
+        #expect(result == [1, 0, 2])
+    }
+
+    @Test("windowless rows fall to the back of their app group")
+    func windowlessToBackOfGroup() {
+        let o = order([1: [10]])
+        let pids: [pid_t?] = [1, 1]
+        let wids: [CGWindowID] = [0, 10] // windowless row first in catalog
+        let result = WindowMRUTracker.windowOrderWithinApps(pids: pids, wids: wids, order: o)
+        #expect(result == [1, 0])
+    }
+
+    @Test("pid-less rows (launchables / recents) hold their slot")
+    func pidlessRowsHoldSlot() {
+        let o = order([1: [11, 10]])
+        let pids: [pid_t?] = [1, 1, nil, nil]
+        let wids: [CGWindowID] = [10, 11, 0, 0]
+        let result = WindowMRUTracker.windowOrderWithinApps(pids: pids, wids: wids, order: o)
+        // App 1's windows reorder by MRU; the two pid-less rows stay in place.
+        #expect(result == [1, 0, 2, 3])
+    }
+
+    @Test("empty order leaves the indices in their incoming order")
+    func emptyOrderIsIdentity() {
+        let result = WindowMRUTracker.windowOrderWithinApps(
+            pids: [1, 1, 2], wids: [10, 11, 20], order: [:]
+        )
+        #expect(result == [0, 1, 2])
+    }
+
+    @Test("non-contiguous rows of one app are not merged across status buckets")
+    func nonContiguousRunsStayPut() {
+        // Incoming rows are status-bucketed (normal → minimized): app 1's normal
+        // window (10) leads, then app 2 (20), then app 1's minimized window (11).
+        // 11 is the most recently focused, but it must NOT be pulled up next to
+        // 10 — that would break the global normal-before-minimized layout. Each
+        // is its own contiguous run, so the layout is preserved.
+        let o = order([1: [11, 10], 2: [20]])
+        let pids: [pid_t?] = [1, 2, 1]
+        let wids: [CGWindowID] = [10, 20, 11]
+        let result = WindowMRUTracker.windowOrderWithinApps(pids: pids, wids: wids, order: o)
+        #expect(result == [0, 1, 2])
+    }
+}


### PR DESCRIPTION
Fixes #30 — switching away from an app and back focused the wrong window
(e.g. two VS Code windows, cycle them, bounce to Chrome and back → lands
on the other VS Code window instead of the last-used one).

## Root cause

`WindowMRUTracker` already recorded each app's last-focused window (fed
by focus-change observers). But only `.mruWindows` consumed it, via a
global recency sort. The default `.mru` (and `.alphabetical`/`.launchOrder`)
left each app's windows in catalog z-order, which lags real focus recency.
So the window that collapses to the app's row was z-order head, not the
last-used one.

## Changes

- `WindowMRUTracker.sortWindowsWithinApps` + pure index core
  `windowOrderWithinApps`: floats each app's most-recently-used window to
  the head of its contiguous run, preserving app order and global status
  bucketing (normal → minimized → hidden). Contiguous-runs restriction
  prevents an app's normal and minimized windows merging across buckets.
- `applyWindowMRUSort`: app-grouped branch now applies within-app sort
  instead of being a no-op. Covers reveal(), applyFullSnapshot, and the
  post-action refresh path.
- `primedAppTargetRow`: fast ⌘Tab tap-release now picks the MRU-front
  window instead of z-order head, so held-panel and quick-tap agree.

## Tests

New `@Suite("WindowMRUTracker within-app sort")` tests: per-app float,
app-order preservation, unseen/windowless sink to run back, pid-less rows
hold slot, non-contiguous runs stay put across status buckets, empty
order is identity.