### PR TITLE
fix: ⌘Tab into a browser lands on the active tab, not tab 1 (#39)

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -265,6 +265,10 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `browserTabsCacheTTL`, bounding osascript spawns across rapid re-opens.
     private var browserTabsCacheStamp: [AXRef: TimeInterval] = [:]
     private static let browserTabsCacheTTL: TimeInterval = 3.0
+    /// Active-tab index per cached browser window, parallel to `browserTabsCache`.
+    /// Lets a window-MRU fast tap into a browser land on the tab the user left on
+    /// instead of snapping to tab 1 when post-expansion title matching misses (#39).
+    private var browserTabsActiveIndex: [AXRef: Int] = [:]
     /// Monotonic time of the last *forced* (event-driven) browser-tab scan. A
     /// forced scan (a browser-window title change while the panel is open, which
     /// fires when a tab is opened/closed/switched) bypasses the per-window TTL so
@@ -2462,13 +2466,24 @@ final class SwitcherController: SwitcherViewDelegate {
             // Window-level mode anchors on the selected *window*; matching by pid
             // would snap a non-first window back to its app's first row. Preserve
             // it by row identity instead. App-grouped modes keep the pid anchor.
-            let windowKey = Preferences.shared.sortOrder == .mruWindows ? selectionKey() : nil
+            let inWindowMode = Preferences.shared.sortOrder == .mruWindows
+            let windowKey = inWindowMode ? selectionKey() : nil
             let selectedPid = rows.indices.contains(index) ? rows[index].pid : targetPid
+            // The stepped-to window's element, so a browser window whose AX title
+            // didn't survive expansion (Chrome's " — <browser>" suffix, trimmed
+            // whitespace, a duplicate title) lands on its active tab instead of the
+            // pid match's first row, i.e. tab 1 (#39). Window mode only — app-grouped
+            // modes intentionally keep the pid anchor.
+            let selectedWindow = (inWindowMode && rows.indices.contains(index)) ? rows[index].window : nil
             baseRows = expandedAtReveal
             baseLabels = RowLabels.labels(for: baseRows)
             rows = baseRows
             labels = baseLabels
             if let windowKey, let match = rows.firstIndex(where: { keyMatches($0, windowKey) }) {
+                index = match
+            } else if let win = selectedWindow,
+                      let active = browserTabsActiveIndex[AXRef(element: win)],
+                      let match = Self.activeBrowserTabIndex(in: rows, window: AXRef(element: win), activeTabIndex: active) {
                 index = match
             } else if let pid = selectedPid, let match = rows.firstIndex(where: { $0.pid == pid }) {
                 index = match
@@ -2513,6 +2528,17 @@ final class SwitcherController: SwitcherViewDelegate {
                 }
             }
         }
+
+        // Fast-tap rescue: ⌘ may have been released during reveal()'s own run —
+        // after the pre-present holdReleaseAlreadyMissed() guard but before `.visible`
+        // armed the tap's `.releaseCmd` delivery, so the tap dropped the release and
+        // nothing dismisses the panel until the 0.2s visibleReleaseBackstop tick.
+        // Honour it now so a quick tap commits instantly instead of leaving the
+        // switcher on screen (#39). Held-chord only — gestures/scoped opens set
+        // primedByHeldChord=false and never release-commit; a still-held ⌘ is a no-op
+        // so a user mid-browse is never committed out from under. commit() bumps
+        // revealGeneration, so the refresh scheduled just above drops on its guard.
+        if primedByHeldChord, holdReleaseAlreadyMissed() { handleModifierRelease() }
     }
 
     /// Audio-playing pids (CoreAudio) and Dock unread badges (the Dock's AX
@@ -2890,6 +2916,7 @@ final class SwitcherController: SwitcherViewDelegate {
         if browserTabsCache.contains(where: { !liveKeys.contains($0.key) }) {
             browserTabsCache = browserTabsCache.filter { liveKeys.contains($0.key) }
             browserTabsCacheStamp = browserTabsCacheStamp.filter { liveKeys.contains($0.key) }
+            browserTabsActiveIndex = browserTabsActiveIndex.filter { liveKeys.contains($0.key) }
         }
         guard !byApp.isEmpty else { return }
         if force { lastForcedBrowserScanAt = now }
@@ -2897,6 +2924,9 @@ final class SwitcherController: SwitcherViewDelegate {
         let apps = Array(byApp.values)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             var fetched: [AXRef: [String]] = [:]
+            // Active-tab index per resolved window, so the panel can land a
+            // window-MRU step on the tab the user left on rather than tab 1 (#39).
+            var fetchedActive: [AXRef: Int] = [:]
             for entry in apps {
                 // A browser window's AX kAXTitleAttribute reflects its ACTIVE TAB,
                 // not the AppleScript window title (e.g. Arc reports "Arc" as the
@@ -2906,23 +2936,26 @@ final class SwitcherController: SwitcherViewDelegate {
                 // window. Titles that aren't unique are left collapsed (cached []).
                 let perWindow = BrowserTabs.allWindowTabs(for: entry.app)
                 var activeCounts: [String: Int] = [:]
-                var byActive: [String: [String]] = [:]
+                var byActive: [String: (tabs: [String], active: Int)] = [:]
                 var titleCounts: [String: Int] = [:]
-                var byTitle: [String: [String]] = [:]
+                var byTitle: [String: (tabs: [String], active: Int)] = [:]
                 for w in perWindow {
+                    let activeIdx = w.tabs.firstIndex(of: w.activeTab) ?? 0
                     let a = w.activeTab.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !a.isEmpty { activeCounts[a, default: 0] += 1; byActive[a] = w.tabs }
+                    if !a.isEmpty { activeCounts[a, default: 0] += 1; byActive[a] = (w.tabs, activeIdx) }
                     let t = w.title.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !t.isEmpty { titleCounts[t, default: 0] += 1; byTitle[t] = w.tabs }
+                    if !t.isEmpty { titleCounts[t, default: 0] += 1; byTitle[t] = (w.tabs, activeIdx) }
                 }
                 for t in entry.wins {
                     let k = t.title.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if activeCounts[k] == 1 {
-                        fetched[t.key] = byActive[k] ?? []
-                    } else if titleCounts[k] == 1 {
-                        fetched[t.key] = byTitle[k] ?? []
+                    if activeCounts[k] == 1, let hit = byActive[k] {
+                        fetched[t.key] = hit.tabs; fetchedActive[t.key] = hit.active
+                    } else if titleCounts[k] == 1, let hit = byTitle[k] {
+                        fetched[t.key] = hit.tabs; fetchedActive[t.key] = hit.active
                     } else if perWindow.count == 1 && entry.wins.count == 1 {
-                        fetched[t.key] = perWindow[0].tabs
+                        let only = perWindow[0]
+                        fetched[t.key] = only.tabs
+                        fetchedActive[t.key] = only.tabs.firstIndex(of: only.activeTab) ?? 0
                     } else {
                         // Negative-cache (empty) a missing/ambiguous window so we
                         // don't re-spawn osascript for it every tick this session.
@@ -2937,6 +2970,7 @@ final class SwitcherController: SwitcherViewDelegate {
                     self.browserTabsFetchInFlight.remove(k)
                     self.browserTabsCache[k] = v
                     self.browserTabsCacheStamp[k] = stamp
+                    self.browserTabsActiveIndex[k] = fetchedActive[k]
                 }
                 onDone?()
             }
@@ -4071,6 +4105,18 @@ final class SwitcherController: SwitcherViewDelegate {
 
     private func keyMatches(_ row: SwitcherRow, _ key: (pid_t, String, Bool)) -> Bool {
         row.pid == key.0 && row.windowTitle == key.1 && (row.window != nil) == key.2
+    }
+
+    /// The expanded-row index for `window`'s active tab — the row a window-MRU
+    /// step should select when the collapsed browser row's title didn't survive
+    /// expansion (so `keyMatches` missed), landing on the tab the user left on
+    /// instead of snapping to tab 1 (#39). nil when no tab row carries that window
+    /// at `activeTabIndex`, so the caller falls back to the pid match. Pure.
+    nonisolated static func activeBrowserTabIndex(in rows: [SwitcherRow], window: AXRef, activeTabIndex: Int) -> Int? {
+        rows.firstIndex {
+            guard let w = $0.window else { return false }
+            return AXRef(element: w) == window && $0.browserTab?.index == activeTabIndex
+        }
     }
 
     /// Recently closed windows/apps to surface for reopening. `forSearchQuery`

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import ApplicationServices
 import CoreGraphics
 import Testing
 @testable import BetterCmdTab
@@ -149,5 +151,55 @@ struct SwitcherVisibleReleaseBackstopTests {
         #expect(arm(stickyOpen: true, tabDrillActive: true, secureInputActive: true))
         // Sticky-without-drill still never arms, secure input or not.
         #expect(!arm(stickyOpen: true, secureInputActive: true))
+    }
+}
+
+/// Pure-logic coverage for the browser-tab active-tab landing (#39). After a
+/// window-MRU step expands a browser window into per-tab rows, the selection must
+/// land on the window's ACTIVE tab — not snap to tab 1 — when the collapsed row's
+/// title didn't survive expansion (Chrome's " — Google Chrome" suffix, trimmed
+/// whitespace, a duplicate title) so the exact-title `keyMatches` missed and the
+/// pid fallback would otherwise pick the window's first row.
+@Suite("Switcher browser active-tab landing")
+struct SwitcherActiveBrowserTabTests {
+    private var hostApp: NSRunningApplication { .current }
+    private func axElement() -> AXUIElement { AXUIElementCreateApplication(getpid()) }
+
+    /// One browser window expanded into three tab rows, preceded by an unrelated
+    /// windowless row — mirrors the post-expansion `rows` the reveal re-map sees.
+    private func expandedRows(window: AXUIElement) -> [SwitcherRow] {
+        let parent = SwitcherRow(app: hostApp, window: window, windowTitle: "Browser",
+                                 isMinimized: false, cgWindowID: 99)
+        let tabs = parent.browserTabRows(tabTitles: ["Inbox", "Docs", "News"])
+        let other = SwitcherRow(app: hostApp, window: nil, windowTitle: "", isMinimized: false)
+        return [other] + tabs   // [windowless, tab0, tab1, tab2]
+    }
+
+    @Test func landsOnActiveTab_notTabOne() {
+        let win = axElement()
+        let rows = expandedRows(window: win)
+        // Active tab is the third (index 2) → row position 3, NOT the first tab (1).
+        #expect(SwitcherController.activeBrowserTabIndex(
+            in: rows, window: AXRef(element: win), activeTabIndex: 2) == 3)
+        // First tab active → its row, position 1.
+        #expect(SwitcherController.activeBrowserTabIndex(
+            in: rows, window: AXRef(element: win), activeTabIndex: 0) == 1)
+    }
+
+    @Test func nilWhenNoTabRowAtThatIndex() {
+        let win = axElement()
+        let rows = expandedRows(window: win)
+        // An active index past the tab count has no matching row → nil, so the caller
+        // falls back to the pid match instead of mis-selecting.
+        #expect(SwitcherController.activeBrowserTabIndex(
+            in: rows, window: AXRef(element: win), activeTabIndex: 9) == nil)
+    }
+
+    @Test func nilWhenWindowHasNoTabRows() {
+        let win = axElement()
+        // No expanded browser rows at all → nil.
+        let rows = [SwitcherRow(app: hostApp, window: nil, windowTitle: "", isMinimized: false)]
+        #expect(SwitcherController.activeBrowserTabIndex(
+            in: rows, window: AXRef(element: win), activeTabIndex: 0) == nil)
     }
 }


### PR DESCRIPTION
Fixes part of #39 — the deterministic half of the "⌘Tab sometimes activates windows I do not expect" report. Scoped to **Bug 1** (wrong window + sticky panel); the browser-tab MRU / single-Safari-entry concerns (Bug 2) follow in a separate PR.

Both defects show up on a quick ⌘Tab when **Show browser tabs as separate entries** is on with the **Most recent (windows)** sort order.

## Wrong window — lands on tab 1 instead of the tab you left on

After a window-MRU step expands a browser window into one row per tab, `reveal()` re-maps the selection onto the expanded list by matching the stepped-to window by **exact title**. A browser window's AX title routinely differs from its tab title — Chrome's `" — Google Chrome"` suffix, trimmed whitespace, or a duplicate title — so the match misses and the pid fallback picks the window's **first** row (tab 1) rather than the active tab.

Worse, the result was non-deterministic: whether the ~100 ms reveal fired before ⌘ was released decided between
- the **primed** fast-tap path (collapsed rows → raises the window → active tab restored — correct), and
- the **visible** path (expanded rows → tab 1 — wrong),

so the same gesture landed differently run to run ("sometimes Window C").

**Fix:** cache an active-tab index per browser window in `scanBrowserTabs` (`browserTabsActiveIndex`, populated from the `activeTab` `allWindowTabs` already returns), and in the post-expansion re-map fall back to that tab (new pure `activeBrowserTabIndex`) **before** the pid match. A quick switch into a browser now restores the active tab, matching the primed path.

## Panel left on screen

A very fast tap can land the ⌘-release `flagsChanged` on the tap thread *before* the `.primed` transition set the switching flag — so the tap drops `.releaseCmd` (it gates on `isSwitchingNow()`) and nothing dismisses the panel until the 0.2 s `visibleReleaseBackstop` ticks.

**Fix:** re-check `holdReleaseAlreadyMissed()` at `reveal()`'s tail and commit immediately. Held-chord only (gestures/scoped opens set `primedByHeldChord = false` and never release-commit); a still-held ⌘ is a no-op so a mid-browse user is never committed out from under. `commit()` bumps `revealGeneration`, so the refresh scheduled just above drops on its generation guard.

## Cost

Hot-path safe. The active-index lookup only runs on the rare exact-title miss and is the same cost class as the existing `keyMatches` scan; the tail re-check is one `CGEventSource.flagsState` read on the held-chord reveal path only (not gestures/scoped). No new allocations or polling on the open path.

## Tests

New `SwitcherActiveBrowserTabTests` suite covers the active-tab landing (lands on the active tab, not tab 1; `nil` when no tab row matches so the caller falls back to the pid match). Full suite: **267 passing**.

UI behavior (the actual quick-tap timing) is verified manually per the project's test policy — the switcher needs a live WindowServer + Accessibility, so it isn't part of the headless unit run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
