### PR TITLE
fix: hide menu-bar agent helper windows from the switcher

### DIFF
--- a/BetterCmdTab/Catalog/AppCatalog.swift
+++ b/BetterCmdTab/Catalog/AppCatalog.swift
@@ -59,8 +59,15 @@ enum AppCatalog {
             let windows = windowsBuffer[i]
             if app.activationPolicy == .regular {
                 enriched.append((app: app, windows: windows))
-            } else if app.activationPolicy == .accessory, !windows.isEmpty {
-                enriched.append((app: app, windows: windows))
+            } else if app.activationPolicy == .accessory {
+                // A menu-bar agent surfaces only its real, user-closable windows;
+                // its non-closable helper window (issue #43) is dropped. If none
+                // remain the agent contributes no row.
+                let keep = WindowEnumerator.switchableWindowIndices(
+                    isRegular: false, hasCloseButton: windows.map(\.hasCloseButton))
+                if !keep.isEmpty {
+                    enriched.append((app: app, windows: keep.map { windows[$0] }))
+                }
             }
         }
 

--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -284,8 +284,15 @@ final class AppCatalogCache {
             let windows = windowsBuffer[i]
             if app.activationPolicy == .regular {
                 dict[app.processIdentifier] = AppCacheEntry(app: app, windows: windows)
-            } else if app.activationPolicy == .accessory, !windows.isEmpty {
-                dict[app.processIdentifier] = AppCacheEntry(app: app, windows: windows)
+            } else if app.activationPolicy == .accessory {
+                // A menu-bar agent surfaces only its real, user-closable windows;
+                // its non-closable helper window (issue #43) is dropped. If none
+                // remain the agent contributes no entry.
+                let keep = WindowEnumerator.switchableWindowIndices(
+                    isRegular: false, hasCloseButton: windows.map(\.hasCloseButton))
+                if !keep.isEmpty {
+                    dict[app.processIdentifier] = AppCacheEntry(app: app, windows: keep.map { windows[$0] })
+                }
             }
         }
         return dict

--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -24,6 +24,12 @@ struct WindowInfo {
     /// for an ordinary single window and whenever "expand tabs as windows" is on
     /// (each tab is then its own `WindowInfo`).
     let tabWindows: [TabWindowRef]
+    /// Whether this window exposes an AX close button (the red traffic light) —
+    /// i.e. a real, user-closable standard window. Used to tell a menu-bar
+    /// agent's genuine utility window from its non-closable helper window so the
+    /// latter is dropped from the switcher (issue #43). Always true in practice
+    /// for `.regular` apps; only consulted for `.accessory` apps.
+    let hasCloseButton: Bool
 
     init(
         ref: AXUIElement,
@@ -32,7 +38,8 @@ struct WindowInfo {
         isMinimized: Bool,
         isFullscreen: Bool = false,
         tabs: [AXUIElement] = [],
-        tabWindows: [TabWindowRef] = []
+        tabWindows: [TabWindowRef] = [],
+        hasCloseButton: Bool = true
     ) {
         self.ref = ref
         self.cgWindowID = cgWindowID
@@ -41,6 +48,7 @@ struct WindowInfo {
         self.isFullscreen = isFullscreen
         self.tabs = tabs
         self.tabWindows = tabWindows
+        self.hasCloseButton = hasCloseButton
     }
 }
 
@@ -187,6 +195,19 @@ enum WindowEnumerator {
         coveredWids: Set<CGWindowID>
     ) -> Set<CGWindowID> {
         expectedCGWindowIDs.subtracting(coveredWids)
+    }
+
+    /// Which of an app's windows belong in the switcher, given its activation
+    /// policy and whether each window exposes a close button (a real,
+    /// user-closable standard window). `.regular` apps surface every window;
+    /// `.accessory` (menu-bar agent) apps surface only their closable windows,
+    /// so an agent's non-closable helper window — e.g. a "MenuBarAgent" status
+    /// surface (issue #43) — is dropped while a genuine utility/settings window
+    /// is kept. Pure, so it's unit-tested without AX. Returns kept indices.
+    static func switchableWindowIndices(isRegular: Bool, hasCloseButton: [Bool]) -> [Int] {
+        isRegular
+            ? Array(hasCloseButton.indices)
+            : hasCloseButton.indices.filter { hasCloseButton[$0] }
     }
 
     /// Full per-pid window enumeration. Returns the windows plus the
@@ -356,6 +377,7 @@ enum WindowEnumerator {
             kAXTitleAttribute,
             kAXPositionAttribute,
             kAXSizeAttribute,
+            kAXCloseButtonAttribute,
         ] as CFArray
         // Per-window attributes, fetched once each (one AX IPC per window —
         // same round-trip count as processing inline). We materialize them up
@@ -372,6 +394,7 @@ enum WindowEnumerator {
             let title: String
             let frameKey: String?
             let fromAXList: Bool
+            let hasCloseButton: Bool
         }
         var raws: [RawWindow] = []
         raws.reserveCapacity(elements.count)
@@ -379,7 +402,7 @@ enum WindowEnumerator {
             AXUIElementSetMessagingTimeout(window, Self.confirmedTimeout)
             var valuesRef: CFArray?
             guard AXUIElementCopyMultipleAttributeValues(window, attrNames, AXCopyMultipleAttributeOptions(rawValue: 0), &valuesRef) == .success,
-                  let values = valuesRef as? [AnyObject], values.count == 7 else { continue }
+                  let values = valuesRef as? [AnyObject], values.count == 8 else { continue }
 
             let subrole = (values[0] as? String) ?? ""
             guard acceptedSubroles.contains(subrole) else { continue }
@@ -388,6 +411,10 @@ enum WindowEnumerator {
             let minimized = (values[2] as? Bool) ?? false
             let fullscreen = (values[3] as? Bool) ?? false
             let windowTitle = (values[4] as? String) ?? ""
+            // A real, user-closable standard window exposes a close button
+            // (the red traffic light); a missing attribute comes back as an
+            // AXValue error placeholder, so check the value is an AXUIElement.
+            let hasCloseButton = CFGetTypeID(values[7] as CFTypeRef) == AXUIElementGetTypeID()
             // Minimized windows legitimately share (0, 0); fullscreen windows
             // each fill the same display bounds, so two separate fullscreen
             // windows of one app (each on its own Space — recovered by the brute
@@ -404,7 +431,8 @@ enum WindowEnumerator {
                 fullscreen: fullscreen,
                 title: windowTitle,
                 frameKey: frameKey,
-                fromAXList: axListRefs.contains(AXRef(element: window))
+                fromAXList: axListRefs.contains(AXRef(element: window)),
+                hasCloseButton: hasCloseButton
             ))
         }
 
@@ -436,7 +464,8 @@ enum WindowEnumerator {
                 isMinimized: raw.minimized,
                 isFullscreen: raw.fullscreen,
                 tabs: raw.tabs.count > 1 ? raw.tabs : [],
-                tabWindows: tabWindows
+                tabWindows: tabWindows,
+                hasCloseButton: raw.hasCloseButton
             ))
         }
 

--- a/BetterCmdTabTests/TabStackResolutionTests.swift
+++ b/BetterCmdTabTests/TabStackResolutionTests.swift
@@ -95,3 +95,35 @@ struct TabStackResolutionTests {
         #expect(r.siblingIndices.isEmpty)
     }
 }
+
+/// `switchableWindowIndices` decides which of an app's windows reach the
+/// switcher: every window for a regular app, only user-closable (real) windows
+/// for a menu-bar agent, so an agent's non-closable helper window is dropped
+/// (issue #43).
+@Suite("Agent helper-window filter")
+struct SwitchableWindowIndicesTests {
+
+    @Test("regular app surfaces every window, closable or not")
+    func regularKeepsAll() {
+        #expect(WindowEnumerator.switchableWindowIndices(isRegular: true, hasCloseButton: [true, false, true]) == [0, 1, 2])
+    }
+
+    @Test("accessory app keeps only its closable windows")
+    func accessoryKeepsClosable() {
+        // A menu-bar agent with a real settings window (closable) plus a
+        // non-closable status helper → only the real window survives.
+        #expect(WindowEnumerator.switchableWindowIndices(isRegular: false, hasCloseButton: [false, true]) == [1])
+    }
+
+    @Test("accessory app with no closable window contributes nothing")
+    func accessoryAllHelpersDropped() {
+        // The MenuBarAgent case: its only window has no close button → dropped.
+        #expect(WindowEnumerator.switchableWindowIndices(isRegular: false, hasCloseButton: [false]).isEmpty)
+        #expect(WindowEnumerator.switchableWindowIndices(isRegular: false, hasCloseButton: []).isEmpty)
+    }
+
+    @Test("accessory app with all-closable windows keeps them all")
+    func accessoryKeepsAllClosable() {
+        #expect(WindowEnumerator.switchableWindowIndices(isRegular: false, hasCloseButton: [true, true]) == [0, 1])
+    }
+}


### PR DESCRIPTION
## Problem

A menu-bar agent (`LSUIElement` / `.accessory` app) can keep a window the Accessibility API reports with a standard/dialog subrole but that the user can never reach — e.g. a "MenuBarAgent" status surface. It surfaced as a switcher row (#43).

Agent apps with windows are **deliberately** included (some menu-bar utilities have a real settings/main window worth ⌘Tab-ing to), so dropping all `.accessory` apps would be an over-fix that hides legitimate windows.

## Fix

Discriminate by the window, not the app: a real, user-closable window exposes an AX **close button** (the red traffic light); an agent's helper/overlay window does not.

- `WindowEnumerator`: the per-window attribute batch also fetches `kAXCloseButtonAttribute` — **no extra IPC**, just one more value in the existing `AXUIElementCopyMultipleAttributeValues` call — and records `hasCloseButton` on `WindowInfo`.
- Catalog enrichment (`AppCatalog` + `AppCatalogCache`): an `.accessory` app keeps only its closable windows (`WindowEnumerator.switchableWindowIndices`); if none remain it contributes no row. `.regular` apps are unchanged.

## Trade-off

The discriminator is the close button. A genuine agent window with custom chrome and no AX close button would also be dropped — acceptable and matches the report's intent ("a window you can close, behaves like a normal Window"). Regular apps are never affected.

## Test plan

- [x] Full unit suite green (233 tests / 29 suites), incl. new `switchableWindowIndices` tests
- [ ] Manual: confirm the reporter's MenuBarAgent row is gone while a real menu-bar utility's settings window still appears (live AX needed)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)