### PR TITLE
fix: ⌘Q/W stop working after a while — secure-input tap-disable storm (#16)

### DIFF
--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -760,28 +760,37 @@ final class HotkeyTap {
                 DispatchQueue.main.async { handler() }
                 return Unmanaged.passUnretained(event)
             }
-            // Storm guard: count rapid consecutive disables. Re-enabling an active
-            // session tap that the WindowServer keeps disabling (a sustained
-            // timeout with AX still granted) pins THIS tap thread in synchronous
-            // WindowServer IPC — and the WindowServer blocks all system input on
-            // it, freezing the whole machine. Once a burst is seen, stop the tight
-            // re-enable loop and hand off to a main-thread recovery that tears the
-            // tap down / re-arms on a backoff.
-            let now = DispatchTime.now().uptimeNanoseconds
-            let storming = disableGate.withLock { gate -> Bool in
-                if now &- gate.lastNs > Self.disableBurstWindowNs { gate.count = 0 }
-                gate.lastNs = now
-                gate.count += 1
-                return gate.count > Self.maxRapidReenables
-            }
-            if storming {
-                // Return WITHOUT re-enabling so the tap thread stops spinning in
-                // WindowServer IPC; recovery happens on main (uninstall + re-arm,
-                // or stay down if AX was revoked).
-                Log.hotkey.error("CGEventTap disabled repeatedly (storm) — bailing to main-thread recovery")
-                let handler = onTapDisabledStorm
-                DispatchQueue.main.async { handler() }
-                return Unmanaged.passUnretained(event)
+            // Storm guard — TIMEOUT only. `kCGEventTapDisabledByUserInput` is the
+            // secure-input / external-input kind of disable, NOT the watchdog
+            // timeout, and it carries no freeze risk beyond what the AX-trust check
+            // above already guards. On affected setups a secure-input source flaps
+            // on/off ~1×/second, so the WindowServer streams `userInput` disables;
+            // routing them through this gate tore the tap down and re-armed it on a
+            // backoff every second, and during each backoff the ⌘-release was lost
+            // — welding the switcher open so the tap swallowed ⌘W/⌘Q system-wide
+            // (issue #16). For `userInput` just fall through and re-enable (as the
+            // simple alt-tab handler does): under secure input the WindowServer
+            // re-disables instantly and the always-armed Carbon survivor trigger
+            // keeps ⌘Tab working; the tap re-takes over the moment it clears.
+            //
+            // The gate stays for TIMEOUT: re-enabling an active session tap the
+            // WindowServer keeps timing out (AX still granted, main thread wedged)
+            // pins this tap thread in synchronous WindowServer IPC, freezing the
+            // whole machine — so a timeout burst still bails to main-thread recovery.
+            if type == .tapDisabledByTimeout {
+                let now = DispatchTime.now().uptimeNanoseconds
+                let storming = disableGate.withLock { gate -> Bool in
+                    if now &- gate.lastNs > Self.disableBurstWindowNs { gate.count = 0 }
+                    gate.lastNs = now
+                    gate.count += 1
+                    return gate.count > Self.maxRapidReenables
+                }
+                if storming {
+                    Log.hotkey.error("CGEventTap disabled repeatedly (storm) — bailing to main-thread recovery")
+                    let handler = onTapDisabledStorm
+                    DispatchQueue.main.async { handler() }
+                    return Unmanaged.passUnretained(event)
+                }
             }
             // Final trust re-check immediately before the re-enable closes the
             // TOCTOU window: AX can be revoked in the tiny gap since the check

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -814,7 +814,9 @@ final class HotkeyTap {
                     CGEvent.tapEnable(tap: auxTap, enable: true)
                 }
             }
-            Log.hotkey.warning("CGEventTap disabled, re-enabling")
+            // #16-diag (temporary): which kind of disable is storming?
+            let diagReason = type == .tapDisabledByTimeout ? "timeout" : "userInput"
+            Log.hotkey.warning("CGEventTap disabled (\(diagReason)), re-enabling")
             return Unmanaged.passUnretained(event)
         }
 

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -816,7 +816,7 @@ final class HotkeyTap {
             }
             // #16-diag (temporary): which kind of disable is storming?
             let diagReason = type == .tapDisabledByTimeout ? "timeout" : "userInput"
-            Log.hotkey.warning("CGEventTap disabled (\(diagReason)), re-enabling")
+            Log.hotkey.warning("CGEventTap disabled (\(diagReason, privacy: .public)), re-enabling")
             return Unmanaged.passUnretained(event)
         }
 

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -1085,6 +1085,15 @@ final class HotkeyTap {
                                 return nil
                             }
                             if let action = panelKeyMap.withLock({ $0[keyCode] }) {
+                                // #16-diag (temporary): records every time the tap
+                                // consumes an in-panel action key (W/Q/M/H/F). If the
+                                // user sees ⌘W "do nothing" with NO switcher panel on
+                                // screen and this line fired, the tap is swallowing on
+                                // a stranded phase; if ⌘W fails with NO such line, the
+                                // cause is elsewhere (Carbon override / something else).
+                                let diagSwitching = isSwitchingNow()
+                                let diagPresented = isPanelPresented()
+                                Log.hotkey.error("#16-diag tap-swallow action keyCode=\(keyCode) switching=\(diagSwitching) presented=\(diagPresented)")
                                 switch action {
                                 case .close: deliver(.closeWindow)
                                 case .minimize: deliver(.minimizeWindow)

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -823,9 +823,14 @@ final class HotkeyTap {
                     CGEvent.tapEnable(tap: auxTap, enable: true)
                 }
             }
-            // #16-diag (temporary): which kind of disable is storming?
-            let diagReason = type == .tapDisabledByTimeout ? "timeout" : "userInput"
-            Log.hotkey.warning("CGEventTap disabled (\(diagReason, privacy: .public)), re-enabling")
+            // A watchdog timeout is rare and worth a warning; a userInput disable
+            // (secure-input flap) can stream ~1×/s, so log it at debug to avoid
+            // spamming the default log while still being inspectable.
+            if type == .tapDisabledByTimeout {
+                Log.hotkey.warning("CGEventTap disabled (timeout), re-enabling")
+            } else {
+                Log.hotkey.debug("CGEventTap disabled (userInput), re-enabling")
+            }
             return Unmanaged.passUnretained(event)
         }
 
@@ -1096,15 +1101,6 @@ final class HotkeyTap {
                                 return nil
                             }
                             if let action = panelKeyMap.withLock({ $0[keyCode] }) {
-                                // #16-diag (temporary): records every time the tap
-                                // consumes an in-panel action key (W/Q/M/H/F). If the
-                                // user sees ⌘W "do nothing" with NO switcher panel on
-                                // screen and this line fired, the tap is swallowing on
-                                // a stranded phase; if ⌘W fails with NO such line, the
-                                // cause is elsewhere (Carbon override / something else).
-                                let diagSwitching = isSwitchingNow()
-                                let diagPresented = isPanelPresented()
-                                Log.hotkey.error("#16-diag tap-swallow action keyCode=\(keyCode) switching=\(diagSwitching) presented=\(diagPresented)")
                                 switch action {
                                 case .close: deliver(.closeWindow)
                                 case .minimize: deliver(.minimizeWindow)

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -174,12 +174,6 @@ final class SwitcherController: SwitcherViewDelegate {
     /// actively-steered panel never hits it (any nav refreshes the stamp), short
     /// enough to bound how long ⌘W can be eaten when the modifier state is stuck.
     private static let visibleStrandCeiling: TimeInterval = 4
-    /// #16-diag (temporary): a low-frequency probe that dumps the full switcher
-    /// state once the panel has been non-idle past a strand ceiling, so a real
-    /// reproduction of "⌘W stops working" reveals exactly which flag is stuck
-    /// (and whether a panel is genuinely on screen). Remove once #16 is closed.
-    private var strandProbe: Timer?
-    private var nonIdleSince: Date?
     private var currentMetrics: SwitcherMetrics = .baseline
     private var letterBuffer: String = ""
     private var letterBufferTimer: Timer?
@@ -941,7 +935,6 @@ final class SwitcherController: SwitcherViewDelegate {
     private func handleSecureInputChange(_ active: Bool) {
         guard active != secureInputActive else { return }
         secureInputActive = active
-        Log.switcher.error("#16-diag secureInput -> \(active) phase=\(String(describing: self.phase), privacy: .public)") // #16-diag (temporary)
         // While the panel is CLOSED the native-override plan does NOT depend on
         // secure input — the in-panel parity Carbon chords exist only while a panel
         // is open. So a secure-input flap while idle must not recompute/reapply the
@@ -1380,8 +1373,6 @@ final class SwitcherController: SwitcherViewDelegate {
         holdMonitorRunning = false
         visibleReleaseBackstop?.invalidate()
         visibleReleaseBackstop = nil
-        strandProbe?.invalidate() // #16-diag (temporary)
-        strandProbe = nil
         carbonTrigger.uninstall()
         if !disabledSymbolicKeys.isEmpty {
             PrivateAPI.setNativeCommandTabEnabled(true, disabledSymbolicKeys)
@@ -1527,7 +1518,6 @@ final class SwitcherController: SwitcherViewDelegate {
             // Seed the steering stamp on the open edge so the no-interaction
             // force-close ceiling is measured from when the panel appeared.
             if newValue == .visible { lastVisibleActivity = Date() }
-            syncStrandProbe() // #16-diag (temporary)
             // Returning to idle ends any scoped-shortcut open so the next plain
             // ⌘Tab is unfiltered. Single chokepoint — every exit path (commit,
             // cancel, dismiss) flows through here.
@@ -2161,47 +2151,6 @@ final class SwitcherController: SwitcherViewDelegate {
             previousFrontmostApp = nil
             cancel()
         }
-    }
-
-    /// #16-diag (temporary): arm/disarm the strand probe alongside the phase edge.
-    /// Runs only while non-idle (zero timers when the switcher is closed).
-    private func syncStrandProbe() {
-        if phase != .idle {
-            if nonIdleSince == nil { nonIdleSince = Date() }
-            if strandProbe == nil {
-                let timer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
-                    MainActor.assumeIsolated { self?.strandProbeFired() }
-                }
-                RunLoop.main.add(timer, forMode: .common)
-                strandProbe = timer
-            }
-        } else {
-            nonIdleSince = nil
-            strandProbe?.invalidate()
-            strandProbe = nil
-        }
-    }
-
-    /// #16-diag (temporary): dump the full switcher state once the panel has been
-    /// non-idle past a strand ceiling (4 s — well beyond a normal switch). When
-    /// ⌘W "stops working", reproduce and read this line: it shows whether a panel
-    /// is genuinely on screen (`panel.isVisible`) and which flag is stuck.
-    private func strandProbeFired() {
-        guard let since = nonIdleSince, Date().timeIntervalSince(since) > 4 else { return }
-        // Bind to locals first: the os.Logger interpolation is an autoclosure, so
-        // touching these stored properties inside it would require explicit self.
-        let age = Int(Date().timeIntervalSince(since))
-        let phaseDesc = String(describing: phase)
-        let panelVisible = panel.isVisible
-        let panelKey = panel.isKeyWindow
-        let sticky = stickyOpen
-        let heldChord = primedByHeldChord
-        let drill = tabDrillActive
-        let search = searchActive
-        let secure = secureInputActive
-        let held = holdMonitor.isHeld
-        let symbolic = disabledSymbolicKeys.count
-        Log.switcher.error("#16-diag STRAND phase=\(phaseDesc, privacy: .public) panelVisible=\(panelVisible) panelKey=\(panelKey) sticky=\(sticky) heldChord=\(heldChord) tabDrill=\(drill) search=\(search) secureInput=\(secure) holdHeld=\(held) symbolicDisabled=\(symbolic) age=\(age)s")
     }
 
     private func schedulePrimedReveal() {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -939,13 +939,22 @@ final class SwitcherController: SwitcherViewDelegate {
     /// React to a Secure Event Input transition surfaced by `secureInputMonitor`:
     /// re-derive and apply the native-shortcut override for the new state.
     private func handleSecureInputChange(_ active: Bool) {
+        guard active != secureInputActive else { return }
         secureInputActive = active
-        Log.switcher.error("#16-diag secureInput -> \(active) (phase=\(String(describing: self.phase), privacy: .public))") // #16-diag (temporary)
+        Log.switcher.error("#16-diag secureInput -> \(active) phase=\(String(describing: self.phase), privacy: .public)") // #16-diag (temporary)
+        // While the panel is CLOSED the native-override plan does NOT depend on
+        // secure input — the in-panel parity Carbon chords exist only while a panel
+        // is open. So a secure-input flap while idle must not recompute/reapply the
+        // override: a flapping secure-input source (observed pulsing ~1×/s) was
+        // driving syncNativeHotkeyOverride → carbonTrigger.update(), which
+        // UNREGISTERS + RE-REGISTERS every global Carbon hotkey on each flap. That
+        // ~1 Hz WindowServer churn was disabling the CGEvent tap (the issue #16
+        // storm → missed ⌘-release → stranded panel → ⌘W/⌘Q swallowed). The flag is
+        // kept current above; the panel's open edge re-syncs the override from it.
+        guard phase != .idle else { return }
+        // A secure-input flip while a panel IS open changes which poller owns
+        // ⌘-release detection (HoldModifierMonitor under secure input), so re-sync.
         syncNativeHotkeyOverride()
-        // A secure-input flip changes which poller owns ⌘-release detection: under
-        // Secure Event Input `HoldModifierMonitor` (started by the sync above) owns
-        // it, so stand the normal-input backstop down; when it clears, reclaim it —
-        // catching a release dropped while the tap was deaf (issue #16).
         syncVisibleReleaseBackstop()
     }
 

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -162,6 +162,18 @@ final class SwitcherController: SwitcherViewDelegate {
     /// tier, which exists only because there the poll is the sole commit signal),
     /// keeping the main-thread wake count low while the panel is briefly up.
     private static let visibleReleaseBackstopInterval: TimeInterval = 0.2
+    /// Last time the user actively *steered* a visible panel (navigation, search
+    /// edit, drill nav — see `noteSteeringActivity`). The release-to-commit
+    /// backstop force-closes a panel that has gone this long without steering, so
+    /// a panel welded open by a STUCK `CGEventSource.flagsState` (the tap was
+    /// disabled across the real ⌘-release, leaving the modifier reported as still
+    /// held — which defeats every flagsState-based recovery, incl. PR #67) still
+    /// self-heals and the tap stops swallowing ⌘W/⌘Q (issue #16).
+    private var lastVisibleActivity: Date?
+    /// No-interaction ceiling for the force-close above. Generous enough that an
+    /// actively-steered panel never hits it (any nav refreshes the stamp), short
+    /// enough to bound how long ⌘W can be eaten when the modifier state is stuck.
+    private static let visibleStrandCeiling: TimeInterval = 4
     /// #16-diag (temporary): a low-frequency probe that dumps the full switcher
     /// state once the panel has been non-idle past a strand ceiling, so a real
     /// reproduction of "⌘W stops working" reveals exactly which flag is stuck
@@ -1066,8 +1078,14 @@ final class SwitcherController: SwitcherViewDelegate {
         tabDrillActive: Bool,
         secureInputActive: Bool
     ) -> Bool {
-        phase == .visible && primedByHeldChord && !secureInputActive
-            && (!stickyOpen || tabDrillActive)
+        // NOTE: secure input is deliberately NOT excluded. Under Secure Event Input
+        // the release is supposed to be caught by HoldModifierMonitor, but that
+        // poll reads the SAME CGEventSource.flagsState that can stick reporting
+        // ⌘-held (issue #16) — so the backstop must also run there to drive the
+        // flagsState-independent no-interaction force-close. `secureInputActive`
+        // is kept as a parameter for the unit matrix and future use.
+        _ = secureInputActive
+        return phase == .visible && primedByHeldChord && (!stickyOpen || tabDrillActive)
     }
 
     /// Live check of `releaseAlreadyMissed` against the current physical modifier
@@ -1497,6 +1515,9 @@ final class SwitcherController: SwitcherViewDelegate {
             // (commit/cancel → `.idle`) always tears it down, and a fresh `.visible`
             // arms it.
             syncVisibleReleaseBackstop()
+            // Seed the steering stamp on the open edge so the no-interaction
+            // force-close ceiling is measured from when the panel appeared.
+            if newValue == .visible { lastVisibleActivity = Date() }
             syncStrandProbe() // #16-diag (temporary)
             // Returning to idle ends any scoped-shortcut open so the next plain
             // ⌘Tab is unfiltered. Single chokepoint — every exit path (commit,
@@ -1627,6 +1648,7 @@ final class SwitcherController: SwitcherViewDelegate {
 
     func switcherViewDidHover(index: Int) {
         guard phase == .visible else { return }
+        lastVisibleActivity = Date() // #16: mouse steering keeps the panel alive
         guard rows.indices.contains(index), index != self.index else { return }
         // Moving the selection off the drilled-in row drops drill mode — the
         // strip belongs to the previous row's tabs.
@@ -1672,7 +1694,27 @@ final class SwitcherController: SwitcherViewDelegate {
         }
     }
 
+    /// Refresh `lastVisibleActivity` on genuine user *steering* of the panel —
+    /// navigation, search editing, drill nav. Deliberately NOT the in-panel action
+    /// keys (close/quit/minimize/hide/fullscreen — those are the very symptom of a
+    /// stranded swallow, and a user mashing ⌘W must not keep the panel alive), nor
+    /// commit/escape/dismiss/releaseCmd (those already close it). Lets the
+    /// no-interaction force-close distinguish "actively browsing" from "welded
+    /// open and abandoned" (issue #16).
+    private func noteSteeringActivity(for event: HotkeyTap.Event) {
+        switch event {
+        case .nextApp, .prevApp, .nextWindow, .prevWindow, .nextRow, .prevRow,
+             .spatialLeft, .spatialRight, .letterInput, .letterInputKey,
+             .searchInput, .searchInputKey, .searchBackspace, .toggleSearch,
+             .enterTabDrill, .exitTabDrill, .tabPrev, .tabNext:
+            lastVisibleActivity = Date()
+        default:
+            break
+        }
+    }
+
     private func handle(_ event: HotkeyTap.Event) {
+        noteSteeringActivity(for: event)
         switch event {
         case .nextApp:
             // Secure-input Carbon parity with the tap's drill branch: while
@@ -2088,9 +2130,28 @@ final class SwitcherController: SwitcherViewDelegate {
             syncVisibleReleaseBackstop()
             return
         }
-        guard holdReleaseAlreadyMissed() else { return }
-        Log.switcher.warning("visible panel outlived its ⌘-release — recovering (issue #16)")
-        handleModifierRelease()
+        // Fast path: the live modifier state confirms ⌘ is up — honour the missed
+        // release immediately (commit), exactly as the tap's `.releaseCmd` would.
+        if holdReleaseAlreadyMissed() {
+            Log.switcher.warning("visible panel outlived its ⌘-release — recovering (issue #16)")
+            handleModifierRelease()
+            return
+        }
+        // Robust path: when the tap was disabled across the real release, the
+        // ⌘-up is lost AND `CGEventSource.flagsState` can stick reporting ⌘-held —
+        // so the fast path never fires and the panel is welded open with the tap
+        // swallowing ⌘W/⌘Q. Force it closed once the user has stopped steering it
+        // past the ceiling. flagsState-independent, so it heals a stuck modifier
+        // that PR #67 could not (issue #16).
+        if let last = lastVisibleActivity,
+           Date().timeIntervalSince(last) > Self.visibleStrandCeiling {
+            let idle = Int(Date().timeIntervalSince(last))
+            Log.switcher.error("visible panel stranded \(idle)s with no interaction — force-closing (issue #16)")
+            // The user has moved on by now; don't yank focus back to the app that
+            // was frontmost at open — just dismiss so the tap stops swallowing ⌘W.
+            previousFrontmostApp = nil
+            cancel()
+        }
     }
 
     /// #16-diag (temporary): arm/disarm the strand probe alongside the phase edge.

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -162,6 +162,12 @@ final class SwitcherController: SwitcherViewDelegate {
     /// tier, which exists only because there the poll is the sole commit signal),
     /// keeping the main-thread wake count low while the panel is briefly up.
     private static let visibleReleaseBackstopInterval: TimeInterval = 0.2
+    /// #16-diag (temporary): a low-frequency probe that dumps the full switcher
+    /// state once the panel has been non-idle past a strand ceiling, so a real
+    /// reproduction of "⌘W stops working" reveals exactly which flag is stuck
+    /// (and whether a panel is genuinely on screen). Remove once #16 is closed.
+    private var strandProbe: Timer?
+    private var nonIdleSince: Date?
     private var currentMetrics: SwitcherMetrics = .baseline
     private var letterBuffer: String = ""
     private var letterBufferTimer: Timer?
@@ -1346,6 +1352,8 @@ final class SwitcherController: SwitcherViewDelegate {
         holdMonitorRunning = false
         visibleReleaseBackstop?.invalidate()
         visibleReleaseBackstop = nil
+        strandProbe?.invalidate() // #16-diag (temporary)
+        strandProbe = nil
         carbonTrigger.uninstall()
         if !disabledSymbolicKeys.isEmpty {
             PrivateAPI.setNativeCommandTabEnabled(true, disabledSymbolicKeys)
@@ -1488,6 +1496,7 @@ final class SwitcherController: SwitcherViewDelegate {
             // (commit/cancel → `.idle`) always tears it down, and a fresh `.visible`
             // arms it.
             syncVisibleReleaseBackstop()
+            syncStrandProbe() // #16-diag (temporary)
             // Returning to idle ends any scoped-shortcut open so the next plain
             // ⌘Tab is unfiltered. Single chokepoint — every exit path (commit,
             // cancel, dismiss) flows through here.
@@ -2081,6 +2090,47 @@ final class SwitcherController: SwitcherViewDelegate {
         guard holdReleaseAlreadyMissed() else { return }
         Log.switcher.warning("visible panel outlived its ⌘-release — recovering (issue #16)")
         handleModifierRelease()
+    }
+
+    /// #16-diag (temporary): arm/disarm the strand probe alongside the phase edge.
+    /// Runs only while non-idle (zero timers when the switcher is closed).
+    private func syncStrandProbe() {
+        if phase != .idle {
+            if nonIdleSince == nil { nonIdleSince = Date() }
+            if strandProbe == nil {
+                let timer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.strandProbeFired() }
+                }
+                RunLoop.main.add(timer, forMode: .common)
+                strandProbe = timer
+            }
+        } else {
+            nonIdleSince = nil
+            strandProbe?.invalidate()
+            strandProbe = nil
+        }
+    }
+
+    /// #16-diag (temporary): dump the full switcher state once the panel has been
+    /// non-idle past a strand ceiling (4 s — well beyond a normal switch). When
+    /// ⌘W "stops working", reproduce and read this line: it shows whether a panel
+    /// is genuinely on screen (`panel.isVisible`) and which flag is stuck.
+    private func strandProbeFired() {
+        guard let since = nonIdleSince, Date().timeIntervalSince(since) > 4 else { return }
+        // Bind to locals first: the os.Logger interpolation is an autoclosure, so
+        // touching these stored properties inside it would require explicit self.
+        let age = Int(Date().timeIntervalSince(since))
+        let phaseDesc = String(describing: phase)
+        let panelVisible = panel.isVisible
+        let panelKey = panel.isKeyWindow
+        let sticky = stickyOpen
+        let heldChord = primedByHeldChord
+        let drill = tabDrillActive
+        let search = searchActive
+        let secure = secureInputActive
+        let held = holdMonitor.isHeld
+        let symbolic = disabledSymbolicKeys.count
+        Log.switcher.error("#16-diag STRAND phase=\(phaseDesc) panelVisible=\(panelVisible) panelKey=\(panelKey) sticky=\(sticky) heldChord=\(heldChord) tabDrill=\(drill) search=\(search) secureInput=\(secure) holdHeld=\(held) symbolicDisabled=\(symbolic) age=\(age)s")
     }
 
     private func schedulePrimedReveal() {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -928,6 +928,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// re-derive and apply the native-shortcut override for the new state.
     private func handleSecureInputChange(_ active: Bool) {
         secureInputActive = active
+        Log.switcher.error("#16-diag secureInput -> \(active) (phase=\(String(describing: self.phase), privacy: .public))") // #16-diag (temporary)
         syncNativeHotkeyOverride()
         // A secure-input flip changes which poller owns ⌘-release detection: under
         // Secure Event Input `HoldModifierMonitor` (started by the sync above) owns
@@ -2130,7 +2131,7 @@ final class SwitcherController: SwitcherViewDelegate {
         let secure = secureInputActive
         let held = holdMonitor.isHeld
         let symbolic = disabledSymbolicKeys.count
-        Log.switcher.error("#16-diag STRAND phase=\(phaseDesc) panelVisible=\(panelVisible) panelKey=\(panelKey) sticky=\(sticky) heldChord=\(heldChord) tabDrill=\(drill) search=\(search) secureInput=\(secure) holdHeld=\(held) symbolicDisabled=\(symbolic) age=\(age)s")
+        Log.switcher.error("#16-diag STRAND phase=\(phaseDesc, privacy: .public) panelVisible=\(panelVisible) panelKey=\(panelKey) sticky=\(sticky) heldChord=\(heldChord) tabDrill=\(drill) search=\(search) secureInput=\(secure) holdHeld=\(held) symbolicDisabled=\(symbolic) age=\(age)s")
     }
 
     private func schedulePrimedReveal() {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -138,6 +138,30 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `revealDelay` (clamped to 40…500 ms) and any off-main first-scan, so it
     /// only ever fires on a genuine strand, never on a legitimately slow open.
     private static let primedWatchdogTimeout: TimeInterval = 1.5
+    /// Liveness backstop for a stranded `.visible` release-to-commit panel — the
+    /// `.visible` twin of `primedWatchdog`. The keyboard ⌘Tab panel closes on the
+    /// ⌘-release `flagsChanged`, delivered under NORMAL input by the CGEvent tap
+    /// alone (a single edge-triggered event). If that one event is ever dropped —
+    /// the tap was disabled-by-timeout at that instant, transient deafness, a
+    /// Secure-Event-Input flap — the panel welds into `.visible`:
+    /// `panelPresentedFlag` stays set and the tap then swallows ⌘W/⌘Q/⌘M/⌘H/⌘F +
+    /// letter-jump system-wide, the "Cmd+Q/W stop working after a while" failure
+    /// (issue #16). `primedWatchdog` recovers only `.primed`; `HoldModifierMonitor`
+    /// polls the release only under Secure Event Input — so `.visible` under normal
+    /// input had no recovery. `.visible` has no fixed ceiling (the user may hold ⌘
+    /// while deciding for an unbounded time), so this can't be a timeout: it polls
+    /// the live physical modifier on a relaxed cadence and commits only once ⌘ is
+    /// actually up. Armed only for a held-chord, non-parked panel under normal
+    /// input (see `shouldArmVisibleReleaseBackstop`); `nil` otherwise, so a closed
+    /// switcher schedules no timer.
+    private var visibleReleaseBackstop: Timer?
+    /// Relaxed poll cadence for `visibleReleaseBackstop`. The tap is the instant
+    /// fast path that commits the common case; this only catches a *dropped*
+    /// release, where ~0.2 s of extra latency on an already-glitched event is
+    /// invisible — so ~5 Hz is plenty (not `HoldModifierMonitor`'s 33 Hz held
+    /// tier, which exists only because there the poll is the sole commit signal),
+    /// keeping the main-thread wake count low while the panel is briefly up.
+    private static let visibleReleaseBackstopInterval: TimeInterval = 0.2
     private var currentMetrics: SwitcherMetrics = .baseline
     private var letterBuffer: String = ""
     private var letterBufferTimer: Timer?
@@ -151,8 +175,14 @@ final class SwitcherController: SwitcherViewDelegate {
     /// modifier) no longer commits — only Return or a mouse click does.
     /// (The secure-input Carbon chords no longer key off this: they gate on the
     /// live hold modifier + the search/drill mode, re-synced from the poller and
-    /// the search/drill transitions, so `stickyOpen` needs no `didSet` here.)
-    private var stickyOpen = false
+    /// the search/drill transitions.)
+    ///
+    /// Sticky transitions happen mid-`.visible` with no phase edge (mouse detach,
+    /// stay-open park, drill enter/exit), and they flip whether releasing ⌘ would
+    /// still commit — so the `didSet` re-syncs `visibleReleaseBackstop` (issue #16).
+    private var stickyOpen = false {
+        didSet { if stickyOpen != oldValue { syncVisibleReleaseBackstop() } }
+    }
     /// `stickyOpen` snapshotted at drill entry so exiting the drill (e.g. the
     /// `\` toggle while ⌘ is still held) restores the pre-drill detach state
     /// instead of leaving `applyDrill`'s forced `stickyOpen = true` set — which
@@ -162,7 +192,13 @@ final class SwitcherController: SwitcherViewDelegate {
     /// Cmd+Left/Right, arrows) step `tabIndex` inside the highlighted row's
     /// `tabs` array instead of changing the app selection. Reset on every row
     /// change, dismiss, and `baseRows` swap.
-    private var tabDrillActive: Bool = false
+    ///
+    /// Drilling in/out flips whether releasing ⌘ commits (the drill commits the
+    /// highlighted tab on release even though it forces `stickyOpen`), so the
+    /// `didSet` re-syncs `visibleReleaseBackstop` on those edges (issue #16).
+    private var tabDrillActive: Bool = false {
+        didSet { if tabDrillActive != oldValue { syncVisibleReleaseBackstop() } }
+    }
     private var tabIndex: Int = 0
     private var tabTitles: [String] = []
     /// Transient, non-interactive message shown in the tab-strip region (e.g.
@@ -887,6 +923,11 @@ final class SwitcherController: SwitcherViewDelegate {
     private func handleSecureInputChange(_ active: Bool) {
         secureInputActive = active
         syncNativeHotkeyOverride()
+        // A secure-input flip changes which poller owns ⌘-release detection: under
+        // Secure Event Input `HoldModifierMonitor` (started by the sync above) owns
+        // it, so stand the normal-input backstop down; when it clears, reclaim it —
+        // catching a release dropped while the tap was deaf (issue #16).
+        syncVisibleReleaseBackstop()
     }
 
     /// Re-derive the secure-input Carbon chords after an in-panel mode change
@@ -999,6 +1040,27 @@ final class SwitcherController: SwitcherViewDelegate {
         let appHeld = appMask.map { HoldModifierMonitor.holdState(flags: flags, mask: $0) } ?? false
         let windowHeld = windowMask.map { HoldModifierMonitor.holdState(flags: flags, mask: $0) } ?? false
         return !(appHeld || windowHeld)
+    }
+
+    /// Pure: should the `.visible` release-to-commit liveness backstop
+    /// (`visibleReleaseBackstop`) be armed? Only when a panel is actually on
+    /// screen (`.visible`) for a held-chord keyboard open (`primedByHeldChord` —
+    /// false for gesture/scoped opens, which don't commit on release) under NORMAL
+    /// input, AND releasing the hold modifier would still commit something: i.e.
+    /// not parked sticky/stay-open (`stickyOpen`) UNLESS drilled into a tab strip
+    /// (the drill commits the highlighted tab on release even though it forces
+    /// `stickyOpen` true). Secure Event Input is excluded because
+    /// `HoldModifierMonitor` already polls the release there — running both would
+    /// double-poll. Isolated so the arming matrix stays unit-testable.
+    nonisolated static func shouldArmVisibleReleaseBackstop(
+        phase: Phase,
+        primedByHeldChord: Bool,
+        stickyOpen: Bool,
+        tabDrillActive: Bool,
+        secureInputActive: Bool
+    ) -> Bool {
+        phase == .visible && primedByHeldChord && !secureInputActive
+            && (!stickyOpen || tabDrillActive)
     }
 
     /// Live check of `releaseAlreadyMissed` against the current physical modifier
@@ -1282,6 +1344,8 @@ final class SwitcherController: SwitcherViewDelegate {
         secureInputMonitor.stop()
         holdMonitor.stop()
         holdMonitorRunning = false
+        visibleReleaseBackstop?.invalidate()
+        visibleReleaseBackstop = nil
         carbonTrigger.uninstall()
         if !disabledSymbolicKeys.isEmpty {
             PrivateAPI.setNativeCommandTabEnabled(true, disabledSymbolicKeys)
@@ -1418,6 +1482,12 @@ final class SwitcherController: SwitcherViewDelegate {
                 primedWatchdog?.invalidate()
                 primedWatchdog = nil
             }
+            // Liveness backstop for a stranded `.visible` release-to-commit panel
+            // (issue #16). Synced on EVERY phase edge — deliberately NOT under the
+            // `secureInputActive` gate below — so the common normal-input close
+            // (commit/cancel → `.idle`) always tears it down, and a fresh `.visible`
+            // arms it.
+            syncVisibleReleaseBackstop()
             // Returning to idle ends any scoped-shortcut open so the next plain
             // ⌘Tab is unfiltered. Single chokepoint — every exit path (commit,
             // cancel, dismiss) flows through here.
@@ -1959,6 +2029,58 @@ final class SwitcherController: SwitcherViewDelegate {
         }
         RunLoop.main.add(timer, forMode: .common)
         primedWatchdog = timer
+    }
+
+    /// Arm or tear down `visibleReleaseBackstop` to match the current state.
+    /// Idempotent — a no-op when the desired and actual states already agree — so
+    /// it is safe to call from every edge that can change the decision: the single
+    /// `phase` chokepoint, the `stickyOpen` / `tabDrillActive` `didSet`s, and a
+    /// secure-input transition. Costs nothing while the switcher is closed (the
+    /// decision is false at `.idle`, so no timer is ever scheduled).
+    private func syncVisibleReleaseBackstop() {
+        let want = Self.shouldArmVisibleReleaseBackstop(
+            phase: phase,
+            primedByHeldChord: primedByHeldChord,
+            stickyOpen: stickyOpen,
+            tabDrillActive: tabDrillActive,
+            secureInputActive: secureInputActive
+        )
+        if want {
+            guard visibleReleaseBackstop == nil else { return }
+            let timer = Timer(timeInterval: Self.visibleReleaseBackstopInterval, repeats: true) { [weak self] _ in
+                // The timer fires on the main run loop (added below), so stay on it
+                // inline rather than hopping through `Task { @MainActor }` (mirrors
+                // the reveal timer in `schedulePrimedReveal`).
+                MainActor.assumeIsolated { self?.visibleReleaseBackstopFired() }
+            }
+            RunLoop.main.add(timer, forMode: .common)
+            visibleReleaseBackstop = timer
+        } else {
+            visibleReleaseBackstop?.invalidate()
+            visibleReleaseBackstop = nil
+        }
+    }
+
+    /// One `visibleReleaseBackstop` tick. Stand down if the panel is no longer in a
+    /// backstopped state; otherwise re-read the live physical modifier and, only if
+    /// the hold modifier is genuinely up, route through the same chokepoint the
+    /// tap's `.releaseCmd` uses — recovering a panel whose ⌘-release `flagsChanged`
+    /// was dropped. A still-held ⌘ (`holdReleaseAlreadyMissed() == false`) is a
+    /// no-op, so a user mid-decision is never committed out from under (issue #16).
+    private func visibleReleaseBackstopFired() {
+        guard Self.shouldArmVisibleReleaseBackstop(
+            phase: phase,
+            primedByHeldChord: primedByHeldChord,
+            stickyOpen: stickyOpen,
+            tabDrillActive: tabDrillActive,
+            secureInputActive: secureInputActive
+        ) else {
+            syncVisibleReleaseBackstop()
+            return
+        }
+        guard holdReleaseAlreadyMissed() else { return }
+        Log.switcher.warning("visible panel outlived its ⌘-release — recovering (issue #16)")
+        handleModifierRelease()
     }
 
     private func schedulePrimedReveal() {

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -80,3 +80,71 @@ struct SwitcherReleaseMissedTests {
         #expect(SwitcherController.releaseAlreadyMissed(flags: [.maskCommand], appMask: nil, windowMask: nil))
     }
 }
+
+/// Pure-logic coverage for the `.visible` release-to-commit liveness backstop —
+/// the recovery the prior #16 fixes lacked. A keyboard ⌘Tab panel closes on the
+/// tap's single ⌘-release `flagsChanged`; if that event is dropped the panel
+/// welds into `.visible` and the tap keeps swallowing ⌘W/⌘Q. The backstop polls
+/// the live modifier and commits a missed release — but only for a panel where
+/// releasing ⌘ would actually commit, and never when `HoldModifierMonitor`
+/// already owns the release under Secure Event Input. These pin that arming
+/// matrix so it can't silently widen (perpetual poll) or narrow (re-strand).
+@Suite("Switcher visible-release backstop")
+struct SwitcherVisibleReleaseBackstopTests {
+    /// Helper with the common-case defaults: a live keyboard ⌘Tab panel.
+    private func arm(
+        phase: SwitcherController.Phase = .visible,
+        primedByHeldChord: Bool = true,
+        stickyOpen: Bool = false,
+        tabDrillActive: Bool = false,
+        secureInputActive: Bool = false
+    ) -> Bool {
+        SwitcherController.shouldArmVisibleReleaseBackstop(
+            phase: phase,
+            primedByHeldChord: primedByHeldChord,
+            stickyOpen: stickyOpen,
+            tabDrillActive: tabDrillActive,
+            secureInputActive: secureInputActive
+        )
+    }
+
+    @Test func arms_forLiveKeyboardPanel() {
+        // The primary issue #16 case: a held-chord ⌘Tab panel on screen under
+        // normal input — releasing ⌘ commits, so the backstop must guard it.
+        #expect(arm())
+    }
+
+    @Test func off_whenNotVisible() {
+        // Closed (the ~99.99% case) and panel-less `.primed` (owned by
+        // primedWatchdog) schedule no timer.
+        #expect(!arm(phase: .idle))
+        #expect(!arm(phase: .primed))
+    }
+
+    @Test func off_forGestureOrScopedOpens() {
+        // Gesture / scoped opens carry `primedByHeldChord == false`: they are
+        // sticky and never commit on release, so the backstop must stay off.
+        #expect(!arm(primedByHeldChord: false))
+    }
+
+    @Test func off_whenParkedSticky() {
+        // Mouse detach / stay-open search parks the panel (`stickyOpen`): releasing
+        // ⌘ no longer commits, so polling would only waste wakes.
+        #expect(!arm(stickyOpen: true))
+    }
+
+    @Test func on_whenDrilledIntoTabStrip() {
+        // Tab drill-in forces `stickyOpen` true but STILL commits the highlighted
+        // tab on release — so a dropped release there must be recovered too. This
+        // is the gap a naive `!stickyOpen` gate would leave open.
+        #expect(arm(stickyOpen: true, tabDrillActive: true))
+    }
+
+    @Test func off_underSecureInput() {
+        // Under Secure Event Input `HoldModifierMonitor` owns the release poll;
+        // running both would double-poll, so this backstop stands down.
+        #expect(!arm(secureInputActive: true))
+        // Even drilled-in, secure input keeps it off (no double-poll).
+        #expect(!arm(stickyOpen: true, tabDrillActive: true, secureInputActive: true))
+    }
+}

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -140,11 +140,14 @@ struct SwitcherVisibleReleaseBackstopTests {
         #expect(arm(stickyOpen: true, tabDrillActive: true))
     }
 
-    @Test func off_underSecureInput() {
-        // Under Secure Event Input `HoldModifierMonitor` owns the release poll;
-        // running both would double-poll, so this backstop stands down.
-        #expect(!arm(secureInputActive: true))
-        // Even drilled-in, secure input keeps it off (no double-poll).
-        #expect(!arm(stickyOpen: true, tabDrillActive: true, secureInputActive: true))
+    @Test func arms_underSecureInput_forFlagsStateIndependentRecovery() {
+        // Secure input is intentionally NOT excluded (issue #16): HoldModifierMonitor's
+        // release poll reads the same CGEventSource.flagsState that can stick reporting
+        // ⌘-held, so the backstop must also run under secure input to drive the
+        // flagsState-independent no-interaction force-close.
+        #expect(arm(secureInputActive: true))
+        #expect(arm(stickyOpen: true, tabDrillActive: true, secureInputActive: true))
+        // Sticky-without-drill still never arms, secure input or not.
+        #expect(!arm(stickyOpen: true, secureInputActive: true))
     }
 }


### PR DESCRIPTION
Refs #16 — merged for observation (intentionally **not** auto-closing; see note below).

## Symptom

After running a while, ⌘Q / ⌘W (and ⌘M/⌘H/⌘F) stop working system-wide until relaunch.

## Root cause (confirmed from on-device logs)

On affected machines an external source flaps **Secure Event Input on/off ~1×/second**. Each flap makes the WindowServer disable the session CGEvent tap with `kCGEventTapDisabledByUserInput`. That stream of disables was routed through the tap's storm-guard, which **tore the tap down and re-armed it on a backoff every second** — and during each backoff the ⌘-release was dropped, so the switcher welded into `.visible` and the tap kept swallowing the in-panel action keys (⌘W/⌘Q/⌘M/⌘H/⌘F) from the focused app.

Compounding it: every flap also re-ran the native-hotkey override (`carbonTrigger.update()` wholesale unregister+re-register), and the panel's stranded state was unrecoverable because the existing recovery (`HoldModifierMonitor` / the first backstop) trusts `CGEventSource.flagsState`, which sticks reporting ⌘-held after a missed key-up.

## Fixes (layered: root + safety nets)

- **Don't storm-teardown the tap on `userInput` disables** — they aren't the watchdog timeout and carry no freeze risk beyond the AX-trust check that already runs first, so just re-enable (as alt-tab does). The storm-guard stays for `kCGEventTapDisabledByTimeout`, the real freeze case it was written for. *(the root fix)*
- **flagsState-independent force-close** — a release-to-commit panel the user has stopped steering force-closes after a short no-interaction ceiling, so a stuck modifier can't keep ⌘W welded; bounds the damage to ≤4 s for any residual strand.
- **Visible-release backstop** — re-reads the live modifier and commits a missed ⌘-release (the flagsState fast path), recovering the common stranded `.visible` panel that the prior `.primed`-only watchdog never covered.
- **No override churn on idle secure-input flaps** — while the panel is closed the override plan is invariant to secure input, so a flap only updates the cached flag instead of re-registering every global Carbon hotkey.

## Tests

Pure-logic coverage for the backstop arming matrix added to `SwitcherPhaseTests`; full suite green (**264 tests, 31 suites**). The runtime recovery needs a live WindowServer, so it is verified manually per the project's UI-verification policy.

## Why this stays open

The triggering secure-input flap is environmental (some app on the affected machine pulses Secure Event Input) and can't be reproduced here, so #16 is kept **open for observation** — the production recovery logs (`force-closing stranded panel`, `outlived its ⌘-release — recovering`) are the signal to watch for any recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
