### PR TITLE
ci: deploy web to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,60 @@
+name: Deploy web to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-web.yml"
+  workflow_dispatch:
+
+# Allow the GITHUB_TOKEN to deploy to Pages and verify the deployment origin.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; cancel superseded queued runs but let an in-flight one finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Add custom domain + SPA fallback
+        run: |
+          echo "bettercmdtab.app" > dist/CNAME
+          cp dist/index.html dist/404.html
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Highlights
Auto-publish the `web/` marketing site to GitHub Pages on push to `main`.

### Added
- `.github/workflows/deploy-web.yml` — Bun build (`bun run build`: tsc + vite + prerender) → upload `web/dist` → `deploy-pages`.
- Trigger: push to `main` touching `web/**` (or manual `workflow_dispatch`).
- Writes `dist/CNAME` (`bettercmdtab.app`) to keep the custom domain + `404.html` SPA fallback.

### Manual setup required (GitHub side, one-time)
1. Settings → Pages → **Source = GitHub Actions**.
2. Custom domain = `bettercmdtab.app`, enable **Enforce HTTPS**.
3. DNS: apex A `185.199.108–111.153` (+ AAAA `2606:50c0:8000–8003::153`); `www` CNAME `rokartur.github.io`.

Vite `base` stays `/` (custom-domain root) — matches the canonical/og URLs already in `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)