### PR TITLE
feat: toggles to disable mouse hover/click window selection

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -464,6 +464,8 @@ final class Preferences: ObservableObject {
         static let currentSpaceOnly = "Switcher.currentSpaceOnly"
         static let directActivationBindings = "Switcher.directActivationBindings"
         static let scopedShortcutScopes = "Switcher.scopedShortcutScopes"
+        static let mouseHoverSelectionEnabled = "Switcher.mouseHoverSelectionEnabled"
+        static let mouseClickSelectionEnabled = "Switcher.mouseClickSelectionEnabled"
         static let hoverActionsEnabled = "Switcher.hoverActionsEnabled"
         static let hoverShowClose = "Switcher.hoverShowClose"
         static let hoverShowMinimize = "Switcher.hoverShowMinimize"
@@ -794,6 +796,28 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != vimNavigationEnabled else { return }
             UserDefaults.standard.set(vimNavigationEnabled, forKey: Keys.vimNavigationEnabled)
+        }
+    }
+
+    /// Move the switcher selection to the row under the pointer. Default on.
+    /// Off keeps the keyboard selection put so the mouse can't change the
+    /// highlighted row by accident (issue #47). Hover-action buttons still
+    /// appear under the pointer when `hoverActionsEnabled` is on.
+    @Published var mouseHoverSelectionEnabled: Bool {
+        didSet {
+            guard oldValue != mouseHoverSelectionEnabled else { return }
+            UserDefaults.standard.set(mouseHoverSelectionEnabled, forKey: Keys.mouseHoverSelectionEnabled)
+        }
+    }
+
+    /// Commit the switcher selection when a row is clicked. Default on. Off
+    /// ignores clicks inside the panel so the mouse can't pick a window by
+    /// accident (issue #47); the tab strip and hover-action buttons still work,
+    /// and click-outside-to-dismiss is unaffected.
+    @Published var mouseClickSelectionEnabled: Bool {
+        didSet {
+            guard oldValue != mouseClickSelectionEnabled else { return }
+            UserDefaults.standard.set(mouseClickSelectionEnabled, forKey: Keys.mouseClickSelectionEnabled)
         }
     }
 
@@ -1208,6 +1232,8 @@ final class Preferences: ObservableObject {
         self.currentSpaceOnly = defaults.object(forKey: Keys.currentSpaceOnly) as? Bool ?? false
         self.directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
         self.scopedShortcutScopes = Self.loadScopes(defaults.stringArray(forKey: Keys.scopedShortcutScopes))
+        self.mouseHoverSelectionEnabled = defaults.object(forKey: Keys.mouseHoverSelectionEnabled) as? Bool ?? true
+        self.mouseClickSelectionEnabled = defaults.object(forKey: Keys.mouseClickSelectionEnabled) as? Bool ?? true
         self.hoverActionsEnabled = defaults.object(forKey: Keys.hoverActionsEnabled) as? Bool ?? false
         self.hoverShowClose = defaults.object(forKey: Keys.hoverShowClose) as? Bool ?? true
         self.hoverShowMinimize = defaults.object(forKey: Keys.hoverShowMinimize) as? Bool ?? true
@@ -1270,6 +1296,8 @@ final class Preferences: ObservableObject {
         scrollReverseDirection = defaults.object(forKey: Keys.scrollReverseDirection) as? Bool ?? false
         clickOutsideToDismiss = defaults.object(forKey: Keys.clickOutsideToDismiss) as? Bool ?? true
         vimNavigationEnabled = defaults.object(forKey: Keys.vimNavigationEnabled) as? Bool ?? false
+        mouseHoverSelectionEnabled = defaults.object(forKey: Keys.mouseHoverSelectionEnabled) as? Bool ?? true
+        mouseClickSelectionEnabled = defaults.object(forKey: Keys.mouseClickSelectionEnabled) as? Bool ?? true
         cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false
         experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
         tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -42,6 +42,8 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let scrollReverseSwitch = NSSwitch()
     private let clickDismissSwitch = NSSwitch()
     private let vimNavSwitch = NSSwitch()
+    private let hoverSelectSwitch = NSSwitch()
+    private let clickSelectSwitch = NSSwitch()
 
     // Hover actions
     private let hoverSwitch = NSSwitch()
@@ -199,6 +201,14 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         addRow(to: navigation, title: String(localized: "Vim keys (h j k l)"),
                subtitle: String(localized: "Use h / j / k / l like the arrow keys while the switcher is open. h overrides the Hide binding and j / k / l override letter-jump; search mode still types those letters."),
                accessory: vimNavSwitch, searchItemID: SearchID.vimNavigation)
+        configureSwitch(hoverSelectSwitch, action: #selector(toggleHoverSelect(_:)))
+        addRow(to: navigation, title: String(localized: "Select window on hover"),
+               subtitle: String(localized: "Move the selection to the row your pointer is over. Off keeps the keyboard selection put so the mouse can't change it by accident."),
+               accessory: hoverSelectSwitch)
+        configureSwitch(clickSelectSwitch, action: #selector(toggleClickSelect(_:)))
+        addRow(to: navigation, title: String(localized: "Select window on click"),
+               subtitle: String(localized: "Click a row to switch to that window. Off ignores clicks inside the switcher so the mouse can't pick a window — the tab strip and hover actions still work."),
+               accessory: clickSelectSwitch)
 
         // Hover actions section — buttons revealed on a row under the pointer.
         let actions = addSection(title: String(localized: "Hover actions"), anchor: SettingsAnchor.actions)
@@ -258,6 +268,8 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         scrollReverseSwitch.isEnabled = prefs.scrollToSwitch
         clickDismissSwitch.state = prefs.clickOutsideToDismiss ? .on : .off
         vimNavSwitch.state = prefs.vimNavigationEnabled ? .on : .off
+        hoverSelectSwitch.state = prefs.mouseHoverSelectionEnabled ? .on : .off
+        clickSelectSwitch.state = prefs.mouseClickSelectionEnabled ? .on : .off
         hoverSwitch.state = prefs.hoverActionsEnabled ? .on : .off
         hoverCloseSwitch.state = prefs.hoverShowClose ? .on : .off
         hoverMinimizeSwitch.state = prefs.hoverShowMinimize ? .on : .off
@@ -400,6 +412,14 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleVimNavigation(_ sender: NSSwitch) {
         Preferences.shared.vimNavigationEnabled = (sender.state == .on)
+    }
+
+    @objc private func toggleHoverSelect(_ sender: NSSwitch) {
+        Preferences.shared.mouseHoverSelectionEnabled = (sender.state == .on)
+    }
+
+    @objc private func toggleClickSelect(_ sender: NSSwitch) {
+        Preferences.shared.mouseClickSelectionEnabled = (sender.state == .on)
     }
 
     @objc private func toggleHover(_ sender: NSSwitch) {

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -367,7 +367,13 @@ final class SwitcherView: NSView, TabStripDelegate {
         let idx = indexAtWindowPoint(event.locationInWindow)
         setHoveredIndex(idx ?? -1)
         if let idx {
-            delegate?.switcherViewDidHover(index: idx)
+            // Hover-select moves the selection to the row under the pointer; the
+            // user can turn it off so the mouse can't change the selection by
+            // accident (issue #47). The visual hover + action dots still track
+            // the pointer either way.
+            if Preferences.shared.mouseHoverSelectionEnabled {
+                delegate?.switcherViewDidHover(index: idx)
+            }
             // Highlight the hover-action dot under the pointer, if any.
             itemViews[idx].setHotDot(atWindowPoint: event.locationInWindow)
         }
@@ -406,7 +412,12 @@ final class SwitcherView: NSView, TabStripDelegate {
             delegate?.switcherViewDidInvokeAction(action, atIndex: idx)
             return
         }
-        delegate?.switcherViewDidClick(index: idx)
+        // Click-select commits the row under the pointer; the user can turn it
+        // off so a stray click inside the panel can't pick a window (issue #47).
+        // Tab-strip and hover-action clicks above stay live regardless.
+        if Preferences.shared.mouseClickSelectionEnabled {
+            delegate?.switcherViewDidClick(index: idx)
+        }
     }
 
     /// Re-entrancy guard: when the strip's scroll view can't use a wheel event


### PR DESCRIPTION
## Summary

Adds two independent **Switcher → Navigation** toggles so the mouse can't accidentally change the switcher selection while it's open. Both default **on** — existing behavior is unchanged.

- **Select window on hover** — off: the pointer no longer moves the selection (keyboard selection stays put). Visual hover + hover-action buttons still track the pointer.
- **Select window on click** — off: a click inside the panel no longer commits a row. Tab strip, hover-action buttons, and click-outside-to-dismiss are unaffected.

## Implementation

- `Preferences`: two persisted Bools (`mouseHoverSelectionEnabled` / `mouseClickSelectionEnabled`), default true, wired through `reloadFromDefaults` so settings import/export round-trips them.
- `SwitcherView`: `mouseMoved` gates the hover-select delegate call; `mouseDown` gates the click commit. Both read the preference on the main actor on the existing event path (one Bool read — no new allocation/hot-loop work).
- `SwitcherSettingsViewController`: two switches in the Navigation section mirroring the existing toggle pattern.

## Test plan

- [x] `BetterCmdTab Debug` builds (Debug)
- [x] Full unit suite green (229 tests / 28 suites) — settings keys round-trip
- [ ] Manual: with each toggle off, confirm hover/click no longer selects; tab strip + close-on-click-outside still work (live WindowServer + AX needed)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)