### PR TITLE
feat(web): add copyable Homebrew install command

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -183,6 +183,51 @@ h2 {
   transform-origin: center;
 }
 
+.brew {
+  display: inline-flex;
+  align-items: stretch;
+  margin-top: 14px;
+  max-width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #111;
+  overflow: hidden;
+}
+
+.brew-code {
+  display: block;
+  padding: 8px 14px;
+  color: var(--dim);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.brew-code::before {
+  content: "$ ";
+  color: var(--muted);
+}
+
+.brew-copy {
+  flex: none;
+  padding: 8px 14px;
+  border: 0;
+  border-left: 1px solid var(--border);
+  background: #161616;
+  color: var(--muted);
+  font-family: var(--mono);
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    background 0.2s;
+}
+
+.brew-copy:hover,
+.brew-copy:focus-visible {
+  color: var(--accent);
+  background: #1b1b1b;
+}
+
 .shots {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -184,9 +184,13 @@ h2 {
 }
 
 .brew {
+  margin-top: 14px;
+  max-width: 100%;
+}
+
+.brew-box {
   display: inline-flex;
   align-items: stretch;
-  margin-top: 14px;
   max-width: 100%;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -210,6 +214,11 @@ h2 {
 
 .brew-copy {
   flex: none;
+  /* fixed width so the Copy → Copied swap doesn't reflow the box */
+  min-width: 98px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 8px 14px;
   border: 0;
   border-left: 1px solid var(--border);
@@ -226,6 +235,17 @@ h2 {
 .brew-copy:focus-visible {
   color: var(--accent);
   background: #1b1b1b;
+}
+
+.brew-copy-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.brew-copy-inner svg {
+  display: block;
+  flex: none;
 }
 
 .shots {

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -9,6 +9,8 @@ export const Route = createFileRoute("/")({
 
 const REPO = "https://github.com/rokartur/BetterCmdTab";
 
+const BREW = "brew install --cask bettercmdtab";
+
 const EASE = [0.22, 1, 0.36, 1] as const;
 
 const reveal = {
@@ -451,6 +453,44 @@ function DownloadCta({ href }: { href: string }) {
   );
 }
 
+// Copyable Homebrew one-liner. clipboard access lives inside the click
+// handler, so this stays SSR-safe during the prerender (no top-level
+// navigator/window reference).
+function BrewCmd() {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<number | undefined>(undefined);
+
+  const copy = () => {
+    navigator.clipboard?.writeText(BREW).then(() => {
+      setCopied(true);
+      if (timer.current !== undefined) window.clearTimeout(timer.current);
+      timer.current = window.setTimeout(() => setCopied(false), 1600);
+    });
+  };
+
+  useEffect(
+    () => () => {
+      if (timer.current !== undefined) window.clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  return (
+    <motion.div className="brew" variants={reveal}>
+      <code className="brew-code">{BREW}</code>
+      <motion.button
+        type="button"
+        className="brew-copy"
+        onClick={copy}
+        aria-label={copied ? "Copied to clipboard" : "Copy Homebrew command"}
+        whileTap={{ scale: 0.96 }}
+      >
+        {copied ? "Copied" : "Copy"}
+      </motion.button>
+    </motion.div>
+  );
+}
+
 const downloadFmt = new Intl.NumberFormat("en-US");
 
 export function Home() {
@@ -504,6 +544,7 @@ export function Home() {
               macOS 13.0+ · Apple Silicon &amp; Intel
             </span>
           </motion.p>
+          <BrewCmd />
         </motion.section>
 
         <motion.section {...inView}>

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -453,6 +453,48 @@ function DownloadCta({ href }: { href: string }) {
   );
 }
 
+function CopyGlyph() {
+  return (
+    <svg
+      width="13"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="4.75" y="4.75" width="7.25" height="7.25" rx="1.5" />
+      <path d="M9.25 4.75 V3 A1.5 1.5 0 0 0 7.75 1.5 H3 A1.5 1.5 0 0 0 1.5 3 v4.75 A1.5 1.5 0 0 0 3 9.25 h1.75" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg
+      width="13"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <motion.path
+        d="M2.75 7.5 L5.75 10.5 L11.25 4"
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.32, ease: EASE }}
+      />
+    </svg>
+  );
+}
+
 // Copyable Homebrew one-liner. clipboard access lives inside the click
 // handler, so this stays SSR-safe during the prerender (no top-level
 // navigator/window reference).
@@ -477,16 +519,34 @@ function BrewCmd() {
 
   return (
     <motion.div className="brew" variants={reveal}>
-      <code className="brew-code">{BREW}</code>
-      <motion.button
-        type="button"
-        className="brew-copy"
-        onClick={copy}
-        aria-label={copied ? "Copied to clipboard" : "Copy Homebrew command"}
-        whileTap={{ scale: 0.96 }}
+      <motion.div
+        className="brew-box"
+        animate={{ borderColor: copied ? "#3b82f6" : "#222222" }}
+        transition={{ duration: 0.3, ease: EASE }}
       >
-        {copied ? "Copied" : "Copy"}
-      </motion.button>
+        <code className="brew-code">{BREW}</code>
+        <motion.button
+          type="button"
+          className="brew-copy"
+          onClick={copy}
+          aria-label={copied ? "Copied to clipboard" : "Copy Homebrew command"}
+          whileTap={{ scale: 0.95 }}
+        >
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.span
+              key={copied ? "done" : "idle"}
+              className="brew-copy-inner"
+              initial={{ opacity: 0, y: 9 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -9 }}
+              transition={{ duration: 0.18, ease: EASE }}
+            >
+              {copied ? <CheckGlyph /> : <CopyGlyph />}
+              {copied ? "Copied" : "Copy"}
+            </motion.span>
+          </AnimatePresence>
+        </motion.button>
+      </motion.div>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Highlights
Adds a one-click-copy Homebrew install command to the marketing site's Download section.

### Added
- Terminal-style box showing `brew install --cask bettercmdtab` with a **Copy** button (transient "Copied" state).
- Clipboard write lives inside the click handler → build-time prerender stays SSR-safe; command also ships in the prerendered HTML.

Verified: `bun run build` (tsc + vite + prerender) green, oxlint + oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)