### PR TITLE
fix: empty state on reveal, dismiss on closing the last window (#31)

### DIFF
--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -24,6 +24,10 @@ final class AppCatalogCache {
     }
 
     private(set) var entries: [pid_t: AppCacheEntry] = [:]
+    /// True once at least one full off-main scan has landed in `entries`.
+    /// Lets the reveal path tell "cache cold, never scanned" apart from
+    /// "scanned, and the filters legitimately yield zero rows".
+    private(set) var hasCompletedFullScan = false
     /// Whether the switcher panel is on screen. Title-change notifications are
     /// only acted on while this is true. Set via `setPanelVisible`.
     private var panelVisible = false
@@ -181,6 +185,7 @@ final class AppCatalogCache {
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.entries = fresh
+                self.hasCompletedFullScan = true
                 // Drop coverage memos for pids the full refresh no longer lists
                 // (terminated apps a missed observer teardown left behind); the
                 // memo stays valid across refresh otherwise — it's keyed on the

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -4461,6 +4461,34 @@
         }
       }
     },
+    "No open windows" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine offenen Fenster"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay ventanas abiertas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune fenêtre ouverte"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak otwartych okien"
+          }
+        }
+      }
+    },
     "None" : {
       "localizations" : {
         "de" : {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -2122,6 +2122,19 @@ final class SwitcherController: SwitcherViewDelegate {
             } else {
                 index = 0
             }
+        } else if cache.hasCompletedFullScan {
+            // Zero rows out of an already-scanned cache means the filters
+            // legitimately hide everything — e.g. only a windowless Finder is
+            // running and its default when-no-windows exception drops it.
+            // Present the empty state directly (#31): placeholder rows would
+            // only flash, since the background snapshot comes back just as
+            // empty and clears them a few frames later. A genuinely cold
+            // cache (no scan yet) still takes the placeholder path below.
+            baseRows = []
+            baseLabels = []
+            rows = []
+            labels = []
+            index = 0
         } else {
             baseRows = snapshotApps.map { app in
                 SwitcherRow(
@@ -2170,7 +2183,9 @@ final class SwitcherController: SwitcherViewDelegate {
                 index = max(0, min(index, rows.count - 1))
             }
         }
-        guard !rows.isEmpty else { cancel(); return }
+        // Empty rows no longer cancel: the panel presents with the view's
+        // "No open windows" empty state instead of flashing away (#31). This
+        // also covers a scoped open whose filter matches nothing.
 
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
@@ -2336,7 +2351,23 @@ final class SwitcherController: SwitcherViewDelegate {
 
     private func applyFullSnapshot(_ fresh: [SwitcherRow], anchorPid: pid_t?) {
         guard phase == .visible else { return }
-        if fresh.isEmpty { cancel(); return }
+        if fresh.isEmpty {
+            // Distinguish "opened onto nothing" from "had windows, lost the
+            // last one". If the panel is still showing placeholder rows (a cold
+            // reveal whose background scan just resolved to empty), settle into
+            // the empty state instead of flashing away (#31). If it was showing
+            // real rows, the user/window-server just closed the last window —
+            // dismiss the panel. refreshDisplay still appends recently-closed
+            // rows, so those remain reopenable from the empty panel.
+            if rows.allSatisfy(\.isPlaceholder) {
+                baseRows = []
+                baseLabels = []
+                refreshDisplay(anchorPid: anchorPid)
+            } else {
+                cancel()
+            }
+            return
+        }
 
         // Drop apps being quit so a background refresh doesn't re-add one as a
         // windowless row during its death gap (see `quittingPids`).
@@ -2835,7 +2866,12 @@ final class SwitcherController: SwitcherViewDelegate {
         prefetchedFocusedWindow = nil
         prefetchedTargetScreen = nil
         // We picked a target — `pendingActivation` activates it, so there's
-        // nothing to restore. Drop the captured previous app.
+        // nothing to restore. Without a pick (committing out of the empty
+        // state, or a primed commit that resolved no app) undo present()'s
+        // self-activation like cancel() does, then drop the captured app.
+        if pendingActivation == nil {
+            restorePreviousFrontmostApp()
+        }
         previousFrontmostApp = nil
         resetLetterBuffer()
         resetSearch()
@@ -3404,6 +3440,27 @@ final class SwitcherController: SwitcherViewDelegate {
             return
         }
 
+        // Closing this window left no other open window anywhere — the user
+        // closed the last one, so dismiss instead of lingering on a demoted
+        // windowless row or the empty state. Consult the canonical per-window
+        // cache (minus the window just closed, which the pending refresh hasn't
+        // dropped yet) rather than `baseRows`: in "Applications only" mode
+        // baseRows is collapsed to one row per app and would miss an app's
+        // other windows, dismissing while windows remain. Windowless rows don't
+        // count — with no window to switch to, the panel has no purpose.
+        // Checked before the demotion below so the app isn't inserted as a
+        // windowless row only to be torn down a line later.
+        let closedWindow = row.window
+        let anyWindowRemains = cache.rows(orderedBy: mru.order).contains { r in
+            guard let w = r.window else { return false }
+            if let cw = closedWindow { return !CFEqual(w, cw) }
+            return true
+        }
+        if !anyWindowRemains {
+            cancel()
+            return
+        }
+
         // If this was the only window for a regular app, demote the app to a
         // windowless row right now. Otherwise the app visibly vanishes for
         // ~250ms (until the cache refresh + tombstone filter substitute one) —
@@ -3448,10 +3505,12 @@ final class SwitcherController: SwitcherViewDelegate {
             )
         }
 
-        if baseRows.isEmpty {
-            cancel()
-            return
-        }
+        // A window still exists somewhere (checked above), so the panel stays
+        // open. `baseRows` itself can still be empty here in "Applications only"
+        // mode — the closed app's other windows live in the cache but aren't
+        // separate rows, and the demotion above is filter-gated — in which case
+        // `refreshDisplay()` shows the empty state until the 250ms refresh
+        // re-collapses the remaining window back in. Safe either way.
         baseLabels = RowLabels.labels(for: baseRows)
         refreshDisplay()
 

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -38,7 +38,11 @@ final class SwitcherView: NSView, TabStripDelegate {
     private let listContainer = NSView()
     private let searchBar = SwitcherSearchBarView()
     private let tabStrip = TabStripView()
-    private let noResultsLabel = NSTextField(labelWithString: String(localized: "No matches"))
+    /// Empty-state glyph + caption, shown centered when there are no rows
+    /// (no open windows, or a search/scope that matched nothing — #31). Framed
+    /// as a centered icon-over-title group in `layout()` via `emptyLayout()`.
+    private let emptyIcon = NSImageView()
+    private let emptyTitle = NSTextField(labelWithString: "")
     private var itemViews: [SwitcherItemViewProtocol] = []
     private var rows: [SwitcherRow] = []
     private(set) var labels: [String] = []
@@ -93,11 +97,15 @@ final class SwitcherView: NSView, TabStripDelegate {
         tabStrip.isHidden = true
         tabStrip.delegate = self
         contentContainer.addSubview(tabStrip)
-        noResultsLabel.isHidden = true
-        noResultsLabel.alignment = .center
-        noResultsLabel.textColor = .secondaryLabelColor
-        noResultsLabel.font = .systemFont(ofSize: 13, weight: .medium)
-        contentContainer.addSubview(noResultsLabel)
+        emptyIcon.isHidden = true
+        emptyIcon.imageScaling = .scaleProportionallyUpOrDown
+        emptyIcon.contentTintColor = .tertiaryLabelColor
+        contentContainer.addSubview(emptyIcon)
+        emptyTitle.isHidden = true
+        emptyTitle.alignment = .center
+        emptyTitle.textColor = .secondaryLabelColor
+        emptyTitle.font = .systemFont(ofSize: 14, weight: .semibold)
+        contentContainer.addSubview(emptyTitle)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
@@ -143,7 +151,22 @@ final class SwitcherView: NSView, TabStripDelegate {
         } else {
             tabStrip.isHidden = true
         }
-        noResultsLabel.isHidden = !(searchActive && rows.isEmpty)
+        // Empty state (#31): no rows means either nothing is open (filters left
+        // the catalog empty) or a live search/scope matched nothing. Present a
+        // centered glyph + caption instead of flashing the panel away. The
+        // glyph and copy switch on whether the user is searching.
+        if rows.isEmpty {
+            let symbol = searchActive ? "magnifyingglass" : "macwindow"
+            let conf = NSImage.SymbolConfiguration(pointSize: round(34 * metrics.scale), weight: .regular)
+            emptyIcon.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)?
+                .withSymbolConfiguration(conf)
+            emptyTitle.stringValue = searchActive
+                ? String(localized: "No matches")
+                : String(localized: "No open windows")
+            emptyTitle.font = .systemFont(ofSize: round(14 * metrics.scale), weight: .semibold)
+        }
+        emptyIcon.isHidden = !rows.isEmpty
+        emptyTitle.isHidden = !rows.isEmpty
         let layoutModeChanged = metrics.layoutMode != self.metrics.layoutMode
         if metrics != self.metrics {
             self.metrics = metrics
@@ -229,7 +252,8 @@ final class SwitcherView: NSView, TabStripDelegate {
         tabStripActive = false
         tabStrip.isHidden = true
         searchBar.isHidden = true
-        noResultsLabel.isHidden = true
+        emptyIcon.isHidden = true
+        emptyTitle.isHidden = true
         WindowThumbnailCache.shared.onReady = nil
     }
 
@@ -500,7 +524,27 @@ final class SwitcherView: NSView, TabStripDelegate {
             y: listOriginY
         )
         listContainer.frame = NSRect(origin: listOrigin, size: info.listSize)
-        noResultsLabel.frame = NSRect(x: 0, y: reservedTabStripHeight, width: bounds.width, height: listAreaHeight)
+
+        // Empty state: stack the glyph over the caption and center the group in
+        // the list area. Sized off the active scale so it tracks panel size.
+        if rows.isEmpty {
+            let g = emptyStateGeometry()
+            let groupH = g.icon + g.spacing + g.title
+            let midY = reservedTabStripHeight + listAreaHeight / 2
+            let topY = midY + groupH / 2
+            emptyIcon.frame = NSRect(
+                x: (bounds.width - g.icon) / 2,
+                y: topY - g.icon,
+                width: g.icon,
+                height: g.icon
+            )
+            emptyTitle.frame = NSRect(
+                x: 0,
+                y: topY - g.icon - g.spacing - g.title,
+                width: bounds.width,
+                height: g.title
+            )
+        }
 
         if tabStripActive {
             tabStrip.frame = NSRect(
@@ -575,16 +619,49 @@ final class SwitcherView: NSView, TabStripDelegate {
     private func computeLayout() -> ListLayout {
         if let cachedLayout { return cachedLayout }
         let layout: ListLayout
-        switch metrics.layoutMode {
-        case .list:
-            layout = computeListLayout()
-        case .gridView:
-            layout = computeIconDockLayout()
-        case .windowPreview:
-            layout = computePreviewLayout()
+        if rows.isEmpty {
+            layout = emptyLayout()
+        } else {
+            switch metrics.layoutMode {
+            case .list:
+                layout = computeListLayout()
+            case .gridView:
+                layout = computeIconDockLayout()
+            case .windowPreview:
+                layout = computePreviewLayout()
+            }
         }
         cachedLayout = layout
         return layout
+    }
+
+    /// Pixel sizes of the empty-state group's three parts at the current scale.
+    /// Shared by `emptyLayout()` (panel sizing) and `layout()` (positioning) so
+    /// the reserved box and the placed views always agree.
+    private func emptyStateGeometry() -> (icon: CGFloat, spacing: CGFloat, title: CGFloat) {
+        let s = metrics.scale
+        return (icon: round(40 * s), spacing: round(12 * s), title: round(22 * s))
+    }
+
+    /// A compact, balanced panel for the no-rows case — wide enough for the
+    /// caption with margins, tall enough for the glyph-over-title group plus
+    /// breathing room — rather than the one-row sliver the list/grid layouts
+    /// produce from a zero count.
+    private func emptyLayout() -> ListLayout {
+        let g = emptyStateGeometry()
+        let outer = metrics.outerPadding
+        let s = metrics.scale
+        let titleW = ceil(emptyTitle.intrinsicContentSize.width)
+        let contentW = max(round(260 * s), titleW + round(64 * s))
+        let contentH = g.icon + g.spacing + g.title + round(44 * s)
+        let listSize = NSSize(width: contentW, height: contentH)
+        return ListLayout(
+            frames: [],
+            listSize: listSize,
+            total: NSSize(width: contentW + outer * 2, height: contentH + outer * 2),
+            rowsPerCol: 0,
+            cols: 1
+        )
     }
 
     /// Returns the visible frame of the screen to size the panel for. Uses


### PR DESCRIPTION
Fixes #31.

## Problem

Pressing ⌘Tab with no open windows — e.g. only a windowless Finder, which its default *hide when no windows* exception filters out — made the switcher panel **flash**: it presented, the background catalog scan returned empty, and a `cancel()` a few frames later tore it down.

## What changed

**Empty state on reveal.** Instead of flashing, the switcher now settles into a proper empty state: a centered SF Symbol glyph over a localized caption — `No open windows`, or `No matches` while searching — sized by a dedicated `emptyLayout()` rather than the one-row sliver the list/grid layouts produced from a zero count.

- `AppCatalogCache` gains a `hasCompletedFullScan` flag so `reveal()` can tell a **cold cache** (show placeholder rows) from a **scanned cache whose filters legitimately yield nothing** (show the empty state). No more placeholder flash.
- `SwitcherView` replaces the old flat `noResultsLabel` with an `emptyIcon` + `emptyTitle` group, centered in `layout()`, with zero-count-safe sizing.

**Dismiss on closing the last window.** Closing the last open window from the switcher now closes the switcher:

- `performCloseAction` consults the canonical **per-window cache** (minus the just-closed window) and `cancel()`s when no window remains anywhere, instead of lingering on a demoted windowless row. It reads the cache, not the collapsed `baseRows`, so it stays correct in *Applications only* mode (where `baseRows` is one row per app and would miss an app's other windows).
- `applyFullSnapshot` distinguishes *opened onto nothing* (placeholder rows → keep empty state) from *had windows, lost the last one* (→ dismiss).
- Committing out of the empty state restores the previously frontmost app, mirroring `cancel()` (since `present()` self-activates for the glass backdrop).

## i18n

`No open windows` added to `Localizable.xcstrings` with de/es/fr/pl translations (separate from the pre-existing singular `No open window` used by `SwitcherIndicators`).

## Testing

- `xcodebuild` Debug build: green.
- Full unit test suite (`BetterCmdTab Debug`, Swift Testing): green.
- Two adversarial review passes: no CRITICAL/HIGH findings.
- **Verified on device** (live WindowServer + Accessibility): empty-state panel across list/grid/window-preview layouts, close-last-window dismiss across default / Applications-only / windows-only (⌘`) / browser-tab modes, ⌘-release focus restore, search-no-match, and SF Symbol rendering in light/dark.

## Notes for reviewers

- Hot ⌘Tab path with windows is unchanged — the new branches only run when there are zero rows, or on a close action (neither is the open/nav hot path).
- Known low-priority follow-ups (not blocking): a warm reveal onto zero windows takes the cold branch and does one redundant off-main `AppCatalog.snapshot`; the search-no-match panel is slightly narrower than the result panel, causing a small resize while typing.
