### PR TITLE
fix: drop Electron phantom windows from the switcher

### DIFF
--- a/BetterCmdTab/Catalog/AppCatalog.swift
+++ b/BetterCmdTab/Catalog/AppCatalog.swift
@@ -47,7 +47,8 @@ enum AppCatalog {
                     forPid: pid,
                     isRegularApp: app.activationPolicy == .regular,
                     expectedCGWindowIDs: cgSnapshot.ids(for: pid),
-                    cgZOrder: cgSnapshot.zOrder(for: pid)
+                    cgZOrder: cgSnapshot.zOrder(for: pid),
+                    nonNormalLayerWids: cgSnapshot.nonNormalLayer(for: pid)
                 )
             }
         }

--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -272,7 +272,8 @@ final class AppCatalogCache {
                     forPid: pid,
                     isRegularApp: app.activationPolicy == .regular,
                     expectedCGWindowIDs: cgSnapshot.ids(for: pid),
-                    cgZOrder: cgSnapshot.zOrder(for: pid)
+                    cgZOrder: cgSnapshot.zOrder(for: pid),
+                    nonNormalLayerWids: cgSnapshot.nonNormalLayer(for: pid)
                 )
             }
         }
@@ -563,7 +564,8 @@ final class AppCatalogCache {
                     isRegularApp: item.isRegular,
                     expectedCGWindowIDs: expected,
                     cgZOrder: cgSnapshot.zOrder(for: item.pid),
-                    knownUncoverable: known
+                    knownUncoverable: known,
+                    nonNormalLayerWids: cgSnapshot.nonNormalLayer(for: item.pid)
                 )
                 return BumpScan(windows: result.windows, expected: expected, uncoverable: result.uncoverable)
             }

--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -59,14 +59,23 @@ enum CatalogFilter {
         // current-Space filter needs every window's Space; the phantom filter
         // only cares about off-screen windows, so when current-Space is off we
         // resolve just those (see resolveSpaces).
-        let spaces = resolveSpaces(rows, needsAllWindows: cfg.currentSpaceOnly)
+        //
+        // Gate the whole thing behind a pure, IPC-free precheck: a phantom can
+        // only be dropped when some app has two or more window-bearing rows (the
+        // never-shown helper always coexists with the app's real window — see
+        // phantomWindowOffsets). When that's impossible and current-Space is off,
+        // skip resolveSpaces entirely so a default-config reveal pays zero
+        // WindowServer round-trips on the ⌘Tab hot path.
+        let spaces = needsSpaceResolution(rows, cfg)
+            ? resolveSpaces(rows, needsAllWindows: cfg.currentSpaceOnly)
+            : .unavailable
 
         // Drop Electron-style phantom windows first, unconditionally. These are
         // never-shown helper windows the user can't reach (not a preference), so
         // they're removed even under an identity config that skips the rest.
-        let rows = filterPhantomWindows(rows, spaces)
-        if cfg.isIdentity { return rows }
-        var filtered = rows.filter {
+        let phantomFiltered = filterPhantomWindows(rows, spaces)
+        if cfg.isIdentity { return phantomFiltered }
+        var filtered = phantomFiltered.filter {
             includes(bundleID: $0.bundleIdentifier, isPlaceholder: $0.isPlaceholder, isMinimized: $0.isMinimized, appHidden: $0.isHidden, hasWindow: $0.window != nil, cfg)
         }
         if cfg.sortOrder != .mru {
@@ -77,6 +86,25 @@ enum CatalogFilter {
             filtered = filterToCurrentSpace(filtered, spaces)
         }
         return filtered
+    }
+
+    /// Whether this reveal needs any WindowServer Space resolution. The
+    /// current-Space filter always does; otherwise it's needed only when a
+    /// phantom could exist — i.e. some app has two or more window-bearing rows,
+    /// since `phantomWindowOffsets` can never drop an app's lone window. Pure and
+    /// IPC-free, so the common "nothing to drop" reveal skips `resolveSpaces`.
+    static func needsSpaceResolution(_ rows: [SwitcherRow], _ cfg: Config) -> Bool {
+        cfg.currentSpaceOnly || hasMultiWindowApp(pids: rows.map { $0.cgWindowID != 0 ? $0.pid : nil })
+    }
+
+    /// Pure core of `needsSpaceResolution`: true when any pid appears on two or
+    /// more window-bearing rows. `nil` entries (windowless / launchable / recent
+    /// rows) are ignored. Split out so the gate can be unit-tested without
+    /// constructing `SwitcherRow`s.
+    static func hasMultiWindowApp(pids: [pid_t?]) -> Bool {
+        var seen = Set<pid_t>()
+        for case let pid? in pids where !seen.insert(pid).inserted { return true }
+        return false
     }
 
     /// Collapse a window-level row list to one row per application (classic
@@ -119,16 +147,19 @@ enum CatalogFilter {
     /// Space membership resolved once per `filteredRows` call and shared by the
     /// phantom filter and the current-Space filter, so neither re-queries
     /// WindowServer for the same window. `spaceByWindow` maps each *resolved*
-    /// window id to its first Space; `onScreen` is the set of currently visible
-    /// window ids; `activeSpace` is nil when the private Space API is
-    /// unavailable, in which case both filters no-op.
+    /// window id to its single Space; `confirmedSpaceless` is the set of wids
+    /// WindowServer positively reports as belonging to no Space (the phantom
+    /// signal — never multi-Space/sticky or failed queries); `onScreen` is the
+    /// set of currently visible window ids; `activeSpace` is nil when the private
+    /// Space API is unavailable, in which case both filters no-op.
     struct SpaceResolution {
         let spaceByWindow: [CGWindowID: UInt64]
+        let confirmedSpaceless: Set<CGWindowID>
         let onScreen: Set<CGWindowID>
         let activeSpace: UInt64?
 
         /// Space API unavailable — callers degrade to showing every window.
-        static let unavailable = SpaceResolution(spaceByWindow: [:], onScreen: [], activeSpace: nil)
+        static let unavailable = SpaceResolution(spaceByWindow: [:], confirmedSpaceless: [], onScreen: [], activeSpace: nil)
     }
 
     /// Resolve Space membership for `rows`. When `needsAllWindows` is true (the
@@ -145,17 +176,17 @@ enum CatalogFilter {
                 wids.insert(row.cgWindowID)
             }
         }
-        let spaceByWindow = wids.isEmpty ? [:] : PrivateAPI.spaces(forWindows: Array(wids))
-        return SpaceResolution(spaceByWindow: spaceByWindow, onScreen: onScreen, activeSpace: active)
+        let membership = wids.isEmpty
+            ? (resolved: [CGWindowID: UInt64](), spaceless: Set<CGWindowID>())
+            : PrivateAPI.spaceMembership(forWindows: Array(wids))
+        return SpaceResolution(
+            spaceByWindow: membership.resolved,
+            confirmedSpaceless: membership.spaceless,
+            onScreen: onScreen,
+            activeSpace: active
+        )
     }
 
-    /// Drop windows that live on a Space other than the one in focus. Rows
-    /// without a real window (windowless apps, launchables, recents) and any
-    /// window whose Space can't be resolved — including multi-Space (All
-    /// Desktops / sticky) windows, which `PrivateAPI.spaces(forWindows:)`
-    /// leaves unresolved — are kept, so the filter only ever hides windows
-    /// it's certain are elsewhere. Reads Space membership from the shared
-    /// `SpaceResolution`; degrades to a no-op when it's unavailable.
     /// Convenience for standalone callers outside the `filteredRows` pipeline
     /// (e.g. the windows-only scope path) that don't already hold a shared
     /// `SpaceResolution`. Resolves every window's Space, then filters.
@@ -163,6 +194,13 @@ enum CatalogFilter {
         filterToCurrentSpace(rows, resolveSpaces(rows, needsAllWindows: true))
     }
 
+    /// Drop windows that live on a Space other than the one in focus. Rows
+    /// without a real window (windowless apps, launchables, recents) and any
+    /// window whose Space can't be resolved — including multi-Space (All
+    /// Desktops / sticky) windows, which `PrivateAPI.spaceMembership(forWindows:)`
+    /// leaves unresolved — are kept, so the filter only ever hides windows it's
+    /// certain are elsewhere. Reads Space membership from the shared
+    /// `SpaceResolution`; degrades to a no-op when it's unavailable.
     static func filterToCurrentSpace(_ rows: [SwitcherRow], _ spaces: SpaceResolution) -> [SwitcherRow] {
         guard let active = spaces.activeSpace, !spaces.spaceByWindow.isEmpty else { return rows }
         var dropOffsets = Set<Int>()
@@ -175,26 +213,28 @@ enum CatalogFilter {
         return rows.enumerated().filter { !dropOffsets.contains($0.offset) }.map(\.element)
     }
 
-    /// Drop "phantom" windows: real CGWindow-backed rows that have never been
-    /// mapped to a Space. Electron apps (Teams, Signal, …) keep a hidden
-    /// `BrowserWindow` that the AX window list still reports — it has a valid
-    /// CGWindowID and standard subrole but a blank title, so it surfaces as a
-    /// duplicate row labelled with the bare app name. A never-shown window
-    /// belongs to no Space; minimized, hidden-app, other-Space and fullscreen
-    /// windows all keep theirs.
+    /// Drop "phantom" windows: real CGWindow-backed rows that WindowServer
+    /// reports as belonging to no Space at all. Electron apps (Teams, Signal, …)
+    /// keep a hidden `BrowserWindow` that the AX window list still reports — it
+    /// has a valid CGWindowID and standard subrole but a blank title, so it
+    /// surfaces as a duplicate row labelled with the bare app name. A never-shown
+    /// window belongs to no Space; minimized, hidden-app, other-Space, sticky
+    /// (All Desktops) and fullscreen windows all keep theirs.
     ///
-    /// Two guards keep the failure bias on the safe side — drop only what we're
+    /// Three guards keep the failure bias on the safe side — drop only what we're
     /// sure is unreachable, never the user's actual window:
-    ///   1. Only *off-screen* windows are candidates. An on-screen window is by
-    ///      definition on a Space, so it's skipped without a Space query — which
-    ///      also bounds the per-window `CGSCopySpacesForWindows` IPCs to the few
-    ///      off-screen rows instead of every row on every reveal.
-    ///   2. A spaceless window is dropped only when its app *also* has a window
-    ///      that does occupy a Space (on-screen, or an off-screen sibling that
-    ///      resolved). A phantom always coexists with the app's real window, so
-    ///      this still catches it — but if an app's *only* window fails to
-    ///      resolve (a transient WindowServer miss), it's kept rather than
-    ///      vanishing from the switcher.
+    ///   1. Only a window WindowServer *positively* reports as spaceless
+    ///      (`confirmedSpaceless`, `count == 0`) is a candidate. A multi-Space /
+    ///      sticky window or a failed Space query is not spaceless, so it's kept.
+    ///      On-screen windows are never queried, which also bounds the per-window
+    ///      `CGSCopySpacesForWindows` IPCs to off-screen rows.
+    ///   2. Minimized windows are never candidates — a minimized window is a real
+    ///      user window (the Electron phantom is never minimized).
+    ///   3. A spaceless window is dropped only when its app *also* has a window
+    ///      that occupies a Space (on-screen, or a sibling that resolved). A
+    ///      phantom always coexists with the app's real window, so this still
+    ///      catches it — but if an app's *only* window is spaceless, it's kept
+    ///      rather than vanishing from the switcher.
     ///
     /// Reads Space membership from the shared `SpaceResolution`; degrades to a
     /// no-op when it's unavailable.
@@ -202,20 +242,19 @@ enum CatalogFilter {
         guard spaces.activeSpace != nil else { return rows }
 
         // Every window-bearing row tagged with whether WindowServer currently
-        // shows it. The wid is the one captured at enumeration time (no AX
-        // round-trip). Rows without a real window (placeholders/launchables/
-        // recents) carry wid 0 or no pid and are never candidates.
-        let windowRows: [(offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool)] =
+        // shows it and whether it's minimized. The wid is the one captured at
+        // enumeration time (no AX round-trip). Rows without a real window
+        // (placeholders/launchables/recents) carry wid 0 or no pid and are never
+        // candidates.
+        let windowRows: [(offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool, isMinimized: Bool)] =
             rows.enumerated().compactMap { idx, row in
                 guard row.cgWindowID != 0, let pid = row.pid else { return nil }
-                return (idx, pid, row.cgWindowID, spaces.onScreen.contains(row.cgWindowID))
+                return (idx, pid, row.cgWindowID, spaces.onScreen.contains(row.cgWindowID), row.isMinimized)
             }
-        // `spaceByWindow` holds every wid that resolved to a Space (on-screen
-        // windows are included only when the current-Space filter forced a full
-        // query; otherwise on-screen rows are covered by their on-screen flag).
         let dropOffsets = phantomWindowOffsets(
             windowRows: windowRows,
-            resolvedCandidateWids: Set(spaces.spaceByWindow.keys)
+            resolvedCandidateWids: Set(spaces.spaceByWindow.keys),
+            spacelessWids: spaces.confirmedSpaceless
         )
         if dropOffsets.isEmpty { return rows }
         return rows.enumerated().filter { !dropOffsets.contains($0.offset) }.map(\.element)
@@ -223,25 +262,27 @@ enum CatalogFilter {
 
     /// Pure index-level core of `filterPhantomWindows`, split out so it can be
     /// unit-tested without CGS calls or `SwitcherRow`/AX. `windowRows` is every
-    /// window-bearing row (offset, owning pid, wid, on-screen flag);
-    /// `resolvedCandidateWids` is the set of off-screen wids that resolved to a
-    /// Space. Returns the offsets to drop: off-screen, spaceless windows whose
-    /// app occupies a Space elsewhere (so a real window exists and this one is
-    /// the never-shown helper).
+    /// window-bearing row (offset, owning pid, wid, on-screen flag, minimized
+    /// flag); `resolvedCandidateWids` is the set of wids that resolved to a Space;
+    /// `spacelessWids` is the set WindowServer positively reports as belonging to
+    /// no Space. Returns the offsets to drop: non-minimized, confirmed-spaceless
+    /// windows whose app also has a window occupying a Space (so a real window
+    /// exists and this one is the never-shown helper).
     static func phantomWindowOffsets(
-        windowRows: [(offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool)],
-        resolvedCandidateWids: Set<CGWindowID>
+        windowRows: [(offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool, isMinimized: Bool)],
+        resolvedCandidateWids: Set<CGWindowID>,
+        spacelessWids: Set<CGWindowID>
     ) -> Set<Int> {
         // Apps with at least one window known to occupy a Space: any on-screen
-        // window, or any off-screen window that resolved.
+        // window, or any window that resolved to a Space.
         var pidsOccupyingSpace = Set<pid_t>()
         for r in windowRows where r.onScreen || resolvedCandidateWids.contains(r.wid) {
             pidsOccupyingSpace.insert(r.pid)
         }
         var drop = Set<Int>()
         for r in windowRows
-        where !r.onScreen
-            && !resolvedCandidateWids.contains(r.wid)
+        where !r.isMinimized
+            && spacelessWids.contains(r.wid)
             && pidsOccupyingSpace.contains(r.pid) {
             drop.insert(r.offset)
         }

--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreGraphics
 
 /// Applies the user's catalog-filter preferences (per-app hide rules, pinned
 /// apps, minimized/hidden visibility) to produced switcher rows and app lists.
@@ -53,6 +54,17 @@ enum CatalogFilter {
     /// windows, then move pinned apps to the front in pin order. Placeholders
     /// (cache-warm rows) are never filtered or reordered.
     static func filteredRows(_ rows: [SwitcherRow], _ cfg: Config) -> [SwitcherRow] {
+        // Resolve Space membership once and share it across both Space-based
+        // filters so a reveal never queries the same window's Space twice. The
+        // current-Space filter needs every window's Space; the phantom filter
+        // only cares about off-screen windows, so when current-Space is off we
+        // resolve just those (see resolveSpaces).
+        let spaces = resolveSpaces(rows, needsAllWindows: cfg.currentSpaceOnly)
+
+        // Drop Electron-style phantom windows first, unconditionally. These are
+        // never-shown helper windows the user can't reach (not a preference), so
+        // they're removed even under an identity config that skips the rest.
+        let rows = filterPhantomWindows(rows, spaces)
         if cfg.isIdentity { return rows }
         var filtered = rows.filter {
             includes(bundleID: $0.bundleIdentifier, isPlaceholder: $0.isPlaceholder, isMinimized: $0.isMinimized, appHidden: $0.isHidden, hasWindow: $0.window != nil, cfg)
@@ -62,7 +74,7 @@ enum CatalogFilter {
         }
         filtered = pinnedToFront(filtered, cfg.pinned)
         if cfg.currentSpaceOnly {
-            filtered = filterToCurrentSpace(filtered)
+            filtered = filterToCurrentSpace(filtered, spaces)
         }
         return filtered
     }
@@ -104,29 +116,151 @@ enum CatalogFilter {
         return kept
     }
 
+    /// Space membership resolved once per `filteredRows` call and shared by the
+    /// phantom filter and the current-Space filter, so neither re-queries
+    /// WindowServer for the same window. `spaceByWindow` maps each *resolved*
+    /// window id to its first Space; `onScreen` is the set of currently visible
+    /// window ids; `activeSpace` is nil when the private Space API is
+    /// unavailable, in which case both filters no-op.
+    struct SpaceResolution {
+        let spaceByWindow: [CGWindowID: UInt64]
+        let onScreen: Set<CGWindowID>
+        let activeSpace: UInt64?
+
+        /// Space API unavailable — callers degrade to showing every window.
+        static let unavailable = SpaceResolution(spaceByWindow: [:], onScreen: [], activeSpace: nil)
+    }
+
+    /// Resolve Space membership for `rows`. When `needsAllWindows` is true (the
+    /// current-Space filter is active) every window is queried; otherwise only
+    /// off-screen windows are — an on-screen window is by definition on a Space,
+    /// so the phantom filter doesn't need it and we skip that per-window IPC.
+    static func resolveSpaces(_ rows: [SwitcherRow], needsAllWindows: Bool) -> SpaceResolution {
+        guard let active = PrivateAPI.activeSpace() else { return .unavailable }
+        let onScreen = onScreenWindowIDs()
+        // Unique wids to resolve (browser-tab rows can share a parent wid).
+        var wids = Set<CGWindowID>()
+        for row in rows where row.cgWindowID != 0 {
+            if needsAllWindows || !onScreen.contains(row.cgWindowID) {
+                wids.insert(row.cgWindowID)
+            }
+        }
+        let spaceByWindow = wids.isEmpty ? [:] : PrivateAPI.spaces(forWindows: Array(wids))
+        return SpaceResolution(spaceByWindow: spaceByWindow, onScreen: onScreen, activeSpace: active)
+    }
+
     /// Drop windows that live on a Space other than the one in focus. Rows
     /// without a real window (windowless apps, launchables, recents) and any
     /// window whose Space can't be resolved — including multi-Space (All
     /// Desktops / sticky) windows, which `PrivateAPI.spaces(forWindows:)`
     /// leaves unresolved — are kept, so the filter only ever hides windows
-    /// it's certain are elsewhere. Degrades to a no-op when the private Space
-    /// APIs are unavailable.
+    /// it's certain are elsewhere. Reads Space membership from the shared
+    /// `SpaceResolution`; degrades to a no-op when it's unavailable.
+    /// Convenience for standalone callers outside the `filteredRows` pipeline
+    /// (e.g. the windows-only scope path) that don't already hold a shared
+    /// `SpaceResolution`. Resolves every window's Space, then filters.
     static func filterToCurrentSpace(_ rows: [SwitcherRow]) -> [SwitcherRow] {
-        guard let active = PrivateAPI.activeSpace() else { return rows }
-        let widByOffset: [(offset: Int, wid: CGWindowID)] = rows.enumerated().compactMap { idx, row in
-            guard let window = row.window else { return nil }
-            let wid = PrivateAPI.cgWindowId(of: window)
-            return wid == 0 ? nil : (idx, wid)
-        }
-        guard !widByOffset.isEmpty else { return rows }
-        let spaceByWindow = PrivateAPI.spaces(forWindows: widByOffset.map(\.wid))
-        guard !spaceByWindow.isEmpty else { return rows }
+        filterToCurrentSpace(rows, resolveSpaces(rows, needsAllWindows: true))
+    }
+
+    static func filterToCurrentSpace(_ rows: [SwitcherRow], _ spaces: SpaceResolution) -> [SwitcherRow] {
+        guard let active = spaces.activeSpace, !spaces.spaceByWindow.isEmpty else { return rows }
         var dropOffsets = Set<Int>()
-        for (offset, wid) in widByOffset {
-            if let space = spaceByWindow[wid], space != active { dropOffsets.insert(offset) }
+        for (offset, row) in rows.enumerated() where row.cgWindowID != 0 {
+            if let space = spaces.spaceByWindow[row.cgWindowID], space != active {
+                dropOffsets.insert(offset)
+            }
         }
         if dropOffsets.isEmpty { return rows }
         return rows.enumerated().filter { !dropOffsets.contains($0.offset) }.map(\.element)
+    }
+
+    /// Drop "phantom" windows: real CGWindow-backed rows that have never been
+    /// mapped to a Space. Electron apps (Teams, Signal, …) keep a hidden
+    /// `BrowserWindow` that the AX window list still reports — it has a valid
+    /// CGWindowID and standard subrole but a blank title, so it surfaces as a
+    /// duplicate row labelled with the bare app name. A never-shown window
+    /// belongs to no Space; minimized, hidden-app, other-Space and fullscreen
+    /// windows all keep theirs.
+    ///
+    /// Two guards keep the failure bias on the safe side — drop only what we're
+    /// sure is unreachable, never the user's actual window:
+    ///   1. Only *off-screen* windows are candidates. An on-screen window is by
+    ///      definition on a Space, so it's skipped without a Space query — which
+    ///      also bounds the per-window `CGSCopySpacesForWindows` IPCs to the few
+    ///      off-screen rows instead of every row on every reveal.
+    ///   2. A spaceless window is dropped only when its app *also* has a window
+    ///      that does occupy a Space (on-screen, or an off-screen sibling that
+    ///      resolved). A phantom always coexists with the app's real window, so
+    ///      this still catches it — but if an app's *only* window fails to
+    ///      resolve (a transient WindowServer miss), it's kept rather than
+    ///      vanishing from the switcher.
+    ///
+    /// Reads Space membership from the shared `SpaceResolution`; degrades to a
+    /// no-op when it's unavailable.
+    static func filterPhantomWindows(_ rows: [SwitcherRow], _ spaces: SpaceResolution) -> [SwitcherRow] {
+        guard spaces.activeSpace != nil else { return rows }
+
+        // Every window-bearing row tagged with whether WindowServer currently
+        // shows it. The wid is the one captured at enumeration time (no AX
+        // round-trip). Rows without a real window (placeholders/launchables/
+        // recents) carry wid 0 or no pid and are never candidates.
+        let windowRows: [(offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool)] =
+            rows.enumerated().compactMap { idx, row in
+                guard row.cgWindowID != 0, let pid = row.pid else { return nil }
+                return (idx, pid, row.cgWindowID, spaces.onScreen.contains(row.cgWindowID))
+            }
+        // `spaceByWindow` holds every wid that resolved to a Space (on-screen
+        // windows are included only when the current-Space filter forced a full
+        // query; otherwise on-screen rows are covered by their on-screen flag).
+        let dropOffsets = phantomWindowOffsets(
+            windowRows: windowRows,
+            resolvedCandidateWids: Set(spaces.spaceByWindow.keys)
+        )
+        if dropOffsets.isEmpty { return rows }
+        return rows.enumerated().filter { !dropOffsets.contains($0.offset) }.map(\.element)
+    }
+
+    /// Pure index-level core of `filterPhantomWindows`, split out so it can be
+    /// unit-tested without CGS calls or `SwitcherRow`/AX. `windowRows` is every
+    /// window-bearing row (offset, owning pid, wid, on-screen flag);
+    /// `resolvedCandidateWids` is the set of off-screen wids that resolved to a
+    /// Space. Returns the offsets to drop: off-screen, spaceless windows whose
+    /// app occupies a Space elsewhere (so a real window exists and this one is
+    /// the never-shown helper).
+    static func phantomWindowOffsets(
+        windowRows: [(offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool)],
+        resolvedCandidateWids: Set<CGWindowID>
+    ) -> Set<Int> {
+        // Apps with at least one window known to occupy a Space: any on-screen
+        // window, or any off-screen window that resolved.
+        var pidsOccupyingSpace = Set<pid_t>()
+        for r in windowRows where r.onScreen || resolvedCandidateWids.contains(r.wid) {
+            pidsOccupyingSpace.insert(r.pid)
+        }
+        var drop = Set<Int>()
+        for r in windowRows
+        where !r.onScreen
+            && !resolvedCandidateWids.contains(r.wid)
+            && pidsOccupyingSpace.contains(r.pid) {
+            drop.insert(r.offset)
+        }
+        return drop
+    }
+
+    /// WindowServer ids currently visible on the active Space(s), via one
+    /// `CGWindowListCopyWindowInfo` call. Used to skip the per-window Space query
+    /// for windows already known to be on screen (and therefore on a Space).
+    private static func onScreenWindowIDs() -> Set<CGWindowID> {
+        guard let arr = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [NSDictionary] else {
+            return []
+        }
+        var ids = Set<CGWindowID>()
+        ids.reserveCapacity(arr.count)
+        for entry in arr {
+            if let n = entry[kCGWindowNumber as String] as? Int { ids.insert(CGWindowID(n)) }
+        }
+        return ids
     }
 
     /// Row-level inclusion test split out so it can be unit-tested without

--- a/BetterCmdTab/System/PrivateAPIs.swift
+++ b/BetterCmdTab/System/PrivateAPIs.swift
@@ -128,36 +128,44 @@ enum PrivateAPI {
         return space == 0 ? nil : space
     }
 
-    /// Maps each window id to its single Space. Windows that belong to more
-    /// than one Space (All Desktops / sticky windows) are omitted along with
-    /// windows whose Space can't be resolved — they're visible on the current
-    /// Space too, and the current-Space filter keeps whatever it can't pin
-    /// down. The result is empty when the private API is unavailable (callers
-    /// should then degrade to showing every window).
-    static func spaces(forWindows wids: [CGWindowID]) -> [CGWindowID: UInt64] {
+    /// Classify each window id by Space membership in a single CGS pass.
+    /// `resolved[wid]` is its Space when the window belongs to exactly one
+    /// (`count == 1`); `spaceless` holds the wids WindowServer *positively*
+    /// reports as belonging to zero Spaces (`count == 0`) — a never-mapped
+    /// window, the phantom signal. Multi-Space (All Desktops / sticky,
+    /// `count > 1`) windows and windows whose query fails are in NEITHER set: a
+    /// sticky window is on the current Space by definition and a failed query is
+    /// unknown, so callers keep both. Both sets are empty when the private API is
+    /// unavailable (callers degrade to showing every window).
+    static func spaceMembership(forWindows wids: [CGWindowID]) -> (resolved: [CGWindowID: UInt64], spaceless: Set<CGWindowID>) {
         guard !wids.isEmpty,
               let mainConnection = mainConnectionFn,
-              let copySpaces = copySpacesForWindowsFn else { return [:] }
+              let copySpaces = copySpacesForWindowsFn else { return ([:], []) }
         let cid = mainConnection()
-        var result: [CGWindowID: UInt64] = [:]
-        result.reserveCapacity(wids.count)
+        var resolved: [CGWindowID: UInt64] = [:]
+        var spaceless = Set<CGWindowID>()
+        resolved.reserveCapacity(wids.count)
         for wid in wids where wid != 0 {
             // Query one window at a time: `CGSCopySpacesForWindows` returns the
             // union of Spaces for the whole input array, so a single call can't
             // be attributed back to individual windows.
             let list = [NSNumber(value: wid)] as CFArray
-            // == 1: a multi-Space window (All Desktops) is on the current Space
-            // by definition, so leave it unresolved and the filter keeps it.
-            guard let spaces = copySpaces(cid, 0x7, list)?.takeRetainedValue(),
-                  CFArrayGetCount(spaces) == 1,
-                  let raw = CFArrayGetValueAtIndex(spaces, 0) else { continue }
-            let number = Unmanaged<CFNumber>.fromOpaque(raw).takeUnretainedValue()
-            var space: UInt64 = 0
-            if CFNumberGetValue(number, .sInt64Type, &space), space != 0 {
-                result[wid] = space
+            guard let spaces = copySpaces(cid, 0x7, list)?.takeRetainedValue() else { continue }
+            let count = CFArrayGetCount(spaces)
+            if count == 0 {
+                // Positively belongs to no Space — a never-mapped phantom window.
+                spaceless.insert(wid)
+            } else if count == 1, let raw = CFArrayGetValueAtIndex(spaces, 0) {
+                let number = Unmanaged<CFNumber>.fromOpaque(raw).takeUnretainedValue()
+                var space: UInt64 = 0
+                if CFNumberGetValue(number, .sInt64Type, &space), space != 0 {
+                    resolved[wid] = space
+                }
             }
+            // count > 1: a multi-Space (All Desktops) window is on the current
+            // Space by definition — leave it in neither set so the filter keeps it.
         }
-        return result
+        return (resolved, spaceless)
     }
 
     /// One-shot startup diagnostic. Returns the list of dlsym symbols that

--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -73,11 +73,19 @@ struct AXRef: Hashable {
 struct CGWindowSnapshot {
     let ids: [pid_t: Set<CGWindowID>]
     let zOrder: [pid_t: [CGWindowID]]
+    /// Wids WindowServer reports at a non-switchable window level — Dock level
+    /// (20) and above (menus, status items, pop-ups, overlays, HUDs, notification
+    /// panels, screensaver) plus the sub-normal desktop band (< 0). Dropped during
+    /// enumeration so they never become switcher rows even though AX lists them as
+    /// standard windows. Floating/modal/utility windows (levels 1–19) are NOT here
+    /// — they are legitimate user windows and stay in the switcher.
+    let nonNormalLayer: [pid_t: Set<CGWindowID>]
 
-    static let empty = CGWindowSnapshot(ids: [:], zOrder: [:])
+    static let empty = CGWindowSnapshot(ids: [:], zOrder: [:], nonNormalLayer: [:])
 
     func ids(for pid: pid_t) -> Set<CGWindowID> { ids[pid] ?? [] }
     func zOrder(for pid: pid_t) -> [CGWindowID] { zOrder[pid] ?? [] }
+    func nonNormalLayer(for pid: pid_t) -> Set<CGWindowID> { nonNormalLayer[pid] ?? [] }
 }
 
 enum WindowEnumerator {
@@ -98,6 +106,36 @@ enum WindowEnumerator {
     private static let bruteForceStaleBudget: UInt64 = 256
     private static let preFilterTimeout: Float = 0.025
     private static let confirmedTimeout: Float = 0.2
+
+    /// Lowest CGWindow level we treat as a non-switchable overlay: Dock level
+    /// (20). Windows at this level and above are system surfaces (Dock, menus,
+    /// status items, pop-ups, overlays, HUDs, notification panels, screensaver);
+    /// levels 1–19 (floating "keep on top", modal panel, utility) are legitimate
+    /// user windows kept in the switcher.
+    static let dockWindowLevel = Int(CGWindowLevelForKey(.dockWindow))
+
+    /// Classification of a `CGWindowListCopyWindowInfo` entry for snapshot
+    /// bucketing. `.normal` windows feed the id/z-order hint; `.nonNormalLayer`
+    /// windows (Dock-level-and-above overlays plus the sub-normal desktop band)
+    /// are recorded so enumeration can drop them; `.excluded` covers invisible or
+    /// sub-100px surfaces ignored entirely. Layer takes precedence: a
+    /// non-switchable-layer window is `.nonNormalLayer` even if also tiny/transparent.
+    enum CGWindowBucket: Equatable {
+        case normal
+        case nonNormalLayer
+        case excluded
+    }
+
+    static func cgWindowBucket(layer: Int, alpha: Double, width: Double, height: Double) -> CGWindowBucket {
+        // Drop only non-switchable surfaces: Dock level (20) and above, plus the
+        // sub-normal desktop band (< 0). Levels 1–19 — floating ("keep on top"),
+        // modal panels, utility windows — are real user windows and stay. The
+        // Teams notification phantom sits at level 20 (Dock), so it's still caught.
+        if layer >= Self.dockWindowLevel || layer < 0 { return .nonNormalLayer }
+        if alpha <= 0 { return .excluded }
+        if width < 100 || height < 100 { return .excluded }
+        return .normal
+    }
 
     /// Snapshot of every window grouped by owner pid via the public
     /// `CGWindowListCopyWindowInfo` API. Uses `.optionAll` (not
@@ -122,24 +160,34 @@ enum WindowEnumerator {
         }
         var ids: [pid_t: Set<CGWindowID>] = [:]
         var zOrder: [pid_t: [CGWindowID]] = [:]
+        var nonNormalLayer: [pid_t: Set<CGWindowID>] = [:]
         for entry in cfArray {
             guard let ownerPID = entry[kCGWindowOwnerPID as String] as? pid_t else { continue }
-            let layer = (entry[kCGWindowLayer as String] as? Int) ?? 0
-            if layer != 0 { continue }
-            let alpha = (entry[kCGWindowAlpha as String] as? Double) ?? 1.0
-            if alpha <= 0 { continue }
             guard let widNum = entry[kCGWindowNumber as String] as? Int else { continue }
             let wid = CGWindowID(widNum)
+            let layer = (entry[kCGWindowLayer as String] as? Int) ?? 0
+            let alpha = (entry[kCGWindowAlpha as String] as? Double) ?? 1.0
+            // Missing bounds key => treat as large enough, preserving the prior
+            // "no bounds -> keep" behavior. A present-but-empty bounds dict yields
+            // 0 and is correctly excluded by the size gate inside cgWindowBucket.
+            var width = Double.greatestFiniteMagnitude
+            var height = Double.greatestFiniteMagnitude
             if let bounds = entry[kCGWindowBounds as String] as? NSDictionary {
-                let w = (bounds["Width"] as? Double) ?? 0
-                let h = (bounds["Height"] as? Double) ?? 0
-                if w < 100 || h < 100 { continue }
+                width = (bounds["Width"] as? Double) ?? 0
+                height = (bounds["Height"] as? Double) ?? 0
             }
-            if ids[ownerPID, default: []].insert(wid).inserted {
-                zOrder[ownerPID, default: []].append(wid)
+            switch cgWindowBucket(layer: layer, alpha: alpha, width: width, height: height) {
+            case .normal:
+                if ids[ownerPID, default: []].insert(wid).inserted {
+                    zOrder[ownerPID, default: []].append(wid)
+                }
+            case .nonNormalLayer:
+                nonNormalLayer[ownerPID, default: []].insert(wid)
+            case .excluded:
+                break
             }
         }
-        return CGWindowSnapshot(ids: ids, zOrder: zOrder)
+        return CGWindowSnapshot(ids: ids, zOrder: zOrder, nonNormalLayer: nonNormalLayer)
     }
 
     /// Back-compat entry point for the cold full-catalog paths (`AppCatalog`,
@@ -151,13 +199,15 @@ enum WindowEnumerator {
         forPid pid: pid_t,
         isRegularApp: Bool = true,
         expectedCGWindowIDs: Set<CGWindowID> = [],
-        cgZOrder: [CGWindowID] = []
+        cgZOrder: [CGWindowID] = [],
+        nonNormalLayerWids: Set<CGWindowID> = []
     ) -> [WindowInfo] {
         enumerate(
             forPid: pid,
             isRegularApp: isRegularApp,
             expectedCGWindowIDs: expectedCGWindowIDs,
-            cgZOrder: cgZOrder
+            cgZOrder: cgZOrder,
+            nonNormalLayerWids: nonNormalLayerWids
         ).windows
     }
 
@@ -197,7 +247,8 @@ enum WindowEnumerator {
         isRegularApp: Bool = true,
         expectedCGWindowIDs: Set<CGWindowID> = [],
         cgZOrder: [CGWindowID] = [],
-        knownUncoverable: Set<CGWindowID> = []
+        knownUncoverable: Set<CGWindowID> = [],
+        nonNormalLayerWids: Set<CGWindowID> = []
     ) -> (windows: [WindowInfo], uncoverable: Set<CGWindowID>) {
         let axApp = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(axApp, Self.confirmedTimeout)
@@ -225,6 +276,11 @@ enum WindowEnumerator {
             // AX-windows-list path silently didn't, which is the asymmetry
             // that allowed the flicker. Keep both paths consistent.
             guard wid != 0 else { return }
+            // Drop windows WindowServer reports at a non-normal window level
+            // (notification panels/HUDs/overlays). These are AX-listed as
+            // standard windows but are not user-switchable — e.g. the Teams
+            // Notification Center helper's off-screen "Window" at layer 20.
+            if nonNormalLayerWids.contains(wid) { return }
             if seenByWid.contains(wid) { return }
             seenByWid.insert(wid)
             seenByElement.insert(ref)

--- a/BetterCmdTabTests/CatalogFilterTests.swift
+++ b/BetterCmdTabTests/CatalogFilterTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Foundation
 import Testing
@@ -220,65 +221,153 @@ struct CatalogFilterTests {
 
     // MARK: - phantom-window filtering
 
-    private func win(_ offset: Int, _ pid: pid_t, _ wid: CGWindowID, onScreen: Bool)
-        -> (offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool) {
-        (offset, pid, wid, onScreen)
+    private func win(_ offset: Int, _ pid: pid_t, _ wid: CGWindowID, onScreen: Bool, minimized: Bool = false)
+        -> (offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool, isMinimized: Bool) {
+        (offset, pid, wid, onScreen, minimized)
     }
 
     @Test("phantom dropped when its app has an on-screen sibling")
     func phantomDroppedWithOnScreenSibling() {
         // The Teams case: pid 7's real chat window (9168) is on screen, its
-        // never-shown BrowserWindow (49502) is off screen and resolves to no
-        // Space → only the phantom is dropped.
+        // never-shown BrowserWindow (49502) is off screen and WindowServer
+        // positively reports it spaceless → only the phantom is dropped.
         let rows = [win(0, 7, 9168, onScreen: true), win(1, 7, 49502, onScreen: false)]
-        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [], spacelessWids: [49502])
         #expect(drop == [1])
     }
 
     @Test("phantom dropped when its app has an off-screen sibling that resolved")
     func phantomDroppedWithResolvedSibling() {
         // Neither window is on screen, but the real one (9168) resolves to a
-        // Space (e.g. it's on another desktop); the phantom (49502) does not.
+        // Space (e.g. it's on another desktop); the phantom (49502) is spaceless.
         let rows = [win(0, 7, 9168, onScreen: false), win(1, 7, 49502, onScreen: false)]
-        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [9168])
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [9168], spacelessWids: [49502])
         #expect(drop == [1])
     }
 
-    @Test("off-screen spaceless window kept when it's the app's only window")
-    func soleUnresolvedWindowKept() {
-        // No on-screen window and nothing resolved for pid 5 → its app has no
-        // window known to occupy a Space, so a transient query miss must NOT
-        // drop the user's only window.
+    @Test("spaceless window kept when it's the app's only window")
+    func soleSpacelessWindowKept() {
+        // Nothing resolved/on-screen for pid 5 → its app has no window known to
+        // occupy a Space, so even a confirmed-spaceless lone window is kept
+        // rather than vanishing entirely from the switcher.
         let rows = [win(0, 5, 100, onScreen: false)]
-        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [], spacelessWids: [100])
+        #expect(drop.isEmpty)
+    }
+
+    @Test("off-screen sticky / All-Desktops window kept (not confirmed spaceless)")
+    func stickyWindowKept() {
+        // pid 7: on-screen real window (9168) + an off-screen All-Desktops window
+        // (49502) that spaceMembership leaves UNRESOLVED (count > 1, so it's in
+        // neither resolved nor spaceless). It must be kept — only positively
+        // spaceless windows drop.
+        let rows = [win(0, 7, 9168, onScreen: true), win(1, 7, 49502, onScreen: false)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [], spacelessWids: [])
+        #expect(drop.isEmpty)
+    }
+
+    @Test("minimized window kept even if WindowServer reports it spaceless")
+    func minimizedSpacelessKept() {
+        // pid 7: on-screen sibling (9168) + a MINIMIZED window (49502) that
+        // failed to map to a Space. A minimized window is a real user window (the
+        // Electron phantom is never minimized), so it must not be dropped.
+        let rows = [win(0, 7, 9168, onScreen: true), win(1, 7, 49502, onScreen: false, minimized: true)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [], spacelessWids: [49502])
         #expect(drop.isEmpty)
     }
 
     @Test("on-screen windows are never dropped")
     func onScreenWindowsNeverDropped() {
         let rows = [win(0, 1, 200, onScreen: true), win(1, 2, 201, onScreen: true)]
-        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [], spacelessWids: [])
         #expect(drop.isEmpty)
     }
 
     @Test("phantom decision is per-app, not global")
     func phantomDecisionIsPerApp() {
-        // pid 7 has a real on-screen window + a phantom; pid 9 has a single
-        // off-screen unresolved window. Only pid 7's phantom is dropped — pid 9's
-        // lone window is kept because pid 9 occupies no known Space.
+        // pid 7 has a real on-screen window + a spaceless phantom; pid 9 has a
+        // single off-screen spaceless window. Only pid 7's phantom is dropped —
+        // pid 9's lone window is kept because pid 9 occupies no known Space.
         let rows = [
             win(0, 7, 9168, onScreen: true),
             win(1, 7, 49502, onScreen: false),
             win(2, 9, 300, onScreen: false),
         ]
-        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [], spacelessWids: [49502, 300])
         #expect(drop == [1])
     }
 
-    @Test("all windows kept when every off-screen window resolves")
-    func allResolvedKeepsEverything() {
+    @Test("all windows kept when none are spaceless")
+    func noSpacelessKeepsEverything() {
         let rows = [win(0, 1, 100, onScreen: false), win(1, 1, 200, onScreen: false)]
-        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [100, 200])
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [100, 200], spacelessWids: [])
         #expect(drop.isEmpty)
+    }
+
+    // MARK: - needsSpaceResolution (phantom-resolution gate)
+
+    @Test("multi-window app detected for the phantom-resolution gate")
+    func hasMultiWindowAppCore() {
+        #expect(!CatalogFilter.hasMultiWindowApp(pids: [7, 9, 11]))    // all distinct
+        #expect(CatalogFilter.hasMultiWindowApp(pids: [7, 9, 7]))      // pid 7 twice
+        #expect(!CatalogFilter.hasMultiWindowApp(pids: [nil, nil, 7])) // windowless rows ignored
+        #expect(!CatalogFilter.hasMultiWindowApp(pids: []))
+    }
+
+    @Test("current-Space-only forces resolution; otherwise empty/windowless rows skip it")
+    func needsSpaceResolutionGate() {
+        #expect(CatalogFilter.needsSpaceResolution([], config(currentSpaceOnly: true)))
+        #expect(!CatalogFilter.needsSpaceResolution([], config()))
+        // Launchable rows carry cgWindowID 0 → never counted, so the IPC sweep is
+        // skipped even with two rows sharing nothing.
+        #expect(!CatalogFilter.needsSpaceResolution([launchRow("com.a"), launchRow("com.b")], config()))
+    }
+
+    // MARK: - filterToCurrentSpace (cached-wid path) + degrade
+
+    /// A window-bearing row for the current process carrying an explicit wid.
+    /// Only `cgWindowID` is read by the Space filters; `window` can be nil.
+    private func spaceRow(_ wid: CGWindowID) -> SwitcherRow {
+        SwitcherRow(app: .current, window: nil, windowTitle: "", isMinimized: false, cgWindowID: wid)
+    }
+
+    private func resolution(spaceByWindow: [CGWindowID: UInt64], activeSpace: UInt64?) -> CatalogFilter.SpaceResolution {
+        CatalogFilter.SpaceResolution(spaceByWindow: spaceByWindow, confirmedSpaceless: [], onScreen: [], activeSpace: activeSpace)
+    }
+
+    @Test("current-Space filter drops a window on another Space, keeps active-Space")
+    func currentSpaceDropsOtherSpace() {
+        let active: UInt64 = 100
+        let rows = [spaceRow(10), spaceRow(20)]   // 10 on active space, 20 elsewhere
+        let res = resolution(spaceByWindow: [10: active, 20: 200], activeSpace: active)
+        let kept = CatalogFilter.filterToCurrentSpace(rows, res)
+        #expect(kept.map(\.cgWindowID) == [10])
+    }
+
+    @Test("current-Space filter keeps rows whose wid didn't resolve")
+    func currentSpaceKeepsUnresolved() {
+        let active: UInt64 = 100
+        let rows = [spaceRow(10), spaceRow(20)]   // 20 absent from the map
+        let res = resolution(spaceByWindow: [10: 200], activeSpace: active)
+        // 10 resolves to another space → dropped; 20 unresolved → kept.
+        let kept = CatalogFilter.filterToCurrentSpace(rows, res)
+        #expect(kept.map(\.cgWindowID) == [20])
+    }
+
+    @Test("current-Space filter keeps wid-0 (windowless) rows regardless")
+    func currentSpaceKeepsWindowlessRows() {
+        let active: UInt64 = 100
+        let rows = [spaceRow(10), launchRow("com.a")]   // launchRow carries wid 0
+        let res = resolution(spaceByWindow: [10: 200], activeSpace: active)
+        let kept = CatalogFilter.filterToCurrentSpace(rows, res)
+        #expect(kept.contains { $0.isLaunchable })       // wid-0 row always kept
+        #expect(!kept.contains { $0.cgWindowID == 10 })  // other-space window dropped
+    }
+
+    @Test("both Space filters no-op on the unavailable resolution")
+    func unavailableResolutionDegradesToNoOp() {
+        let rows = [spaceRow(10), spaceRow(20)]
+        #expect(CatalogFilter.filterToCurrentSpace(rows, .unavailable).count == 2)
+        #expect(CatalogFilter.filterPhantomWindows(rows, .unavailable).count == 2)
     }
 }

--- a/BetterCmdTabTests/CatalogFilterTests.swift
+++ b/BetterCmdTabTests/CatalogFilterTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Testing
 @testable import BetterCmdTab
@@ -215,5 +216,69 @@ struct CatalogFilterTests {
         let items = [(name: "a", pid: pid_t(3)), (name: "b", pid: pid_t(1)), (name: "c", pid: pid_t(2))]
         let result = CatalogFilter.applySortOrder(items, .launchOrder, name: { $0.name }, pid: { $0.pid })
         #expect(result.map(\.pid) == [1, 2, 3])
+    }
+
+    // MARK: - phantom-window filtering
+
+    private func win(_ offset: Int, _ pid: pid_t, _ wid: CGWindowID, onScreen: Bool)
+        -> (offset: Int, pid: pid_t, wid: CGWindowID, onScreen: Bool) {
+        (offset, pid, wid, onScreen)
+    }
+
+    @Test("phantom dropped when its app has an on-screen sibling")
+    func phantomDroppedWithOnScreenSibling() {
+        // The Teams case: pid 7's real chat window (9168) is on screen, its
+        // never-shown BrowserWindow (49502) is off screen and resolves to no
+        // Space → only the phantom is dropped.
+        let rows = [win(0, 7, 9168, onScreen: true), win(1, 7, 49502, onScreen: false)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        #expect(drop == [1])
+    }
+
+    @Test("phantom dropped when its app has an off-screen sibling that resolved")
+    func phantomDroppedWithResolvedSibling() {
+        // Neither window is on screen, but the real one (9168) resolves to a
+        // Space (e.g. it's on another desktop); the phantom (49502) does not.
+        let rows = [win(0, 7, 9168, onScreen: false), win(1, 7, 49502, onScreen: false)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [9168])
+        #expect(drop == [1])
+    }
+
+    @Test("off-screen spaceless window kept when it's the app's only window")
+    func soleUnresolvedWindowKept() {
+        // No on-screen window and nothing resolved for pid 5 → its app has no
+        // window known to occupy a Space, so a transient query miss must NOT
+        // drop the user's only window.
+        let rows = [win(0, 5, 100, onScreen: false)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        #expect(drop.isEmpty)
+    }
+
+    @Test("on-screen windows are never dropped")
+    func onScreenWindowsNeverDropped() {
+        let rows = [win(0, 1, 200, onScreen: true), win(1, 2, 201, onScreen: true)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        #expect(drop.isEmpty)
+    }
+
+    @Test("phantom decision is per-app, not global")
+    func phantomDecisionIsPerApp() {
+        // pid 7 has a real on-screen window + a phantom; pid 9 has a single
+        // off-screen unresolved window. Only pid 7's phantom is dropped — pid 9's
+        // lone window is kept because pid 9 occupies no known Space.
+        let rows = [
+            win(0, 7, 9168, onScreen: true),
+            win(1, 7, 49502, onScreen: false),
+            win(2, 9, 300, onScreen: false),
+        ]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [])
+        #expect(drop == [1])
+    }
+
+    @Test("all windows kept when every off-screen window resolves")
+    func allResolvedKeepsEverything() {
+        let rows = [win(0, 1, 100, onScreen: false), win(1, 1, 200, onScreen: false)]
+        let drop = CatalogFilter.phantomWindowOffsets(windowRows: rows, resolvedCandidateWids: [100, 200])
+        #expect(drop.isEmpty)
     }
 }

--- a/BetterCmdTabTests/WindowEnumeratorTests.swift
+++ b/BetterCmdTabTests/WindowEnumeratorTests.swift
@@ -53,4 +53,17 @@ struct WindowEnumeratorTests {
     func layerPrecedence() {
         #expect(WindowEnumerator.cgWindowBucket(layer: 20, alpha: 0.0, width: 50, height: 50) == .nonNormalLayer)
     }
+
+    @Test("missing bounds defaults to large enough -> normal")
+    func missingBoundsKept() {
+        // snapshotCGWindowMap defaults an absent bounds key to greatestFiniteMagnitude
+        // so a window with no bounds is kept (the prior "no bounds -> keep" behavior).
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: .greatestFiniteMagnitude, height: .greatestFiniteMagnitude) == .normal)
+    }
+
+    @Test("present-but-empty bounds (0x0) -> excluded")
+    func emptyBoundsExcluded() {
+        // A bounds dict missing Width/Height yields 0, which the size gate excludes.
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 0, height: 0) == .excluded)
+    }
 }

--- a/BetterCmdTabTests/WindowEnumeratorTests.swift
+++ b/BetterCmdTabTests/WindowEnumeratorTests.swift
@@ -1,0 +1,56 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import BetterCmdTab
+
+@Suite("WindowEnumerator")
+struct WindowEnumeratorTests {
+
+    // MARK: - cgWindowBucket
+
+    @Test("layer 0, opaque, large enough -> normal")
+    func normalWindow() {
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 200, height: 200) == .normal)
+    }
+
+    @Test("Dock-level-and-above overlays -> nonNormalLayer (the notification phantom)")
+    func notificationPhantom() {
+        // Teams Notification Center "Window": level 20 (Dock); a second helper at 103.
+        #expect(WindowEnumerator.cgWindowBucket(layer: 20, alpha: 1.0, width: 200, height: 200) == .nonNormalLayer)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 103, alpha: 1.0, width: 200, height: 200) == .nonNormalLayer)
+    }
+
+    @Test("floating / modal / utility windows (levels 1-19) stay switchable")
+    func keepBandWindows() {
+        // "Float on top" document window, modal panel, utility panel — real,
+        // user-reachable windows that must NOT be dropped.
+        #expect(WindowEnumerator.cgWindowBucket(layer: 3, alpha: 1.0, width: 200, height: 200) == .normal)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 8, alpha: 1.0, width: 200, height: 200) == .normal)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 19, alpha: 1.0, width: 200, height: 200) == .normal)
+    }
+
+    @Test("sub-normal desktop band -> nonNormalLayer")
+    func desktopBand() {
+        #expect(WindowEnumerator.cgWindowBucket(layer: -1, alpha: 1.0, width: 360, height: 360) == .nonNormalLayer)
+    }
+
+    @Test("Dock level is the drop floor; one below stays")
+    func dropFloorBoundary() {
+        let floor = WindowEnumerator.dockWindowLevel
+        #expect(WindowEnumerator.cgWindowBucket(layer: floor, alpha: 1.0, width: 200, height: 200) == .nonNormalLayer)
+        #expect(WindowEnumerator.cgWindowBucket(layer: floor - 1, alpha: 1.0, width: 200, height: 200) == .normal)
+    }
+
+    @Test("layer 0 but invisible or sub-100px -> excluded")
+    func excludedWindow() {
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 0.0, width: 200, height: 200) == .excluded)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 50, height: 50) == .excluded)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 200, height: 50) == .excluded)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 50, height: 200) == .excluded)
+    }
+
+    @Test("non-switchable layer takes precedence over alpha/size")
+    func layerPrecedence() {
+        #expect(WindowEnumerator.cgWindowBucket(layer: 20, alpha: 0.0, width: 50, height: 50) == .nonNormalLayer)
+    }
+}


### PR DESCRIPTION
## Summary

Electron apps (Teams, etc.) keep hidden helper windows that the Accessibility API reports as standard windows, so they surfaced in the switcher as duplicate or blank rows the user could never reach — e.g. a row literally titled "Window" plus a second "Microsoft Teams".

Two complementary, conservative filters, with Space membership resolved once per reveal and shared between them:

- **Spaceless windows** (`CatalogFilter`, display time) — an off-screen window WindowServer never mapped to a Space, while the same app has another window that does (the real one).
- **Non-switchable window levels** (`WindowEnumerator`, enumeration time) — Dock level (20) and above (notifications, HUDs, overlays) plus the sub-normal desktop band. Floating/modal/utility windows (levels 1–19) stay, so "keep on top" document windows are never dropped.

Both bias toward keeping real windows: a transient WindowServer miss leaves a window in place rather than hiding it.

## Test plan

- [x] Full suite passes (242 tests / 29 suites)
- [x] New unit tests for the layer classifier and the spaceless phantom filter
- [x] Verified live with Teams: phantom "Window" and duplicate "Microsoft Teams" gone; real chat window and floating/document windows of other apps kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #48
