### PR TITLE
feat: open switcher on the active monitor and graduate the "Show switcher on" setting

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -37,7 +37,7 @@ enum SwitcherDisplayMode: String, CaseIterable {
     var displayName: String {
         switch self {
         case .mouseCursor:  return String(localized: "Monitor with the cursor")
-        case .activeWindow: return String(localized: "Monitor with the active window")
+        case .activeWindow: return String(localized: "Monitor with the active space")
         case .mainDisplay:  return String(localized: "Main display")
         }
     }

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -1823,6 +1823,34 @@
         }
       }
     },
+    "Display" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ekran"
+          }
+        }
+      }
+    },
     "Don't hide" : {
       "localizations" : {
         "de" : {
@@ -4092,30 +4120,30 @@
         }
       }
     },
-    "Monitor with the active window" : {
+    "Monitor with the active space" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bildschirm mit dem aktiven Fenster"
+            "value" : "Bildschirm mit dem aktiven Space"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pantalla con la ventana activa"
+            "value" : "Pantalla con el espacio activo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Écran avec la fenêtre active"
+            "value" : "Écran avec l'espace actif"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ekran z aktywnym oknem"
+            "value" : "Ekran z aktywną przestrzenią"
           }
         }
       }

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -16,8 +16,6 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
     private let mruWindowsSortSwitch = NSSwitch()
-    private let displayMonitorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
-    private let displayModes: [SwitcherDisplayMode] = SwitcherDisplayMode.allCases
 
     override func setupContent() {
         // Experimental section — off by default, clearly flagged as unstable.
@@ -67,21 +65,9 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: experimental, title: String(localized: "Most recent (windows) sort order"),
                subtitle: String(localized: "Orders the list by when you last focused each window, across all apps."),
                accessory: mruWindowsSortSwitch, searchItemID: SearchID.mruWindowsSort)
-
-        addDivider(to: experimental)
-        displayMonitorPopup.controlSize = .small
-        displayMonitorPopup.translatesAutoresizingMaskIntoConstraints = false
-        displayMonitorPopup.setContentHuggingPriority(.required, for: .horizontal)
-        displayMonitorPopup.removeAllItems()
-        displayMonitorPopup.addItems(withTitles: displayModes.map(\.displayName))
-        displayMonitorPopup.target = self
-        displayMonitorPopup.action = #selector(displayModeChanged)
-        addRow(to: experimental, title: String(localized: "Show switcher on"),
-               subtitle: String(localized: "Choose which monitor the switcher opens on when you have more than one display."),
-               accessory: displayMonitorPopup, searchItemID: SearchID.displayMonitor)
-        // Tab drill-in (the `\` peek) + tab expansion graduated to the Switcher
-        // tab's "Tabs" section — they are stable, on by default, and belong with
-        // the other content options.
+        // "Show switcher on" (multi-monitor placement) and the `\` tab peek + tab
+        // expansion graduated to the Switcher tab once stable — see its "Display"
+        // and "Tabs" sections.
     }
 
     private func configureSwitch(_ toggle: NSSwitch, action: Selector) {
@@ -129,7 +115,6 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
         mruWindowsSortSwitch.state = prefs.sortOrder == .mruWindows ? .on : .off
-        if let i = displayModes.firstIndex(of: prefs.switcherDisplayMode) { displayMonitorPopup.selectItem(at: i) }
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -166,12 +151,6 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleInstantSpace(_ sender: NSSwitch) {
         Preferences.shared.experimentalInstantSpaceSwitch = (sender.state == .on)
-    }
-
-    @objc private func displayModeChanged() {
-        let idx = displayMonitorPopup.indexOfSelectedItem
-        guard displayModes.indices.contains(idx) else { return }
-        Preferences.shared.switcherDisplayMode = displayModes[idx]
     }
 
     @objc private func toggleMRUWindowsSort(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -37,6 +37,7 @@ enum SettingsAnchor {
     static let permissions = "privacy.permissions"
     static let recovery = "privacy.recovery"
     // Switcher
+    static let display = "switcher.display"
     static let contents = "switcher.contents"
     static let tabs = "switcher.tabs"
     static let search = "switcher.search"
@@ -99,6 +100,7 @@ enum SearchID {
     static let clickDismiss = "switcher.clickDismiss"
     static let vimNavigation = "switcher.vimNavigation"
     static let hoverActions = "switcher.hoverActions"
+    static let displayMonitor = "switcher.displayMonitor"
     static let exceptions = "switcher.exceptions"
     static let pinnedApps = "switcher.pinnedApps"
     // Appearance
@@ -118,7 +120,6 @@ enum SearchID {
     static let sensitivity = "experimental.sensitivity"
     static let instantSpace = "experimental.instantSpace"
     static let mruWindowsSort = "experimental.mruWindowsSort"
-    static let displayMonitor = "experimental.displayMonitor"
 }
 
 @MainActor
@@ -257,6 +258,9 @@ enum SettingsCatalog {
         item(SearchID.restoreShortcuts, .privacy, SettingsAnchor.recovery, String(localized: "Privacy"), String(localized: "Recovery"),
              String(localized: "Restore macOS keyboard shortcuts"), ["restore", "recover", "command tab", "cmd tab", "native", "symbolic hotkey", "stuck", "reset shortcuts"]),
 
+        // Switcher · Display
+        item(SearchID.displayMonitor, .switcher, SettingsAnchor.display, String(localized: "Switcher"), String(localized: "Display"),
+             String(localized: "Show switcher on"), ["display", "monitor", "screen", "multi monitor", "cursor", "main display", "active space"]),
         // Switcher · Contents
         item(SearchID.showMinimized, .switcher, SettingsAnchor.contents, String(localized: "Switcher"), String(localized: "Contents"),
              String(localized: "Show minimized windows"), ["minimized", "minimize"]),
@@ -352,8 +356,6 @@ enum SettingsCatalog {
              String(localized: "Switch Spaces without animation"), ["spaces", "space", "animation", "instant", "full screen"]),
         item(SearchID.mruWindowsSort, .experimental, SettingsAnchor.experimental, String(localized: "Experimental"), String(localized: "Experimental"),
              String(localized: "Most recent (windows) sort order"), ["sort", "window", "recent", "order", "mru", "windows"]),
-        item(SearchID.displayMonitor, .experimental, SettingsAnchor.experimental, String(localized: "Experimental"), String(localized: "Experimental"),
-             String(localized: "Show switcher on"), ["display", "monitor", "screen", "multi monitor", "cursor", "main display", "active window"]),
     ]
 
     private static func item(

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -8,6 +8,10 @@ import Combine
 @MainActor
 final class SwitcherSettingsViewController: SettingsTabViewController {
 
+    // Display
+    private let displayMonitorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let displayModes: [SwitcherDisplayMode] = SwitcherDisplayMode.allCases
+
     // Contents
     private let minimizedSwitch = NSSwitch()
     private let hiddenSwitch = NSSwitch()
@@ -57,6 +61,20 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private var cancellables = Set<AnyCancellable>()
 
     override func setupContent() {
+        // Display section — which monitor the switcher panel opens on (graduated
+        // from Experimental once stable).
+        let display = addSection(title: String(localized: "Display"), anchor: SettingsAnchor.display)
+        displayMonitorPopup.controlSize = .small
+        displayMonitorPopup.translatesAutoresizingMaskIntoConstraints = false
+        displayMonitorPopup.setContentHuggingPriority(.required, for: .horizontal)
+        displayMonitorPopup.removeAllItems()
+        displayMonitorPopup.addItems(withTitles: displayModes.map(\.displayName))
+        displayMonitorPopup.target = self
+        displayMonitorPopup.action = #selector(displayModeChanged)
+        addRow(to: display, title: String(localized: "Show switcher on"),
+               subtitle: String(localized: "Choose which monitor the switcher opens on when you have more than one display."),
+               accessory: displayMonitorPopup, searchItemID: SearchID.displayMonitor)
+
         // Switcher contents section — what kinds of windows/apps appear.
         let contents = addSection(title: String(localized: "Contents"), anchor: SettingsAnchor.contents)
         configureSwitch(minimizedSwitch, action: #selector(toggleMinimized(_:)))
@@ -250,6 +268,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         applicationsOnlySwitch.state = prefs.applicationsOnly ? .on : .off
         badgesSwitch.state = prefs.showUnreadBadges ? .on : .off
         currentSpaceSwitch.state = prefs.currentSpaceOnly ? .on : .off
+        if let i = displayModes.firstIndex(of: prefs.switcherDisplayMode) { displayMonitorPopup.selectItem(at: i) }
         selectSortOrder(prefs.sortOrder)
         tabDrillSwitch.state = prefs.tabDrillEnabled ? .on : .off
         expandTabsSwitch.state = prefs.expandTabsAsWindows ? .on : .off
@@ -324,6 +343,12 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         let idx = sortOrderPopup.indexOfSelectedItem
         guard sortOrders.indices.contains(idx) else { return }
         Preferences.shared.sortOrder = sortOrders[idx]
+    }
+
+    @objc private func displayModeChanged() {
+        let idx = displayMonitorPopup.indexOfSelectedItem
+        guard displayModes.indices.contains(idx) else { return }
+        Preferences.shared.switcherDisplayMode = displayModes[idx]
     }
 
     private func selectSortOrder(_ order: SwitcherSortOrder) {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -108,9 +108,12 @@ final class SwitcherController: SwitcherViewDelegate {
     /// highlighted row and not a live `frontmostApplication` read (which returns
     /// BetterCmdTab once our key panel is on screen). Cleared on teardown.
     private var openFocusedWindow: AXUIElement?
-    /// Screen of the window focused when the switcher opened, resolved off-main
-    /// for `.activeWindow` display mode (#22). nil for other modes or until the
-    /// async read lands. Cleared on teardown with `openFocusedWindow`.
+    /// Target screen for `.activeWindow` ("active Space") display mode (#22),
+    /// resolved off-main: the active monitor (the bright-menu-bar / focused
+    /// display, which does not follow the mouse), or — when that can't be
+    /// resolved — the screen of the window focused when the switcher opened. nil
+    /// for other modes or until the async read lands. Cleared on teardown with
+    /// `openFocusedWindow`.
     private var openTargetScreen: NSScreen?
     /// The app that was frontmost when the switcher opened. On open we activate
     /// BetterCmdTab so the WindowServer renders the Liquid Glass backdrop as
@@ -2037,6 +2040,16 @@ final class SwitcherController: SwitcherViewDelegate {
         return screens[i]
     }
 
+    /// The `NSScreen` whose `CGDirectDisplayID` matches `displayID`, or nil when
+    /// no live screen does (e.g. the display was unplugged between the off-main
+    /// capture and this main-actor lookup). Main-actor only (`NSScreen.screens`).
+    /// Backs `.activeWindow` (active-monitor) placement.
+    private func screen(forDisplayID displayID: CGDirectDisplayID) -> NSScreen? {
+        NSScreen.screens.first {
+            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value == displayID
+        }
+    }
+
     /// Resolve the frontmost app's focused window off the main thread during the
     /// primed phase so the work overlaps the reveal delay instead of stalling
     /// `reveal()`. `openFocusedWindow` is what window-management chords act on
@@ -2057,7 +2070,12 @@ final class SwitcherController: SwitcherViewDelegate {
         let gen = focusedWindowCaptureGen
         DispatchQueue.global(qos: .userInteractive).async {
             let window = Activator.focusedWindow(pid: pid)
-            let axBounds = (wantScreen && window != nil) ? Activator.axBounds(of: window!) : nil
+            // Prefer the active monitor (the one with the bright menu bar — the
+            // focused display, which does NOT follow the mouse; correct even with
+            // no focused window, e.g. a bare desktop). Only pay for the
+            // focused-window AX bounds read when that is unavailable.
+            let activeDisplayID = wantScreen ? PrivateAPI.activeMenuBarDisplayID() : nil
+            let axBounds = (wantScreen && activeDisplayID == nil && window != nil) ? Activator.axBounds(of: window!) : nil
             DispatchQueue.main.async { [weak self] in
                 // `.primed` only: reveal() consumes + nils this and flips to
                 // `.visible`, so a landing after reveal (or after a cancel to
@@ -2066,7 +2084,11 @@ final class SwitcherController: SwitcherViewDelegate {
                 // skip the primed prefetch) would adopt.
                 guard let self, gen == self.focusedWindowCaptureGen, self.phase == .primed else { return }
                 self.prefetchedFocusedWindow = window
-                if let axBounds { self.prefetchedTargetScreen = self.screen(forAXBounds: axBounds) }
+                if let activeDisplayID, let s = self.screen(forDisplayID: activeDisplayID) {
+                    self.prefetchedTargetScreen = s
+                } else if let axBounds {
+                    self.prefetchedTargetScreen = self.screen(forAXBounds: axBounds)
+                }
             }
         }
     }
@@ -2109,17 +2131,22 @@ final class SwitcherController: SwitcherViewDelegate {
         openTargetScreen = prefetchedTargetScreen
         prefetchedTargetScreen = nil
         // Mode may have flipped to .activeWindow after the primed prefetch (which
-        // then captured the window but not the screen). Resolve the screen now
-        // from the already-captured window so active-window mode still applies.
+        // captured the window but not the screen). Resolve the screen now —
+        // active monitor (bright menu bar) first, the captured window as
+        // fallback — so active-window mode still applies.
         if Preferences.shared.switcherDisplayMode == .activeWindow,
            openTargetScreen == nil, let capturedWindow = openFocusedWindow {
             focusedWindowCaptureGen &+= 1
             let gen = focusedWindowCaptureGen
             DispatchQueue.global(qos: .userInteractive).async {
-                let axBounds = Activator.axBounds(of: capturedWindow)
+                let activeDisplayID = PrivateAPI.activeMenuBarDisplayID()
+                let axBounds = activeDisplayID == nil ? Activator.axBounds(of: capturedWindow) : nil
                 DispatchQueue.main.async { [weak self] in
                     guard let self, gen == self.focusedWindowCaptureGen, self.phase == .visible else { return }
-                    if let axBounds, let resolved = self.screen(forAXBounds: axBounds) {
+                    if let activeDisplayID, let resolved = self.screen(forDisplayID: activeDisplayID) {
+                        self.openTargetScreen = resolved
+                        self.reapplySessionScreenIfChanged()
+                    } else if let axBounds, let resolved = self.screen(forAXBounds: axBounds) {
                         self.openTargetScreen = resolved
                         self.reapplySessionScreenIfChanged()
                     }
@@ -2132,12 +2159,16 @@ final class SwitcherController: SwitcherViewDelegate {
             let gen = focusedWindowCaptureGen
             DispatchQueue.global(qos: .userInteractive).async {
                 let window = Activator.focusedWindow(pid: pid)
-                let axBounds = (wantScreen && window != nil) ? Activator.axBounds(of: window!) : nil
+                let activeDisplayID = wantScreen ? PrivateAPI.activeMenuBarDisplayID() : nil
+                let axBounds = (wantScreen && activeDisplayID == nil && window != nil) ? Activator.axBounds(of: window!) : nil
                 DispatchQueue.main.async { [weak self] in
                     guard let self, gen == self.focusedWindowCaptureGen,
                           self.phase == .visible, self.openFocusedWindow == nil else { return }
                     self.openFocusedWindow = window
-                    if let axBounds, let resolved = self.screen(forAXBounds: axBounds) {
+                    if let activeDisplayID, let resolved = self.screen(forDisplayID: activeDisplayID) {
+                        self.openTargetScreen = resolved
+                        self.reapplySessionScreenIfChanged()
+                    } else if let axBounds, let resolved = self.screen(forAXBounds: axBounds) {
                         self.openTargetScreen = resolved
                         self.reapplySessionScreenIfChanged()
                     }

--- a/BetterCmdTab/Switcher/SwitcherPanel.swift
+++ b/BetterCmdTab/Switcher/SwitcherPanel.swift
@@ -237,9 +237,10 @@ final class SwitcherPanel: NSPanel {
     }
 
     /// Resolve the screen for `mode`. `mouseCursor`/`mainDisplay` are cheap live
-    /// reads; `activeWindow` is supplied by the controller (`activeWindowScreen`),
-    /// captured before our key panel stole frontmost — it falls back to cursor →
-    /// main when unavailable (no focused window, or capture not yet landed).
+    /// reads; `activeWindow` (the active monitor — the bright-menu-bar / focused
+    /// display) is supplied by the controller (`activeWindowScreen`), captured
+    /// before our key panel stole frontmost — it falls back to cursor → main when
+    /// unavailable (private API missing, or the capture not yet landed).
     static func preferredScreen(mode: SwitcherDisplayMode? = nil,
                                 activeWindowScreen: NSScreen? = nil) -> NSScreen {
         switch mode ?? Preferences.shared.switcherDisplayMode {

--- a/BetterCmdTab/System/PrivateAPIs.swift
+++ b/BetterCmdTab/System/PrivateAPIs.swift
@@ -117,6 +117,11 @@ enum PrivateAPI {
     // swipe will move, so we only post one for jumps within that display.
     private static let getActiveSpaceFn: (@convention(c) (Int32) -> UInt64)? =
         sym("CGSGetActiveSpace", in: skyLight)
+    // (cid) -> the active (bright) menu bar's display UUID string. Tracks the
+    // FOCUSED display — keyboard focus / frontmost window — NOT the cursor,
+    // unlike CGSGetActiveSpace. Backs opening the switcher on the active monitor.
+    private static let copyActiveMenuBarDisplayFn: (@convention(c) (Int32) -> Unmanaged<CFString>?)? =
+        sym("SLSCopyActiveMenuBarDisplayIdentifier", in: skyLight)
 
     // MARK: - SkyLight: current-Space queries (read-only)
 
@@ -126,6 +131,47 @@ enum PrivateAPI {
         guard let mainConnection = mainConnectionFn, let getActive = getActiveSpaceFn else { return nil }
         let space = getActive(mainConnection())
         return space == 0 ? nil : space
+    }
+
+    /// The CoreGraphics display id of the monitor whose menu bar is currently
+    /// active (the bright one) — i.e. the display the user is working on. This is
+    /// the *focused* display: it follows keyboard focus / the frontmost window,
+    /// NOT the mouse. Hovering the pointer over another monitor leaves that
+    /// monitor's menu bar dimmed and does not change this result.
+    ///
+    /// Resolves via `SLSCopyActiveMenuBarDisplayIdentifier` (a display UUID, or
+    /// the literal "Main"), mapped to a `CGDirectDisplayID`. This is deliberately
+    /// NOT `CGSGetActiveSpace`, whose active-Space id tracks the display under
+    /// the cursor — using that made the switcher follow the mouse onto a dimmed
+    /// monitor instead of staying on the active (bright-menu-bar) one.
+    ///
+    /// Returns nil — so the caller falls back to the focused-window/cursor chain
+    /// — when the private API is unavailable or the identifier can't be placed on
+    /// a live display. CGS/CoreGraphics only (no AppKit) so it is safe to call
+    /// off the main thread, where the switcher resolves its target screen.
+    static func activeMenuBarDisplayID() -> CGDirectDisplayID? {
+        guard let mainConnection = mainConnectionFn,
+              let copyMenuBarDisplay = copyActiveMenuBarDisplayFn,
+              let identifier = copyMenuBarDisplay(mainConnection())?.takeRetainedValue() else { return nil }
+        return displayID(forManagedIdentifier: identifier as String)
+    }
+
+    /// Map a SkyLight "Display Identifier" (e.g. from
+    /// `SLSCopyActiveMenuBarDisplayIdentifier`) to a CG display id. The value is
+    /// the literal "Main" on some macOS builds, otherwise a display UUID string
+    /// matched against the online displays' UUIDs. nil when no online display
+    /// matches (e.g. unplugged between query and lookup).
+    private static func displayID(forManagedIdentifier identifier: String) -> CGDirectDisplayID? {
+        if identifier == "Main" { return CGMainDisplayID() }
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success, count > 0 else { return nil }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else { return nil }
+        for id in ids {
+            guard let uuid = CGDisplayCreateUUIDFromDisplayID(id)?.takeRetainedValue() else { continue }
+            if (CFUUIDCreateString(nil, uuid) as String) == identifier { return id }
+        }
+        return nil
     }
 
     /// Classify each window id by Space membership in a single CGS pass.


### PR DESCRIPTION
## Summary

Makes the **"Show switcher on" → active space** mode actually open the switcher on the monitor you're working on, and promotes the option from the Experimental pane to the Switcher tab.

### The bug
The middle display mode resolved its target screen from the **focused window's bounds** (and was mislabeled *"active window"*). On a two-monitor setup that meant the switcher **followed the mouse onto the dimmed, inactive monitor** instead of staying on the monitor with the bright (active) menu bar.

### The fix
Resolve the active monitor directly from the **bright menu bar** via `SLSCopyActiveMenuBarDisplayIdentifier` — the *focused* display, which tracks keyboard focus, **not the cursor**. `CGSGetActiveSpace` (my first attempt) was the wrong signal: its active‑Space id follows the display under the pointer, which is exactly what produced the mouse‑following behavior.

- Query runs **off‑main** in the existing prefetch (zero cost on the reveal frame); maps the display UUID → `CGDirectDisplayID` → `NSScreen`.
- **Graceful fallback** chain unchanged: active monitor → focused window → cursor → main. If the private API is missing, it degrades to the old heuristic.
- In the common multi‑monitor case it now **skips the focused‑window AX read**, so it's also a touch cheaper.
- Mode relabeled **"active space"** to match what users perceive (bright menu bar = active Space). The persisted enum case stays `.activeWindow`, so `.cmdtab` import/export and existing settings are untouched.

### Graduation
Moved **"Show switcher on"** out of Experimental into a new **Display** section at the top of the **Switcher** tab, updated the search catalog (`switcher.display` anchor + `switcher.displayMonitor` search id), and added `de/es/fr/pl` localizations for the new section title.

## Testing
- `xcodebuild` **Debug** and **Release** (Liquid Glass) builds succeed.
- Full unit suite: **252 tests, 29 suites — all pass**.
- Empirically verified the menu‑bar identifier resolves to the focused display and tracks focus (changed between runs), distinct from the cursor/active‑space signal.
- The CGS screen‑resolution path needs a live WindowServer + ≥2 monitors, so it's manually verified (consistent with the rest of `PrivateAPIs`, which is not unit‑tested). Manual check: mouse on the dimmed monitor, focus/bright menu bar on the other → switcher opens on the monitor with the bright menu bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)