### PR TITLE
diag: log panel/Space visibility on reveal (#46, not for merge)

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -391,6 +391,9 @@ final class SwitcherController: SwitcherViewDelegate {
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            // [#46 diagnostics — temporary] Mark each Space flip so a repro log
+            // shows the order of space-change vs. the next reveal's present().
+            Log.spaceDiag.notice("activeSpaceDidChange activeSpace=\(PrivateAPI.activeSpace().map(String.init) ?? "nil", privacy: .public)")
             Task { @MainActor [weak self] in self?.updateTriggerSuppression() }
         }
     }

--- a/BetterCmdTab/Switcher/SwitcherPanel.swift
+++ b/BetterCmdTab/Switcher/SwitcherPanel.swift
@@ -181,6 +181,14 @@ final class SwitcherPanel: NSPanel {
         }
         CATransaction.commit()
         onFrameDidChange?(Self.cgGlobalFrame(from: frame))
+        // [#46 diagnostics] Capture state right after order-front, and again on
+        // the next runloop once the WindowServer settles, so a repro shows
+        // whether an "invisible" panel is off-active-space, off-screen, occluded,
+        // or simply never ordered in.
+        logSpaceDiagnostics("present.sync", chosenScreen: screen)
+        DispatchQueue.main.async { [weak self] in
+            self?.logSpaceDiagnostics("present.deferred", chosenScreen: nil)
+        }
         // A non-activating panel isn't always granted key on the first
         // `makeKeyAndOrderFront` if another app is mid-activation when the switcher
         // opens; re-key on the next runloop (same approach as `resignKey`) so the
@@ -189,6 +197,29 @@ final class SwitcherPanel: NSPanel {
             guard let self, self.isVisible, !self.isKeyWindow else { return }
             self.makeKeyAndOrderFront(nil)
         }
+    }
+
+    /// [#46 diagnostics — temporary] Log the panel/Space visibility state so the
+    /// "panel invisible on another Space after a full-screen app quits" repro
+    /// can be pinned down. Not for release — remove once #46 is fixed.
+    private func logSpaceDiagnostics(_ phase: String, chosenScreen: NSScreen?) {
+        let screens = NSScreen.screens
+        let chosen = chosenScreen ?? activeScreen()
+        let screenIndex = screens.firstIndex { $0 == chosen } ?? -1
+        let frameOnScreen = chosen.frame.intersects(frame)
+        let activeSpace = PrivateAPI.activeSpace().map(String.init) ?? "nil"
+        let occVisible = occlusionState.contains(.visible)
+        Log.spaceDiag.notice("""
+        [\(phase, privacy: .public)] visible=\(self.isVisible, privacy: .public) \
+        key=\(self.isKeyWindow, privacy: .public) onActiveSpace=\(self.isOnActiveSpace, privacy: .public) \
+        occVisible=\(occVisible, privacy: .public) level=\(self.level.rawValue, privacy: .public) \
+        collBehavior=\(self.collectionBehavior.rawValue, privacy: .public) \
+        activeSpace=\(activeSpace, privacy: .public) \
+        screens=\(screens.count, privacy: .public) chosenScreenIdx=\(screenIndex, privacy: .public) \
+        panelFrame=\(NSStringFromRect(self.frame), privacy: .public) \
+        chosenScreenFrame=\(NSStringFromRect(chosen.frame), privacy: .public) \
+        frameOnChosenScreen=\(frameOnScreen, privacy: .public)
+        """)
     }
 
     /// Hide the panel. `NSGlassEffectView` / `NSVisualEffectView` is a

--- a/BetterCmdTab/System/Log.swift
+++ b/BetterCmdTab/System/Log.swift
@@ -12,6 +12,10 @@ enum Log {
     static let activator = Logger(subsystem: subsystem, category: "activator")
     static let priv = Logger(subsystem: subsystem, category: "private-api")
     static let launch = Logger(subsystem: subsystem, category: "launch-at-login")
+    /// Temporary diagnostics for the "panel invisible on another Space after a
+    /// full-screen app quits" report (#46). Capture with:
+    ///   log stream --predicate 'subsystem == "pro.bettercmdtab.BetterCmdTab" AND category == "space-diag"' --info
+    static let spaceDiag = Logger(subsystem: subsystem, category: "space-diag")
 
     /// Points-of-Interest signposter for the ⌘Tab reveal hot path. Use to capture
     /// where the panel-appearance latency goes in Instruments (Points of Interest


### PR DESCRIPTION
## ⚠️ Diagnostics only — do not merge

Per the decision to **diagnose #46 before fixing**, this branch adds temporary logging to pin down why the switcher panel goes invisible on another Space after a full-screen app is quit. It will be reverted once the root cause is known and a real fix lands.

#46 repro: full-screen an app (Fn+F) → ⌘Q it → dropped to Desktop → ⌘Tab to an app on another Space → switch to it → on that Space ⌘Tab no longer **shows** the panel (switching still works). Un/re-full-screening fixes it.

The panel already sets `[.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]`, so "it's not on this Space" shouldn't happen — the logs will say what actually does.

## What it logs (`category == "space-diag"`)

On every `SwitcherPanel.present()` (sync + next runloop) and on each `activeSpaceDidChange`:
`isVisible`, `isKeyWindow`, `isOnActiveSpace`, occlusion-visible, window `level`, `collectionBehavior`, active Space id, screen count, chosen-screen index, panel frame, chosen-screen frame, and whether the panel frame intersects the chosen screen.

## How to capture (for the maintainer)

1. Run this branch's `BetterCmdTab Debug` build.
2. In a terminal:
   ```
   log stream --predicate 'subsystem == "pro.bettercmdtab.BetterCmdTab" AND category == "space-diag"' --info
   ```
3. Reproduce the bug, then ⌘Tab a few times on the broken Space and on a working Space.
4. Paste the log lines into #46.

Key tells: `onActiveSpace=false` → collectionBehavior/space-association issue; `frameOnChosenScreen=false` → `activeScreen()` picked a stale/disconnected screen; `visible=false` → order-front itself didn't take.

Refs #46