### PR TITLE
Direct self-builders from README to CONTRIBUTING.md Building section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,7 @@ On first launch macOS will ask for **Accessibility** permission — this is requ
 
 ### Build from source
 
-```bash
-git clone https://github.com/rokartur/BetterCmdTab.git
-cd BetterCmdTab
-xcodebuild -scheme "BetterCmdTab" -configuration Release build
-```
-
-Requires Xcode 16+ and the macOS 26 SDK to build the Liquid Glass code paths. The deployment target is macOS 13.0 — older SDKs fall back to NSVisualEffectView automatically.
+If you prefer building it yourself from source, see [this section in CONTRIBUTING.md](CONTRIBUTING.md#Building) for instructions.
 
 ## Privacy
 


### PR DESCRIPTION
I propose this because:

1. The general README is for most casual users who probably prefer downloading pre-built binary so the bash script and technical details are scary noise to them.
2. The CONTRIBUTING file has more information that self-builders would probably need anyway (such as running tests), as they are likely power users or software developers.
3. It is a redundant repeat of the same information in both files.

Thanks for considering this improvement.

This is a documentation update only. No source code change in the app.

PS: Sorry I'm not a fan of those tags like `feat:` and `fix:`. I prefer the traditional style of commit messages (start with a verb). Feel free to change it in a squash merge commit if you wish.