### PR TITLE
feat: searchable browser tabs, result ranking, and type-to-search

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -792,6 +792,7 @@ final class Preferences: ObservableObject {
         static let stayOpenOnQuickTap = "Switcher.stayOpenOnQuickTap"
         static let searchIncludesLaunchableApps = "Switcher.searchIncludesLaunchableApps"
         static let fuzzySearchRankBestMatchFirst = "Switcher.fuzzySearchRankBestMatchFirst"
+        static let searchExpandsBrowserTabs = "Switcher.searchExpandsBrowserTabs"
         static let showRecentlyClosed = "Switcher.showRecentlyClosed"
         static let recentlyClosedLimit = "Switcher.recentlyClosedLimit"
         static let hapticOnCommit = "Switcher.hapticOnCommit"
@@ -1123,6 +1124,18 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != fuzzySearchRankBestMatchFirst else { return }
             UserDefaults.standard.set(fuzzySearchRankBestMatchFirst, forKey: Keys.fuzzySearchRankBestMatchFirst)
+        }
+    }
+
+    /// Experimental. While the search field is active, expand browser windows
+    /// into one row per tab — for the search only — so a query can match a
+    /// background tab. Transient: the rows never enter the canonical list and
+    /// collapse back on exit. No effect when `expandBrowserTabsAsWindows` is on
+    /// (the list is already expanded). Default off.
+    @Published var searchExpandsBrowserTabs: Bool {
+        didSet {
+            guard oldValue != searchExpandsBrowserTabs else { return }
+            UserDefaults.standard.set(searchExpandsBrowserTabs, forKey: Keys.searchExpandsBrowserTabs)
         }
     }
 
@@ -1887,6 +1900,7 @@ final class Preferences: ObservableObject {
 
         self.searchIncludesLaunchableApps = defaults.object(forKey: Keys.searchIncludesLaunchableApps) as? Bool ?? true
         self.fuzzySearchRankBestMatchFirst = defaults.object(forKey: Keys.fuzzySearchRankBestMatchFirst) as? Bool ?? false
+        self.searchExpandsBrowserTabs = defaults.object(forKey: Keys.searchExpandsBrowserTabs) as? Bool ?? false
         self.showRecentlyClosed = defaults.object(forKey: Keys.showRecentlyClosed) as? Bool ?? false
         self.recentlyClosedLimit = defaults.object(forKey: Keys.recentlyClosedLimit) as? Int ?? 5
 
@@ -2024,6 +2038,7 @@ final class Preferences: ObservableObject {
         stayOpenOnQuickTap = defaults.object(forKey: Keys.stayOpenOnQuickTap) as? Bool ?? false
         searchIncludesLaunchableApps = defaults.object(forKey: Keys.searchIncludesLaunchableApps) as? Bool ?? true
         fuzzySearchRankBestMatchFirst = defaults.object(forKey: Keys.fuzzySearchRankBestMatchFirst) as? Bool ?? false
+        searchExpandsBrowserTabs = defaults.object(forKey: Keys.searchExpandsBrowserTabs) as? Bool ?? false
         showRecentlyClosed = defaults.object(forKey: Keys.showRecentlyClosed) as? Bool ?? false
         recentlyClosedLimit = defaults.object(forKey: Keys.recentlyClosedLimit) as? Int ?? 5
 

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -791,6 +791,7 @@ final class Preferences: ObservableObject {
         static let stayOpenOnRelease = "Switcher.stayOpenOnRelease"
         static let stayOpenOnQuickTap = "Switcher.stayOpenOnQuickTap"
         static let searchIncludesLaunchableApps = "Switcher.searchIncludesLaunchableApps"
+        static let fuzzySearchRankBestMatchFirst = "Switcher.fuzzySearchRankBestMatchFirst"
         static let showRecentlyClosed = "Switcher.showRecentlyClosed"
         static let recentlyClosedLimit = "Switcher.recentlyClosedLimit"
         static let hapticOnCommit = "Switcher.hapticOnCommit"
@@ -1112,6 +1113,16 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != searchIncludesLaunchableApps else { return }
             UserDefaults.standard.set(searchIncludesLaunchableApps, forKey: Keys.searchIncludesLaunchableApps)
+        }
+    }
+
+    /// Experimental. Rank fuzzy-search results best-match-first (contiguous and
+    /// word-boundary matches in the app name win) instead of showing them in
+    /// catalog/MRU order. Default off.
+    @Published var fuzzySearchRankBestMatchFirst: Bool {
+        didSet {
+            guard oldValue != fuzzySearchRankBestMatchFirst else { return }
+            UserDefaults.standard.set(fuzzySearchRankBestMatchFirst, forKey: Keys.fuzzySearchRankBestMatchFirst)
         }
     }
 
@@ -1875,6 +1886,7 @@ final class Preferences: ObservableObject {
         self.stayOpenOnQuickTap = defaults.object(forKey: Keys.stayOpenOnQuickTap) as? Bool ?? false
 
         self.searchIncludesLaunchableApps = defaults.object(forKey: Keys.searchIncludesLaunchableApps) as? Bool ?? true
+        self.fuzzySearchRankBestMatchFirst = defaults.object(forKey: Keys.fuzzySearchRankBestMatchFirst) as? Bool ?? false
         self.showRecentlyClosed = defaults.object(forKey: Keys.showRecentlyClosed) as? Bool ?? false
         self.recentlyClosedLimit = defaults.object(forKey: Keys.recentlyClosedLimit) as? Int ?? 5
 
@@ -2011,6 +2023,7 @@ final class Preferences: ObservableObject {
         stayOpenOnRelease = defaults.object(forKey: Keys.stayOpenOnRelease) as? Bool ?? false
         stayOpenOnQuickTap = defaults.object(forKey: Keys.stayOpenOnQuickTap) as? Bool ?? false
         searchIncludesLaunchableApps = defaults.object(forKey: Keys.searchIncludesLaunchableApps) as? Bool ?? true
+        fuzzySearchRankBestMatchFirst = defaults.object(forKey: Keys.fuzzySearchRankBestMatchFirst) as? Bool ?? false
         showRecentlyClosed = defaults.object(forKey: Keys.showRecentlyClosed) as? Bool ?? false
         recentlyClosedLimit = defaults.object(forKey: Keys.recentlyClosedLimit) as? Int ?? 5
 

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -246,6 +246,12 @@ final class HotkeyTap: @unchecked Sendable {
     /// close. `nil` while idle — no timer exists unless Shift is actively held
     /// with the switcher open.
     private let shiftRepeatTimer = OSAllocatedUnfairLock<DispatchSourceTimer?>(initialState: nil)
+    /// Type-to-search: when letter hints are off and fuzzy search is on, every
+    /// letter (incl. the reserved action keys w/m/h/q/f) opens/extends the query
+    /// instead of firing a panel action, so typing filters the switcher like
+    /// Spotlight. Consulted on the tap thread, written from main via
+    /// `setTypeToSearchEnabled`. Default off.
+    private let typeToSearchFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
     /// Rebindable in-panel action keys (#5): physical keycode → action. Consulted
     /// in the non-search switching branch before the letter-jump fallback, so a
     /// bound key suppresses letter-jumping (same as the old hardcoded W/M/H/Q).
@@ -731,6 +737,26 @@ final class HotkeyTap: @unchecked Sendable {
         // from hint generation while vim nav is on), so recompute and re-push to
         // RowLabels on every toggle — not only on binding/layout changes.
         recomputeReservedLetters()
+    }
+
+    /// Enable/disable type-to-search routing (letter hints off + fuzzy on).
+    /// Consulted on the tap thread; written from main when either preference
+    /// changes.
+    func setTypeToSearchEnabled(_ value: Bool) {
+        typeToSearchFlag.withLock { $0 = value }
+    }
+
+    /// Pure: the lowercased a–z letter a key should feed into type-to-search, or
+    /// `nil` if the character can't open a query. Unlike letter-jump this
+    /// deliberately does NOT exclude the reserved action letters (w/m/h/q/f) — in
+    /// type-to-search mode every letter must reach the query, so typing e.g.
+    /// "whatsapp" or "figma" filters instead of closing/minimizing the
+    /// highlighted item. Stateless so the tests can exercise it directly.
+    static func typeToSearchLetter(for character: Character) -> Character? {
+        let lower = Character(character.lowercased())
+        guard lower.isLetter, let ascii = lower.asciiValue,
+              ascii >= 0x61, ascii <= 0x7A else { return nil }
+        return lower
     }
 
     /// Pure mapping from a typed character to the corresponding nav `Event`,
@@ -1280,17 +1306,18 @@ final class HotkeyTap: @unchecked Sendable {
                             // hint generation never assigns them as letter-jump
                             // hints the tap would silently swallow here.
                             //
-                            // `translate` is the only thing the vim check needs
-                            // ahead of `panelKeyMap`, so it is computed only when
-                            // the vim flag is on — keeping the default (vim-off)
-                            // hot path free of any added cost: a bound action key
-                            // (⌘W/⌘M/⌘H/⌘Q/⌘F) still short-circuits in
-                            // `panelKeyMap` below without ever paying a translate.
-                            // When vim is on the resolved character is reused by
-                            // the letter-jump branch, so a keystroke is still
+                            // `translate` is needed only by the vim check and the
+                            // type-to-search opener ahead of `panelKeyMap`, so it
+                            // is computed only when either flag is on — keeping the
+                            // default (both off) hot path free of any added cost: a
+                            // bound action key (⌘W/⌘M/⌘H/⌘Q/⌘F) still short-circuits
+                            // in `panelKeyMap` below without ever paying a translate.
+                            // When it is computed, the resolved character is reused
+                            // by the branches below, so a keystroke is still
                             // translated at most once.
                             let vimOn = vimNavigationFlag.withLock { $0 }
-                            let typed = vimOn ? translate(keyCode: UInt16(keyCode)) : nil
+                            let typeToSearch = typeToSearchFlag.withLock { $0 }
+                            let typed = (vimOn || typeToSearch) ? translate(keyCode: UInt16(keyCode)) : nil
                             if vimOn,
                                Self.onlyTriggerModifiersHeld(
                                    flags,
@@ -1299,6 +1326,21 @@ final class HotkeyTap: @unchecked Sendable {
                                let ch = typed,
                                let vimEvent = Self.vimNavigationEvent(for: Character(ch.lowercased())) {
                                 deliver(vimEvent)
+                                return nil
+                            }
+                            // Type-to-search opener: route every letter (incl. the
+                            // reserved action keys w/m/h/q/f) into the query instead
+                            // of firing a panel action, so a search like "whatsapp"
+                            // or "figma" works. Before `panelKeyMap` so action keys
+                            // don't win; after the vim check so h/j/k/l still
+                            // navigate. ⌥/⌃ pass through (⌘ holds the panel open, ⇧
+                            // is a capital). Only the first keystroke routes here —
+                            // `enterSearch` then sets search mode, after which the
+                            // `isSearchingNow()` branch handles all input.
+                            if typeToSearch, !optionHeld, !controlHeld,
+                               let ch = typed,
+                               let lower = Self.typeToSearchLetter(for: ch) {
+                                deliver(.letterInput(lower))
                                 return nil
                             }
                             if let action = panelKeyMap.withLock({ $0[keyCode] }) {

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -746,17 +746,19 @@ final class HotkeyTap: @unchecked Sendable {
         typeToSearchFlag.withLock { $0 = value }
     }
 
-    /// Pure: the lowercased a–z letter a key should feed into type-to-search, or
-    /// `nil` if the character can't open a query. Unlike letter-jump this
-    /// deliberately does NOT exclude the reserved action letters (w/m/h/q/f) — in
-    /// type-to-search mode every letter must reach the query, so typing e.g.
-    /// "whatsapp" or "figma" filters instead of closing/minimizing the
-    /// highlighted item. Stateless so the tests can exercise it directly.
+    /// Pure: the character a key should feed into type-to-search, or `nil` if
+    /// it can't open a query. Unlike letter-jump this deliberately does NOT
+    /// exclude the reserved action letters (w/m/h/q/f) — in type-to-search mode
+    /// every letter must reach the query, so typing e.g. "whatsapp" or "figma"
+    /// filters instead of closing/minimizing the highlighted item. Letters in
+    /// any script (ż, é, ü…) and digits ("1Password") open the query too,
+    /// matching what the search branch accepts once search mode is active;
+    /// everything else (space, \, /, arrows…) keeps its panel meaning.
+    /// Stateless so the tests can exercise it directly.
     static func typeToSearchLetter(for character: Character) -> Character? {
-        let lower = Character(character.lowercased())
-        guard lower.isLetter, let ascii = lower.asciiValue,
-              ascii >= 0x61, ascii <= 0x7A else { return nil }
-        return lower
+        if character.isLetter { return Character(character.lowercased()) }
+        if character.isNumber { return character }
+        return nil
     }
 
     /// Pure mapping from a typed character to the corresponding nav `Event`,
@@ -1328,10 +1330,11 @@ final class HotkeyTap: @unchecked Sendable {
                                 deliver(vimEvent)
                                 return nil
                             }
-                            // Type-to-search opener: route every letter (incl. the
-                            // reserved action keys w/m/h/q/f) into the query instead
-                            // of firing a panel action, so a search like "whatsapp"
-                            // or "figma" works. Before `panelKeyMap` so action keys
+                            // Type-to-search opener: route every letter and digit
+                            // (incl. the reserved action keys w/m/h/q/f) into the
+                            // query instead of firing a panel action, so a search
+                            // like "whatsapp", "figma" or "1password" works — in
+                            // any keyboard layout. Before `panelKeyMap` so action keys
                             // don't win; after the vim check so h/j/k/l still
                             // navigate. ⌥/⌃ pass through (⌘ holds the panel open, ⇧
                             // is a capital). Only the first keystroke routes here —

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -205,6 +205,40 @@
         }
       }
     },
+    "Order results by how well they match instead of by recent use, so the closest match is selected first." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sortiert die Ergebnisse danach, wie gut sie passen, statt nach letzter Nutzung – der beste Treffer ist zuerst ausgewählt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordena los resultados según lo bien que coinciden en lugar de por uso reciente, de modo que la mejor coincidencia queda seleccionada primero."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classe les résultats selon leur pertinence plutôt que par utilisation récente, afin que la meilleure correspondance soit sélectionnée en premier."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porządkuje wyniki według trafności zamiast ostatniego użycia, więc najlepsze dopasowanie jest zaznaczane jako pierwsze."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按匹配程度而非最近使用来排序结果，最接近的匹配项会最先被选中。"
+          }
+        }
+      }
+    },
     "Peek windows with ↓" : {
       "localizations" : {
         "de" : {
@@ -235,6 +269,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按 ↓ 查看窗口"
+          }
+        }
+      }
+    },
+    "Rank search" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suchtreffer sortieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar resultados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classer les résultats"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ranking wyników"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索结果排序"
           }
         }
       }
@@ -273,6 +341,74 @@
         }
       }
     },
+    "Search browser tabs" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Tabs durchsuchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar pestañas del navegador"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans les onglets du navigateur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szukaj w kartach przeglądarki"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索浏览器标签页"
+          }
+        }
+      }
+    },
+    "Searching matches any browser tab by its title, not just each window's active tab. Matching tabs appear as temporary rows while the search field is active and disappear when you leave search. Not needed if you already use “Show browser tabs as separate entries.”" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Suche findet jeden Browser-Tab über seinen Titel, nicht nur den aktiven Tab jedes Fensters. Passende Tabs erscheinen als vorübergehende Zeilen, solange das Suchfeld aktiv ist, und verschwinden beim Verlassen der Suche. Nicht nötig, wenn „Browser-Tabs als separate Einträge anzeigen“ bereits aktiv ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La búsqueda encuentra cualquier pestaña del navegador por su título, no solo la pestaña activa de cada ventana. Las pestañas coincidentes aparecen como filas temporales mientras el campo de búsqueda está activo y desaparecen al salir de la búsqueda. No es necesario si ya usas «Mostrar las pestañas del navegador como entradas separadas»."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La recherche trouve n’importe quel onglet du navigateur par son titre, pas seulement l’onglet actif de chaque fenêtre. Les onglets correspondants apparaissent comme lignes temporaires tant que le champ de recherche est actif et disparaissent quand vous quittez la recherche. Inutile si vous utilisez déjà « Afficher les onglets du navigateur comme entrées distinctes »."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukiwanie dopasowuje każdą kartę przeglądarki po jej tytule, nie tylko aktywną kartę każdego okna. Pasujące karty pojawiają się jako tymczasowe pozycje, gdy pole wyszukiwania jest aktywne, i znikają po wyjściu z wyszukiwania. Zbędne, jeśli używasz już „Pokazuj karty przeglądarki jako osobne pozycje”."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索会按标题匹配任意浏览器标签页，而不只是每个窗口的活动标签页。匹配的标签页在搜索框激活期间显示为临时条目，退出搜索后消失。如果已开启“将浏览器标签页显示为单独条目”，则无需此选项。"
+          }
+        }
+      }
+    },
     "Serif" : {
       "localizations" : {
         "de" : {
@@ -303,6 +439,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "衬线"
+          }
+        }
+      }
+    },
+    "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing / — action keys like W or Q then type into the search rather than acting on a window." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt auf jedem Fenster einen Buchstaben an und springt durch Tippen dieses Buchstabens dorthin. Ausgeschaltet filtert Tippen stattdessen die Liste, ohne / zu drücken — Aktionstasten wie W oder Q schreiben dann in die Suche, statt auf ein Fenster zu wirken."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra una letra en cada ventana y salta a ella escribiendo esa letra. Desactívalo para filtrar la lista simplemente escribiendo, sin pulsar / — las teclas de acción como W o Q escriben entonces en la búsqueda en lugar de actuar sobre una ventana."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche une lettre sur chaque fenêtre et y accède lorsque vous tapez cette lettre. Désactivez-le pour filtrer la liste en tapant directement, sans appuyer sur / — les touches d’action comme W ou Q s’écrivent alors dans la recherche au lieu d’agir sur une fenêtre."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuj literę na każdym oknie i przeskocz do niego, wpisując tę literę. Wyłącz, aby pisząc od razu filtrować listę, bez naciskania / — klawisze akcji, jak W czy Q, trafiają wtedy do wyszukiwania zamiast działać na oknie."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在每个窗口上显示字母，输入该字母即可跳转。关闭后直接输入即可筛选列表，无需按 / —— W、Q 等操作键会输入到搜索中，而不是对窗口执行操作。"
           }
         }
       }
@@ -8131,40 +8301,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示"
-          }
-        }
-      }
-    },
-    "Show a letter on each window and jump to it by typing that letter." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeigt auf jedem Fenster einen Buchstaben an und springt durch Tippen dieses Buchstabens dorthin."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra una letra en cada ventana y salta a ella escribiendo esa letra."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affiche une lettre sur chaque fenêtre et y accède lorsque vous tapez cette lettre."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokazuj literę na każdym oknie i przeskocz do niego, wpisując tę literę."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在每个窗口上显示字母，输入该字母即可跳转。"
           }
         }
       }

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -210,7 +210,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         let search = addSection(title: String(localized: "Search"), anchor: SettingsAnchor.search)
         configureSwitch(letterHintsSwitch, action: #selector(toggleLetterHints(_:)))
         addRow(to: search, title: String(localized: "Letter hints"),
-               subtitle: String(localized: "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing /."),
+               subtitle: String(localized: "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing / — action keys like W or Q then type into the search rather than acting on a window."),
                accessory: letterHintsSwitch, searchItemID: SearchID.letterHints)
 
         letterTimeoutSlider.minValue = Double(Preferences.letterChainTimeoutRange.lowerBound)

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -210,7 +210,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         let search = addSection(title: String(localized: "Search"), anchor: SettingsAnchor.search)
         configureSwitch(letterHintsSwitch, action: #selector(toggleLetterHints(_:)))
         addRow(to: search, title: String(localized: "Letter hints"),
-               subtitle: String(localized: "Show a letter on each window and jump to it by typing that letter."),
+               subtitle: String(localized: "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing /."),
                accessory: letterHintsSwitch, searchItemID: SearchID.letterHints)
 
         letterTimeoutSlider.minValue = Double(Preferences.letterChainTimeoutRange.lowerBound)

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -17,6 +17,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let instantSpaceSwitch = NSSwitch()
     private let browserTabMRUSwitch = NSSwitch()
     private let livePreviewSwitch = NSSwitch()
+    private let rankResultsSwitch = NSSwitch()
 
     override func setupContent() {
         // Untitled intro card — the unstable warning applies to the whole tab,
@@ -70,6 +71,13 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: browserTabs, title: String(localized: "Track browser tabs in recency"),
                subtitle: String(localized: "With “Show browser tabs as separate entries” and the “Most recent (windows)” sort order on, ⌘Tab returns to the tab you last used, not just the last window. Needs always-on monitoring of your browsers, so it costs a little energy."),
                accessory: browserTabMRUSwitch, searchItemID: SearchID.browserTabMRU)
+
+        // Search section.
+        let searchSection = addSection(title: String(localized: "Search"), anchor: SettingsAnchor.experimentalSearch)
+        configureSwitch(rankResultsSwitch, action: #selector(toggleRankResults(_:)))
+        addRow(to: searchSection, title: String(localized: "Rank search"),
+               subtitle: String(localized: "Order results by how well they match instead of by recent use, so the closest match is selected first."),
+               accessory: rankResultsSwitch, searchItemID: SearchID.rankResults)
 
         // Previews section (the window-preview layout).
         let previews = addSection(title: String(localized: "Previews"), anchor: SettingsAnchor.experimentalPreviews)
@@ -128,6 +136,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
         browserTabMRUSwitch.state = prefs.experimentalBrowserTabMRU ? .on : .off
         livePreviewSwitch.state = prefs.experimentalLivePreviews ? .on : .off
+        rankResultsSwitch.state = prefs.fuzzySearchRankBestMatchFirst ? .on : .off
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -172,6 +181,10 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleLivePreviews(_ sender: NSSwitch) {
         Preferences.shared.experimentalLivePreviews = (sender.state == .on)
+    }
+
+    @objc private func toggleRankResults(_ sender: NSSwitch) {
+        Preferences.shared.fuzzySearchRankBestMatchFirst = (sender.state == .on)
     }
 
     /// The reverse/commit/sensitivity controls only make sense while the swipe

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -18,6 +18,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let browserTabMRUSwitch = NSSwitch()
     private let livePreviewSwitch = NSSwitch()
     private let rankResultsSwitch = NSSwitch()
+    private let searchTabsSwitch = NSSwitch()
 
     override func setupContent() {
         // Untitled intro card — the unstable warning applies to the whole tab,
@@ -78,6 +79,10 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: searchSection, title: String(localized: "Rank search"),
                subtitle: String(localized: "Order results by how well they match instead of by recent use, so the closest match is selected first."),
                accessory: rankResultsSwitch, searchItemID: SearchID.rankResults)
+        configureSwitch(searchTabsSwitch, action: #selector(toggleSearchExpandsTabs(_:)))
+        addRow(to: searchSection, title: String(localized: "Search browser tabs"),
+               subtitle: String(localized: "Type-to-search matches any browser tab by its title, not just each window's active tab. Matching tabs appear as temporary rows while the search field is active and disappear when you leave search. Already covered by “Show browser tabs as separate entries.”"),
+               accessory: searchTabsSwitch, searchItemID: SearchID.searchExpandsBrowserTabs)
 
         // Previews section (the window-preview layout).
         let previews = addSection(title: String(localized: "Previews"), anchor: SettingsAnchor.experimentalPreviews)
@@ -137,6 +142,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         browserTabMRUSwitch.state = prefs.experimentalBrowserTabMRU ? .on : .off
         livePreviewSwitch.state = prefs.experimentalLivePreviews ? .on : .off
         rankResultsSwitch.state = prefs.fuzzySearchRankBestMatchFirst ? .on : .off
+        searchTabsSwitch.state = prefs.searchExpandsBrowserTabs ? .on : .off
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -185,6 +191,10 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleRankResults(_ sender: NSSwitch) {
         Preferences.shared.fuzzySearchRankBestMatchFirst = (sender.state == .on)
+    }
+
+    @objc private func toggleSearchExpandsTabs(_ sender: NSSwitch) {
+        Preferences.shared.searchExpandsBrowserTabs = (sender.state == .on)
     }
 
     /// The reverse/commit/sensitivity controls only make sense while the swipe

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -81,7 +81,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
                accessory: rankResultsSwitch, searchItemID: SearchID.rankResults)
         configureSwitch(searchTabsSwitch, action: #selector(toggleSearchExpandsTabs(_:)))
         addRow(to: searchSection, title: String(localized: "Search browser tabs"),
-               subtitle: String(localized: "Type-to-search matches any browser tab by its title, not just each window's active tab. Matching tabs appear as temporary rows while the search field is active and disappear when you leave search. Already covered by “Show browser tabs as separate entries.”"),
+               subtitle: String(localized: "Searching matches any browser tab by its title, not just each window's active tab. Matching tabs appear as temporary rows while the search field is active and disappear when you leave search. Not needed if you already use “Show browser tabs as separate entries.”"),
                accessory: searchTabsSwitch, searchItemID: SearchID.searchExpandsBrowserTabs)
 
         // Previews section (the window-preview layout).

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -143,6 +143,7 @@ enum SearchID {
     static let browserTabMRU = "experimental.browserTabMRU"
     static let livePreviews = "experimental.livePreviews"
     static let rankResults = "experimental.rankResults"
+    static let searchExpandsBrowserTabs = "experimental.searchExpandsBrowserTabs"
 }
 
 @MainActor
@@ -414,6 +415,8 @@ enum SettingsCatalog {
         // Experimental · Search
         item(SearchID.rankResults, .experimental, SettingsAnchor.experimentalSearch, String(localized: "Experimental"), String(localized: "Search"),
              String(localized: "Rank search"), ["fuzzy", "search", "ranking", "rank", "best match", "sort results", "relevance"]),
+        item(SearchID.searchExpandsBrowserTabs, .experimental, SettingsAnchor.experimentalSearch, String(localized: "Experimental"), String(localized: "Search"),
+             String(localized: "Search browser tabs"), ["search", "browser", "tabs", "tab", "fuzzy", "find tab", "safari", "chrome"]),
         // Experimental · Browser tabs
         item(SearchID.browserTabMRU, .experimental, SettingsAnchor.experimentalTabs, String(localized: "Experimental"), String(localized: "Browser tabs"),
              String(localized: "Track browser tabs in recency"), ["browser", "tab", "tabs", "recent", "mru", "safari", "chrome"]),

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -57,6 +57,7 @@ enum SettingsAnchor {
     static let experimental = "experimental.features"
     static let experimentalSwipe = "experimental.swipeSection"
     static let experimentalSpaces = "experimental.spaces"
+    static let experimentalSearch = "experimental.search"
     static let experimentalTabs = "experimental.browserTabs"
     static let experimentalPreviews = "experimental.windowPreviews"
     // About
@@ -141,6 +142,7 @@ enum SearchID {
     static let instantSpace = "experimental.instantSpace"
     static let browserTabMRU = "experimental.browserTabMRU"
     static let livePreviews = "experimental.livePreviews"
+    static let rankResults = "experimental.rankResults"
 }
 
 @MainActor
@@ -409,6 +411,9 @@ enum SettingsCatalog {
         // Experimental · Spaces
         item(SearchID.instantSpace, .experimental, SettingsAnchor.experimentalSpaces, String(localized: "Experimental"), String(localized: "Spaces"),
              String(localized: "Switch Spaces without animation"), ["spaces", "space", "animation", "instant", "full screen"]),
+        // Experimental · Search
+        item(SearchID.rankResults, .experimental, SettingsAnchor.experimentalSearch, String(localized: "Experimental"), String(localized: "Search"),
+             String(localized: "Rank search"), ["fuzzy", "search", "ranking", "rank", "best match", "sort results", "relevance"]),
         // Experimental · Browser tabs
         item(SearchID.browserTabMRU, .experimental, SettingsAnchor.experimentalTabs, String(localized: "Experimental"), String(localized: "Browser tabs"),
              String(localized: "Track browser tabs in recency"), ["browser", "tab", "tabs", "recent", "mru", "safari", "chrome"]),

--- a/BetterCmdTab/Switcher/FuzzyMatch.swift
+++ b/BetterCmdTab/Switcher/FuzzyMatch.swift
@@ -38,4 +38,114 @@ enum FuzzyMatch {
         }
         return current == nil
     }
+
+    // MARK: - Ranking
+
+    // Tier bases for `scoreFolded`. Gaps are a uniform 1000 so the intra-tier
+    // refinement (clamped to 0..<1000) can never push one tier past another.
+    // A contiguous substring deliberately dominates a scattered subsequence —
+    // that's what separates "microsoft teams" (substring "team") from
+    // "telegram" (subsequence only) for the query "team".
+    private static let appPrefixBase = 7000
+    private static let appWordSubstrBase = 6000
+    private static let appSubstrBase = 5000
+    private static let titleWordSubstrBase = 4000
+    private static let titleSubstrBase = 3000
+    private static let appSubseqBase = 2000
+    private static let titleSubseqBase = 1000
+
+    /// Ranking score for `foldedQuery` against one row's folded fields, or nil
+    /// if it matches neither. Higher = better. Same fold/whitespace contract as
+    /// `matchesFolded`; an empty query is neutral (0). Caller folds once so the
+    /// search hot path doesn't re-fold every row on each keystroke.
+    ///
+    /// Scoring a whole row set per keystroke should use `prepareQuery` once and
+    /// call `scoreFolded(preparedQuery:foldedAppName:foldedWindowTitle:)` per row
+    /// instead — this overload re-strips and re-arrays the query on every call.
+    static func scoreFolded(foldedQuery: String, foldedAppName: String, foldedWindowTitle: String) -> Int? {
+        scoreFolded(preparedQuery: prepareQuery(foldedQuery),
+                    foldedAppName: foldedAppName, foldedWindowTitle: foldedWindowTitle)
+    }
+
+    /// A folded query stripped of whitespace, plus its characters as an array —
+    /// the per-keystroke-invariant inputs `scoreFolded` needs. Build once before
+    /// scoring a row set so the strip + `Array` allocation isn't repeated per row.
+    typealias PreparedQuery = (q: String, qChars: [Character])
+
+    static func prepareQuery(_ foldedQuery: String) -> PreparedQuery {
+        let q = foldedQuery.filter { !$0.isWhitespace }
+        return (q, Array(q))
+    }
+
+    /// Hot-path ranking: scores one row against a query already prepared with
+    /// `prepareQuery`, avoiding the per-row whitespace-strip + `Array` allocation.
+    static func scoreFolded(preparedQuery: PreparedQuery, foldedAppName: String, foldedWindowTitle: String) -> Int? {
+        let (q, qChars) = preparedQuery
+        guard !q.isEmpty else { return 0 }
+        let app = fieldScore(q, qChars, in: foldedAppName,
+                             prefixBase: appPrefixBase, wordSubstrBase: appWordSubstrBase,
+                             substrBase: appSubstrBase, subseqBase: appSubseqBase)
+        let title = fieldScore(q, qChars, in: foldedWindowTitle,
+                               // A title prefix lands in the title word-boundary tier;
+                               // app matches always outrank title matches of the same shape.
+                               prefixBase: titleWordSubstrBase, wordSubstrBase: titleWordSubstrBase,
+                               substrBase: titleSubstrBase, subseqBase: titleSubseqBase)
+        if let app, let title { return max(app, title) }
+        return app ?? title
+    }
+
+    /// Best tier `q` reaches within one field, plus a bounded refinement, or nil
+    /// if `q` isn't even a subsequence of `haystack`.
+    private static func fieldScore(_ q: String, _ qChars: [Character], in haystack: String,
+                                   prefixBase: Int, wordSubstrBase: Int,
+                                   substrBase: Int, subseqBase: Int) -> Int? {
+        guard !haystack.isEmpty else { return nil }
+        if let r = haystack.range(of: q, options: [.literal]) {
+            let start = haystack.distance(from: haystack.startIndex, to: r.lowerBound)
+            let refine = refinement(startIndex: start, consecutiveRun: qChars.count - 1)
+            if start == 0 { return prefixBase + refine }
+            let before = haystack[haystack.index(before: r.lowerBound)]
+            return (isWordBoundary(before) ? wordSubstrBase : substrBase) + refine
+        }
+        guard let refine = subsequenceRefinement(qChars, in: haystack) else { return nil }
+        return subseqBase + refine
+    }
+
+    /// Greedy left-to-right subsequence walk that also reports the first-match
+    /// position and how many matched characters were adjacent, for refinement.
+    /// Returns nil if not a subsequence.
+    private static func subsequenceRefinement(_ needle: [Character], in haystack: String) -> Int? {
+        guard !needle.isEmpty else { return 0 }
+        var nIdx = 0
+        var firstPos = -1
+        var prevMatchPos = -2
+        var consecutive = 0
+        var pos = 0
+        for ch in haystack {
+            if ch == needle[nIdx] {
+                if firstPos < 0 { firstPos = pos }
+                if pos == prevMatchPos + 1 { consecutive += 1 }
+                prevMatchPos = pos
+                nIdx += 1
+                if nIdx == needle.count { break }
+            }
+            pos += 1
+        }
+        guard nIdx == needle.count else { return nil }
+        return refinement(startIndex: firstPos, consecutiveRun: consecutive)
+    }
+
+    /// Intra-tier ordering: earlier matches and more-adjacent runs rank higher.
+    /// Clamped to 0..<1000 so it stays inside a single tier gap.
+    private static func refinement(startIndex: Int, consecutiveRun: Int) -> Int {
+        let positionBonus = max(0, 300 - startIndex * 10)
+        let runBonus = min(consecutiveRun * 100, 600)
+        return min(positionBonus + runBonus, 999)
+    }
+
+    /// On folded (lowercased) strings a word boundary is any non-alphanumeric
+    /// char (space, "-", "/", …). camelCase boundaries are lost to folding.
+    private static func isWordBoundary(_ c: Character) -> Bool {
+        !c.isLetter && !c.isNumber
+    }
 }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -859,6 +859,19 @@ final class SwitcherController: SwitcherViewDelegate {
             .sink { [weak self] enabled in self?.hotkey.setShiftTapStepsBackward(enabled) }
             .store(in: &cancellables)
 
+        // Type-to-search routing depends on two prefs (letter hints off + fuzzy
+        // search on), so re-derive and re-push on either change. With it on, the
+        // tap routes letters — including the reserved action keys — into search.
+        syncTypeToSearchEnabled()
+        Preferences.shared.$letterHintsEnabled
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.syncTypeToSearchEnabled() }
+            .store(in: &cancellables)
+        Preferences.shared.$fuzzySearchEnabled
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.syncTypeToSearchEnabled() }
+            .store(in: &cancellables)
+
         // "Ignore shortcuts" exceptions: seed the suppression flag for the
         // current frontmost app and re-derive it when the exceptions change.
         updateTriggerSuppression()
@@ -2207,8 +2220,19 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     private func handleLetter(_ ch: Character) {
-        guard effective.letterHintsEnabled else { return }
-        guard phase == .visible, !rows.isEmpty, !labels.isEmpty else { return }
+        guard phase == .visible, !rows.isEmpty else { return }
+        // Letter hints off (for this reveal — a per-shortcut override wins over
+        // the global): typing filters via fuzzy search instead of jumping to a
+        // hint. The first keystroke opens search; once the tap is in search
+        // mode the rest arrive as `.searchInput`, so handling the opener (and any
+        // stragglers, since searchActive is already true then) here is enough.
+        if !effective.letterHintsEnabled {
+            guard Preferences.shared.fuzzySearchEnabled else { return }
+            if !searchActive { enterSearch() }
+            handleSearchInput(ch)
+            return
+        }
+        guard !labels.isEmpty else { return }
 
         let attempt = letterBuffer + String(ch)
 
@@ -5019,6 +5043,14 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     // MARK: - Fuzzy search
+
+    /// Push the derived type-to-search flag (letter hints off + fuzzy on) to the
+    /// tap. Called on setup and whenever either preference changes.
+    private func syncTypeToSearchEnabled() {
+        hotkey.setTypeToSearchEnabled(
+            !Preferences.shared.letterHintsEnabled && Preferences.shared.fuzzySearchEnabled
+        )
+    }
 
     private func toggleSearch() {
         if searchActive { exitSearch() } else { enterSearch() }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -4961,13 +4961,35 @@ final class SwitcherController: SwitcherViewDelegate {
         if searchActive, !searchQuery.isEmpty {
             ensureBaseFolded()
             let foldedQuery = FuzzyMatch.fold(searchQuery)
+            // Rank matches best-first (Rank search toggle) instead of catalog order.
+            let rankBest = Preferences.shared.fuzzySearchRankBestMatchFirst
+            // Strip + arrayize the query once per refresh (it's identical for
+            // every row) so scoring a whole row set doesn't re-allocate per row.
+            let preparedQuery = FuzzyMatch.prepareQuery(foldedQuery)
             var newRows: [SwitcherRow] = []
             var newLabels: [String] = []
             newRows.reserveCapacity(baseRows.count)
-            for i in baseRows.indices
-            where FuzzyMatch.matchesFolded(foldedQuery: foldedQuery, foldedAppName: baseFolded[i].app, foldedWindowTitle: baseFolded[i].title) {
-                newRows.append(baseRows[i])
-                newLabels.append(baseLabels[i])
+            if rankBest {
+                // Score every match, then present best-first; ties keep the
+                // original (MRU/catalog) order via the index tie-break.
+                var scored: [(idx: Int, score: Int)] = []
+                scored.reserveCapacity(baseRows.count)
+                for i in baseRows.indices {
+                    if let s = FuzzyMatch.scoreFolded(preparedQuery: preparedQuery, foldedAppName: baseFolded[i].app, foldedWindowTitle: baseFolded[i].title) {
+                        scored.append((idx: i, score: s))
+                    }
+                }
+                scored.sort { $0.score != $1.score ? $0.score > $1.score : $0.idx < $1.idx }
+                for entry in scored {
+                    newRows.append(baseRows[entry.idx])
+                    newLabels.append(baseLabels[entry.idx])
+                }
+            } else {
+                for i in baseRows.indices
+                where FuzzyMatch.matchesFolded(foldedQuery: foldedQuery, foldedAppName: baseFolded[i].app, foldedWindowTitle: baseFolded[i].title) {
+                    newRows.append(baseRows[i])
+                    newLabels.append(baseLabels[i])
+                }
             }
             // Launcher: append matching apps that aren't running yet so the user
             // can launch them from the same search. Labels are inert in search
@@ -4975,17 +4997,37 @@ final class SwitcherController: SwitcherViewDelegate {
             // aligned without affecting display.
             if Preferences.shared.searchIncludesLaunchableApps {
                 let runningBundleIDs = Set(baseRows.compactMap { $0.bundleIdentifier })
-                let launchable = InstalledAppsIndex.shared.matches(
+                var launchable = InstalledAppsIndex.shared.matches(
                     query: searchQuery,
                     excludingRunning: runningBundleIDs,
                     limit: 8
                 )
+                if rankBest {
+                    // Ranks within the (already capped at 8, scan-order) launchable
+                    // set — a stronger match past the cap can still be dropped, which
+                    // is acceptable since the launcher only augments the search.
+                    let scores = launchable.map {
+                        FuzzyMatch.scoreFolded(preparedQuery: preparedQuery, foldedAppName: $0.foldedName, foldedWindowTitle: "") ?? Int.min
+                    }
+                    launchable = launchable.indices.sorted {
+                        scores[$0] != scores[$1] ? scores[$0] > scores[$1] : $0 < $1
+                    }.map { launchable[$0] }
+                }
                 for app in launchable {
                     newRows.append(SwitcherRow(launchable: app))
                     newLabels.append("")
                 }
             }
-            for row in recentlyClosedRows(forSearchQuery: searchQuery, alreadyShown: Set(newRows.compactMap { $0.bundleIdentifier })) {
+            var closed = recentlyClosedRows(forSearchQuery: searchQuery, alreadyShown: Set(newRows.compactMap { $0.bundleIdentifier }))
+            if rankBest {
+                let scores = closed.map {
+                    FuzzyMatch.scoreFolded(preparedQuery: preparedQuery, foldedAppName: FuzzyMatch.fold($0.appName), foldedWindowTitle: FuzzyMatch.fold($0.windowTitle)) ?? Int.min
+                }
+                closed = closed.indices.sorted {
+                    scores[$0] != scores[$1] ? scores[$0] > scores[$1] : $0 < $1
+                }.map { closed[$0] }
+            }
+            for row in closed {
                 newRows.append(row)
                 newLabels.append("")
             }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -5275,6 +5275,12 @@ final class SwitcherController: SwitcherViewDelegate {
         searchActive = false
         searchQuery = ""
         stickyOpen = false
+        // Drop the transient tab-expanded set here too — teardown is the common
+        // end of a search (commit → panel hides), and the rows hold AX window
+        // refs that would otherwise linger until the next reveal.
+        searchExpandedRows = []
+        searchExpandedFolded = []
+        searchExpandedValid = false
         hotkey.setSearchMode(false)
     }
 

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -109,8 +109,12 @@ final class SwitcherController: SwitcherViewDelegate {
             // Folded names/titles belong to the previous row snapshot. Release
             // their strings immediately (especially on dismiss after a very
             // large tab expansion) instead of retaining them until the next
-            // search keystroke rebuilds the cache.
+            // search keystroke rebuilds the cache. Same for the transient
+            // search-time tab expansion, which also holds AX window refs.
             baseFolded.removeAll(keepingCapacity: !baseRows.isEmpty)
+            searchExpandedValid = false
+            searchExpandedRows.removeAll(keepingCapacity: !baseRows.isEmpty)
+            searchExpandedFolded.removeAll(keepingCapacity: !baseRows.isEmpty)
             tabPrefetchGeneration &+= 1
             // Window AXUIElements churn across reveals; drop the prefetch
             // cache so we don't try to drill into a stale element.
@@ -124,6 +128,13 @@ final class SwitcherController: SwitcherViewDelegate {
     /// row-set change rather than re-folding every row on every keystroke.
     private var baseFolded: [(app: String, title: String)] = []
     private var baseFoldedValid = false
+    /// Transient browser-tab expansion used only while searching with the
+    /// `searchExpandsBrowserTabs` feature on. Browser windows are expanded into
+    /// per-tab rows *for the search filter only* — these rows never enter
+    /// `baseRows`. Rebuilt lazily (invalidated with `baseRows`) like `baseFolded`.
+    private var searchExpandedRows: [SwitcherRow] = []
+    private var searchExpandedFolded: [(app: String, title: String)] = []
+    private var searchExpandedValid = false
     private var rows: [SwitcherRow] = []
     private var labels: [String] = []
     /// Hint letters to render on tiles — empty when the user disabled letter
@@ -2651,7 +2662,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// in `handleScreenParametersChange()`; `refreshDisplay()` re-presents.
     private func applySessionScreen(_ screen: NSScreen) {
         panel.targetScreen = screen
-        currentMetrics = SwitcherMetrics.forScreen(screen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, fontScale: effective.fontScale.multiplier, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+        currentMetrics = makeMetrics(for: screen)
         refreshDisplay()
     }
 
@@ -2962,7 +2973,7 @@ final class SwitcherController: SwitcherViewDelegate {
 
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
-        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, fontScale: effective.fontScale.multiplier, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+        currentMetrics = makeMetrics(for: sessionScreen)
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, effective: effective, highlightPrefix: letterBuffer)
         panel.present(opacity: effective.panelOpacity)
         phase = .visible
@@ -3053,7 +3064,7 @@ final class SwitcherController: SwitcherViewDelegate {
 
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
-        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, fontScale: effective.fontScale.multiplier, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+        currentMetrics = makeMetrics(for: sessionScreen)
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, effective: effective, highlightPrefix: letterBuffer)
         panel.present(opacity: effective.panelOpacity)
         phase = .visible
@@ -3440,9 +3451,20 @@ final class SwitcherController: SwitcherViewDelegate {
         // browser into per-tab rows would defeat it, so leave the rows untouched.
         guard effective.expandBrowserTabsAsWindows,
               !effective.applicationsOnly else { return source }
+        return expandBrowserTabsCore(source)
+    }
+
+    /// Pref-free expansion: replace each collapsed browser-window row with one
+    /// row per tab from `browserTabsCache`. Shared by the always-on
+    /// `expandBrowserTabs` path and the transient search expansion. Pure (no AX);
+    /// idempotent (already-expanded tab rows pass through untouched).
+    private func expandBrowserTabsCore(_ source: [SwitcherRow]) -> [SwitcherRow] {
         var out: [SwitcherRow] = []
         out.reserveCapacity(source.count)
         for row in source {
+            // Expand only a still-collapsed (`browserTab == nil`) browser window
+            // whose tabs are cached and number 2+. Anything else — already a tab
+            // row, non-browser, uncached, or single-tab — passes through as-is.
             guard row.browserTab == nil,
                   let window = row.window,
                   BrowserTabs.Family.from(bundleID: row.bundleIdentifier) != nil,
@@ -3451,6 +3473,27 @@ final class SwitcherController: SwitcherViewDelegate {
             out.append(contentsOf: row.browserTabRows(tabTitles: titles))
         }
         return out
+    }
+
+    /// Whether the search filter should run over a transiently tab-expanded row
+    /// set. Off when the always-expand pref is on (`baseRows` is already
+    /// expanded) or in applications-only mode (collapsed to one row per app).
+    private var searchUsesExpandedTabs: Bool {
+        Preferences.shared.searchExpandsBrowserTabs
+            && !effective.expandBrowserTabsAsWindows
+            && !effective.applicationsOnly
+    }
+
+    /// Rebuild the transient tab-expanded search set (rows + folded strings) from
+    /// `baseRows` if it went stale. Mirrors `ensureBaseFolded`: built once per
+    /// `baseRows` change, reused across keystrokes.
+    private func ensureSearchExpanded() {
+        guard !searchExpandedValid else { return }
+        searchExpandedRows = expandBrowserTabsCore(baseRows)
+        searchExpandedFolded = searchExpandedRows.map {
+            (FuzzyMatch.fold($0.appName), FuzzyMatch.fold($0.windowTitle))
+        }
+        searchExpandedValid = true
     }
 
     /// Kick a background Apple Events scan for every collapsed browser window in
@@ -3493,12 +3536,17 @@ final class SwitcherController: SwitcherViewDelegate {
     /// add/close/switch syncs immediately) but is rate-limited by
     /// `forcedBrowserScanMinInterval` so page-load title churn can't spam
     /// osascript. `onDone` runs on the main actor after the cache is updated.
+    /// `wantExpansion` lets the transient search-expansion path request a scan
+    /// while `expandBrowserTabsAsWindows` is off. It only opens this guard — the
+    /// `baseRows`-mutating completion (`reExpandBrowserTabs`) stays wired to the
+    /// two pref-guarded callers, never to the search scan.
     private func scanBrowserTabs(
         rows: [SwitcherRow],
         force: Bool,
+        wantExpansion: Bool = false,
         onDone: (@MainActor @Sendable () -> Void)? = nil
     ) {
-        guard effective.expandBrowserTabsAsWindows else { return }
+        guard effective.expandBrowserTabsAsWindows || wantExpansion else { return }
         let now = ProcessInfo.processInfo.systemUptime
         if force, now - lastForcedBrowserScanAt < Self.forcedBrowserScanMinInterval { return }
 
@@ -4959,36 +5007,62 @@ final class SwitcherController: SwitcherViewDelegate {
         let key = resetSelectionToTop ? nil : selectionKey()
 
         if searchActive, !searchQuery.isEmpty {
-            ensureBaseFolded()
+            // When the transient tab-expansion feature applies, filter over the
+            // expanded row set (browser windows → one row per tab) so a query can
+            // match background tabs; otherwise the canonical rows. The two arrays
+            // are always built together — never cross `srcFolded` with `baseFolded`.
+            let useExpanded = searchUsesExpandedTabs
+            let srcRows: [SwitcherRow]
+            let srcFolded: [(app: String, title: String)]
+            if useExpanded {
+                ensureSearchExpanded()
+                srcRows = searchExpandedRows
+                srcFolded = searchExpandedFolded
+            } else {
+                ensureBaseFolded()
+                srcRows = baseRows
+                srcFolded = baseFolded
+            }
             let foldedQuery = FuzzyMatch.fold(searchQuery)
             // Rank matches best-first (Rank search toggle) instead of catalog order.
             let rankBest = Preferences.shared.fuzzySearchRankBestMatchFirst
             // Strip + arrayize the query once per refresh (it's identical for
             // every row) so scoring a whole row set doesn't re-allocate per row.
             let preparedQuery = FuzzyMatch.prepareQuery(foldedQuery)
+            // Tab expansion can produce far more rows than there were windows. Cap
+            // the populated matches to the pre-existing slot count (`baseRows`,
+            // before expansion) so search never balloons the list — the best
+            // matches fill the slots that already existed. Unbounded otherwise.
+            let slotCap = useExpanded ? baseRows.count : Int.max
             var newRows: [SwitcherRow] = []
             var newLabels: [String] = []
-            newRows.reserveCapacity(baseRows.count)
+            newRows.reserveCapacity(srcRows.count)
+            // Labels are display-suppressed in search mode (see SwitcherView).
+            // The non-expanded path keeps its `baseLabels[idx]` (byte-identical
+            // to before); the expanded path can't index `baseLabels` (its rows
+            // don't map 1:1), so it uses "".
             if rankBest {
                 // Score every match, then present best-first; ties keep the
                 // original (MRU/catalog) order via the index tie-break.
                 var scored: [(idx: Int, score: Int)] = []
-                scored.reserveCapacity(baseRows.count)
-                for i in baseRows.indices {
-                    if let s = FuzzyMatch.scoreFolded(preparedQuery: preparedQuery, foldedAppName: baseFolded[i].app, foldedWindowTitle: baseFolded[i].title) {
+                scored.reserveCapacity(srcRows.count)
+                for i in srcRows.indices {
+                    if let s = FuzzyMatch.scoreFolded(preparedQuery: preparedQuery, foldedAppName: srcFolded[i].app, foldedWindowTitle: srcFolded[i].title) {
                         scored.append((idx: i, score: s))
                     }
                 }
                 scored.sort { $0.score != $1.score ? $0.score > $1.score : $0.idx < $1.idx }
                 for entry in scored {
-                    newRows.append(baseRows[entry.idx])
-                    newLabels.append(baseLabels[entry.idx])
+                    if newRows.count >= slotCap { break }
+                    newRows.append(srcRows[entry.idx])
+                    newLabels.append(useExpanded ? "" : baseLabels[entry.idx])
                 }
             } else {
-                for i in baseRows.indices
-                where FuzzyMatch.matchesFolded(foldedQuery: foldedQuery, foldedAppName: baseFolded[i].app, foldedWindowTitle: baseFolded[i].title) {
-                    newRows.append(baseRows[i])
-                    newLabels.append(baseLabels[i])
+                for i in srcRows.indices
+                where FuzzyMatch.matchesFolded(foldedQuery: foldedQuery, foldedAppName: srcFolded[i].app, foldedWindowTitle: srcFolded[i].title) {
+                    if newRows.count >= slotCap { break }
+                    newRows.append(srcRows[i])
+                    newLabels.append(useExpanded ? "" : baseLabels[i])
                 }
             }
             // Launcher: append matching apps that aren't running yet so the user
@@ -5094,6 +5168,43 @@ final class SwitcherController: SwitcherViewDelegate {
         )
     }
 
+    /// The `browserTabsExpanded` metrics input for the current state. Delegates
+    /// to `SwitcherMetrics.reserveTabBand`, the single predicate shared with the
+    /// view's shrink loop so the two can't drift.
+    private var browserTabsExpandedForMetrics: Bool {
+        SwitcherMetrics.reserveTabBand(
+            expandAsWindows: effective.expandBrowserTabsAsWindows,
+            applicationsOnly: effective.applicationsOnly,
+            searchActive: searchActive,
+            searchExpandsTabs: Preferences.shared.searchExpandsBrowserTabs)
+    }
+
+    /// Build the panel metrics for `screen` from the current reveal's effective
+    /// settings. Single funnel so the `browserTabsExpanded` rule lives in
+    /// exactly one place.
+    private func makeMetrics(for screen: NSScreen?) -> SwitcherMetrics {
+        SwitcherMetrics.forScreen(
+            screen,
+            layoutMode: effective.layoutMode,
+            userScale: effective.panelSize.scale,
+            fontScale: effective.fontScale.multiplier,
+            letterHints: effective.letterHintsEnabled,
+            showAppNames: effective.showApplicationNames,
+            showWindowTitles: effective.showWindowTitleLabel,
+            hoverActionCount: Preferences.shared.enabledHoverActionCount,
+            browserTabsExpanded: browserTabsExpandedForMetrics
+        )
+    }
+
+    /// Recompute `currentMetrics` for the current search state so the preview
+    /// label band toggles with `browserTabsExpandedForMetrics`. Called on every
+    /// search-mode transition that keeps the panel visible (enter/exit). The
+    /// teardown path (`resetSearch`) never re-presents, so it needs no sync.
+    private func syncSearchMetrics() {
+        guard phase == .visible else { return }
+        currentMetrics = makeMetrics(for: panel.targetScreen)
+    }
+
     private func toggleSearch() {
         if searchActive { exitSearch() } else { enterSearch() }
     }
@@ -5111,6 +5222,20 @@ final class SwitcherController: SwitcherViewDelegate {
         if Preferences.shared.searchIncludesLaunchableApps {
             InstalledAppsIndex.shared.ensureFresh()
         }
+        // Warm the browser-tab cache so typing can match background tabs. The
+        // completion only rebuilds the transient search set and re-renders — it
+        // never touches `baseRows` (unlike the pref-on `reExpandBrowserTabs`).
+        if searchUsesExpandedTabs {
+            scanBrowserTabs(rows: baseRows, force: false, wantExpansion: true) { [weak self] in
+                guard let self, self.searchActive else { return }
+                self.searchExpandedValid = false
+                self.refreshDisplay()
+            }
+        }
+        // Reserve the preview label band for transient tab rows (no-op unless the
+        // search-tab feature applies). Before refreshDisplay so it uses the new
+        // metrics.
+        syncSearchMetrics()
         refreshDisplay()
         resyncSecureInputChords()
     }
@@ -5119,7 +5244,13 @@ final class SwitcherController: SwitcherViewDelegate {
         guard searchActive else { return }
         searchActive = false
         searchQuery = ""
+        // Drop the transient tab-expanded set so it can't leak into a later view.
+        searchExpandedRows = []
+        searchExpandedFolded = []
+        searchExpandedValid = false
         hotkey.setSearchMode(false)
+        // Restore the non-search metrics (drops the transient tab-row band).
+        syncSearchMetrics()
         refreshDisplay()
         resyncSecureInputChords()
     }

--- a/BetterCmdTab/Switcher/SwitcherMetrics.swift
+++ b/BetterCmdTab/Switcher/SwitcherMetrics.swift
@@ -101,6 +101,18 @@ struct SwitcherMetrics: Equatable {
 
     static let baseline = SwitcherMetrics.forScale(1.0, layoutMode: .list)
 
+    /// Whether the Window Preview label band must be reserved (the
+    /// `browserTabsExpanded` input to `forScreen`/`forScale`): always when tabs
+    /// are expanded as windows, and transiently while searching with the
+    /// search-tab feature — the matched tab rows then need their title (the only
+    /// thing distinguishing sibling tabs) shown even when "show window title" is
+    /// off. Pure single source of truth shared by the controller and the view's
+    /// shrink loop so the two predicates can't drift.
+    static func reserveTabBand(expandAsWindows: Bool, applicationsOnly: Bool,
+                               searchActive: Bool, searchExpandsTabs: Bool) -> Bool {
+        (expandAsWindows || (searchActive && searchExpandsTabs)) && !applicationsOnly
+    }
+
     static func forScreen(_ screen: NSScreen?, layoutMode: SwitcherLayoutMode = .list, userScale: CGFloat = 1.0, fontScale: CGFloat = 1.0, letterHints: Bool = true, showAppNames: Bool = true, showWindowTitles: Bool = true, hoverActionCount: Int = 0, browserTabsExpanded: Bool = false) -> SwitcherMetrics {
         let width = screen?.frame.width ?? referenceWidth
         let raw = width / referenceWidth

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -728,7 +728,16 @@ final class SwitcherView: NSView, TabStripDelegate {
         var candidate = base
         while scale > minScale + 0.001 {
             scale = max(minScale, scale - 0.05)
-            candidate = SwitcherMetrics.forScale(scale, layoutMode: base.layoutMode, fontScale: effective.fontScale.multiplier, letterHints: letterHints, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+            // Shares `SwitcherMetrics.reserveTabBand` with the controller so a
+            // shrink pass reserves the preview label band on the same rule that
+            // produced `base` — otherwise it would drop the tab titles base
+            // computed while searching with the transient browser-tab feature.
+            let reserveBand = SwitcherMetrics.reserveTabBand(
+                expandAsWindows: effective.expandBrowserTabsAsWindows,
+                applicationsOnly: effective.applicationsOnly,
+                searchActive: searchActive,
+                searchExpandsTabs: Preferences.shared.searchExpandsBrowserTabs)
+            candidate = SwitcherMetrics.forScale(scale, layoutMode: base.layoutMode, fontScale: effective.fontScale.multiplier, letterHints: letterHints, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: reserveBand)
             if fits(candidate) { return candidate }
         }
         return candidate

--- a/BetterCmdTabTests/FuzzyMatchTests.swift
+++ b/BetterCmdTabTests/FuzzyMatchTests.swift
@@ -39,4 +39,63 @@ struct FuzzyMatchTests {
         // Out-of-order characters are not a subsequence.
         #expect(!FuzzyMatch.matches(query: "bha", appName: "Safari", windowTitle: ""))
     }
+
+    // MARK: - Ranking (scoreFolded)
+
+    private func score(_ query: String, app: String, title: String = "") -> Int? {
+        FuzzyMatch.scoreFolded(
+            foldedQuery: FuzzyMatch.fold(query),
+            foldedAppName: FuzzyMatch.fold(app),
+            foldedWindowTitle: FuzzyMatch.fold(title)
+        )
+    }
+
+    /// Regression guard for the reported bug: typing "team" selected Chrome and
+    /// buried Microsoft Teams. The closest match must rank first.
+    @Test("ranks the closest match first: team → Teams > Telegram > Chrome")
+    func ranksBestMatchFirst() throws {
+        let teams = try #require(score("team", app: "Microsoft Teams"))
+        let telegram = try #require(score("team", app: "Telegram"))
+        // Chrome only matches via a scattered subsequence of its window title.
+        let chrome = try #require(score("team", app: "Google Chrome", title: "Stream a movie"))
+        #expect(teams > telegram)
+        #expect(telegram > chrome)
+    }
+
+    @Test("no match scores nil")
+    func noMatchScoresNil() {
+        #expect(score("bha", app: "Safari") == nil)
+        #expect(score("xyz", app: "Safari", title: "Terminal") == nil)
+    }
+
+    @Test("a contiguous substring outranks a scattered subsequence")
+    func substringBeatsSubsequence() throws {
+        let substring = try #require(score("team", app: "Microsoft Teams"))
+        let subsequence = try #require(score("team", app: "Telegram"))
+        #expect(substring > subsequence)
+    }
+
+    @Test("an app-name match outranks a window-title-only match")
+    func appNameBeatsTitleOnly() throws {
+        let appHit = try #require(score("doc", app: "Docs"))
+        let titleHit = try #require(score("doc", app: "Photos", title: "my document"))
+        #expect(appHit > titleHit)
+    }
+
+    @Test("prefix and word-boundary matches outrank a mid-word substring")
+    func prefixAndBoundaryOutrankMidWord() throws {
+        let prefix = try #require(score("saf", app: "Safari"))
+        let midWord = try #require(score("ari", app: "Safari"))
+        #expect(prefix > midWord)
+
+        let boundary = try #require(score("teams", app: "Microsoft Teams"))
+        let plain = try #require(score("soft", app: "Microsoft Teams"))
+        #expect(boundary > plain)
+    }
+
+    @Test("whitespace ignored; empty query is neutral")
+    func scoreWhitespaceAndEmpty() throws {
+        #expect(score("git hub", app: "GitHub") != nil)
+        #expect(score("", app: "Safari", title: "Apple") == 0)
+    }
 }

--- a/BetterCmdTabTests/HotkeyTapVimNavigationTests.swift
+++ b/BetterCmdTabTests/HotkeyTapVimNavigationTests.swift
@@ -56,6 +56,31 @@ struct HotkeyTapVimNavigationTests {
         }
     }
 
+    /// Type-to-search routing (letter hints off + fuzzy on): every a–z letter,
+    /// including the reserved action keys w/m/h/q/f, must feed the query so a
+    /// search like "whatsapp"/"figma" works instead of firing close/minimize/etc.
+    /// This is the pure decision behind the tap's opener branch.
+    @Test func typeToSearchRoutesEveryLetterIncludingReserved() {
+        // Reserved action letters must NOT be excluded (the bug: w/m/h/q/f hit
+        // panelKeyMap and closed/quit instead of opening search).
+        for c: Character in ["w", "m", "h", "q", "f"] {
+            #expect(HotkeyTap.typeToSearchLetter(for: c) == c)
+        }
+        // Ordinary letters route too; uppercase folds to lowercase (⇧ for capitals).
+        #expect(HotkeyTap.typeToSearchLetter(for: "g") == "g")
+        #expect(HotkeyTap.typeToSearchLetter(for: "W") == "w")
+        #expect(HotkeyTap.typeToSearchLetter(for: "Z") == "z")
+    }
+
+    /// Non-letters can't open a query, so they fall through (digits/space/symbols
+    /// keep their normal panel handling; only a–z starts type-to-search).
+    @Test func typeToSearchIgnoresNonLetters() {
+        for c: Character in ["0", "9", " ", "/", "\\", "\n", "-", ".", "é"] {
+            #expect(HotkeyTap.typeToSearchLetter(for: c) == nil,
+                    "\(c) should not open type-to-search")
+        }
+    }
+
     /// While vim is on, h/j/k/l must be reserved on top of the bound action
     /// letters so `RowLabels` never hands out a hint the tap would silently
     /// swallow as motion. With vim off the bound set passes through untouched.

--- a/BetterCmdTabTests/HotkeyTapVimNavigationTests.swift
+++ b/BetterCmdTabTests/HotkeyTapVimNavigationTests.swift
@@ -72,10 +72,21 @@ struct HotkeyTapVimNavigationTests {
         #expect(HotkeyTap.typeToSearchLetter(for: "Z") == "z")
     }
 
-    /// Non-letters can't open a query, so they fall through (digits/space/symbols
-    /// keep their normal panel handling; only a–z starts type-to-search).
-    @Test func typeToSearchIgnoresNonLetters() {
-        for c: Character in ["0", "9", " ", "/", "\\", "\n", "-", ".", "é"] {
+    /// Letters in any script and digits open the query too — a Polish "ż" or the
+    /// "1" in "1Password" must start a search, not leak past the panel — matching
+    /// what the search branch accepts once search mode is active.
+    @Test func typeToSearchRoutesNonASCIILettersAndDigits() {
+        #expect(HotkeyTap.typeToSearchLetter(for: "ż") == "ż")
+        #expect(HotkeyTap.typeToSearchLetter(for: "É") == "é")
+        #expect(HotkeyTap.typeToSearchLetter(for: "ü") == "ü")
+        #expect(HotkeyTap.typeToSearchLetter(for: "1") == "1")
+        #expect(HotkeyTap.typeToSearchLetter(for: "0") == "0")
+    }
+
+    /// Whitespace and punctuation keep their panel meaning (Space commits, \
+    /// enters tab drill-in, / toggles search), so they must not open a query.
+    @Test func typeToSearchIgnoresPunctuationAndWhitespace() {
+        for c: Character in [" ", "/", "\\", "\n", "-", "."] {
             #expect(HotkeyTap.typeToSearchLetter(for: c) == nil,
                     "\(c) should not open type-to-search")
         }

--- a/BetterCmdTabTests/SwitcherMetricsTests.swift
+++ b/BetterCmdTabTests/SwitcherMetricsTests.swift
@@ -5,6 +5,21 @@ import Testing
 @Suite("SwitcherMetrics")
 struct SwitcherMetricsTests {
 
+    @Test("reserveTabBand: on when always-expanded, or transiently while searching with the search-tab feature")
+    func reserveTabBand() {
+        typealias M = SwitcherMetrics
+        // Always-expand reserves the band regardless of search.
+        #expect(M.reserveTabBand(expandAsWindows: true, applicationsOnly: false, searchActive: false, searchExpandsTabs: false))
+        // Search-tab feature: band only while actually searching.
+        #expect(!M.reserveTabBand(expandAsWindows: false, applicationsOnly: false, searchActive: false, searchExpandsTabs: true))
+        #expect(M.reserveTabBand(expandAsWindows: false, applicationsOnly: false, searchActive: true, searchExpandsTabs: true))
+        // Neither feature → never.
+        #expect(!M.reserveTabBand(expandAsWindows: false, applicationsOnly: false, searchActive: true, searchExpandsTabs: false))
+        // Applications-only collapses to one row per app, so the band is never reserved.
+        #expect(!M.reserveTabBand(expandAsWindows: true, applicationsOnly: true, searchActive: false, searchExpandsTabs: false))
+        #expect(!M.reserveTabBand(expandAsWindows: false, applicationsOnly: true, searchActive: true, searchExpandsTabs: true))
+    }
+
     @Test("scale 1.0 yields baseline values")
     func baseline() {
         let m = SwitcherMetrics.forScale(1.0)


### PR DESCRIPTION
## Summary

Three opt-in improvements to switcher fuzzy search, as three reviewable commits:

1. **Type-to-search when letter hints are off** — with letter hints disabled, the reserved action keys (`w`/`m`/`h`/`q`/`f`) were swallowed by the hotkey tap as close/minimize/hide/quit/fullscreen before they could open search, so typing a query like `whatsapp` or `figma` acted on a window instead. Now every letter routes into the query; the first keystroke opens search. Like `/`-initiated search, bare action keys no longer fire in this mode (actions remain on hover/commit).

2. **Rank search results best-match-first** (Experimental → *Rank search*, default off) — orders results by match quality so the closest match is selected first, instead of catalog/MRU order. Tiered scoring in `FuzzyMatch.scoreFolded`: app-name beats window-title, and prefix > word-boundary substring > substring > scattered subsequence, refined by position and run length. The query is prepared once per refresh (`prepareQuery`) rather than per row, keeping the ⌘Tab path allocation-free across the row set. Launchable apps and recently-closed entries rank the same way.

3. **Search browser tabs** (Experimental → *Search browser tabs*, default off) — lets a query match any background browser tab by title, not just each window's active tab, **without** the always-on "Show browser tabs as separate entries" preference. Browser windows expand into per-tab rows for the duration of the search only; the transient rows never enter the canonical list and collapse back on exit. Matches are capped to the pre-existing slot count so the list can't balloon. In Window Preview layout the label band is reserved while searching (`SwitcherMetrics.reserveTabBand`, shared by the controller and the view's shrink loop) so a matched tab's title stays visible even with window titles off.

## Notes

- All three default **off** and live in the Experimental pane.
- Hot-path conscious: tab expansion is pure and cached per row-set; the only osascript cost is one batched scan on search entry (off-main), and ranking folds/arrays the query once per refresh, not per row.
- AppKit only; deployment target unchanged.

## Testing

- `xcodebuild -scheme "BetterCmdTab Debug" -configuration Debug build` — clean, no new warnings.
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test -only-testing:BetterCmdTabTests` — passes, **except** `RowLabelsTests.collisionViaAppName`, which **already fails on `main`** (verified by stashing all changes) and is unrelated to this PR.
- New pure-logic tests added: `HotkeyTap.typeToSearchLetter` (routes reserved letters into search), `SwitcherMetrics.reserveTabBand` (label-band truth table); existing `FuzzyMatchTests` cover the ranking scorer.
- UI/runtime behavior (live tap routing, preview layout while searching) is verified manually per the project's testing policy — it needs a real WindowServer + Accessibility + Automation permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPaiPyYCZ2qwVxMoq4vNpF
