### PR TITLE
feat: browser-tab MRU + permission hint for expand-as-windows (#39)

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -435,6 +435,7 @@ final class Preferences: ObservableObject {
         static let clickOutsideToDismiss = "Switcher.clickOutsideToDismiss"
         static let cycleTileWidths = "Switcher.cycleTileWidths"
         static let experimentalInstantSpaceSwitch = "Switcher.experimentalInstantSpaceSwitch"
+        static let experimentalBrowserTabMRU = "Switcher.experimentalBrowserTabMRU"
         /// `\` tab drill-in (peek the highlighted window's tabs in a strip).
         /// Graduated out of the Experimental tab in 26.x and flipped to default
         /// ON (intentional — the `\` peek is now the standard way to reach tabs).
@@ -869,6 +870,18 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// When true (and "Show browser tabs as separate entries" is on), browser tabs
+    /// are tracked as first-class MRU entries so ⌘Tab returns to the previously
+    /// used tab, not just the previously used window. Requires always-on AX title
+    /// observation of running browsers, so it's off by default — opt-in cost on a
+    /// hot-path app. See `BrowserTabMRUTracker` / `BrowserTabFocusObserver`.
+    @Published var experimentalBrowserTabMRU: Bool {
+        didSet {
+            guard oldValue != experimentalBrowserTabMRU else { return }
+            UserDefaults.standard.set(experimentalBrowserTabMRU, forKey: Keys.experimentalBrowserTabMRU)
+        }
+    }
+
     /// Tab drill-in: pressing `\` on a row whose window has a tab group reveals
     /// a horizontal tab strip beneath the switcher so a specific tab can be
     /// picked. Native AX `AXTabs` for Finder/Terminal/…; AppleScript for
@@ -1224,6 +1237,7 @@ final class Preferences: ObservableObject {
         self.tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
         self.expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         self.expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
+        self.experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
         // Badges graduated out of the Experimental tab and now default on. Honor
         // the new key if present, otherwise carry over a choice made under the
         // old experimental key, otherwise default to on.
@@ -1319,6 +1333,7 @@ final class Preferences: ObservableObject {
         tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
         expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
+        experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
         showUnreadBadges = defaults.object(forKey: Keys.showUnreadBadges) as? Bool ?? true
 
         showWindowTitleLabel = defaults.object(forKey: Keys.showWindowTitleLabel) as? Bool ?? true

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -16,6 +16,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
     private let mruWindowsSortSwitch = NSSwitch()
+    private let browserTabMRUSwitch = NSSwitch()
 
     override func setupContent() {
         // Experimental section — off by default, clearly flagged as unstable.
@@ -65,6 +66,11 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         addRow(to: experimental, title: String(localized: "Most recent (windows) sort order"),
                subtitle: String(localized: "Orders the list by when you last focused each window, across all apps."),
                accessory: mruWindowsSortSwitch, searchItemID: SearchID.mruWindowsSort)
+
+        configureSwitch(browserTabMRUSwitch, action: #selector(toggleBrowserTabMRU(_:)))
+        addRow(to: experimental, title: String(localized: "Track browser tabs in recency"),
+               subtitle: String(localized: "With “Show browser tabs as separate entries” and the windows sort order on, ⌘Tab returns to the tab you last used, not just the last window. Needs always-on monitoring of your browsers, so it costs a little energy."),
+               accessory: browserTabMRUSwitch, searchItemID: SearchID.browserTabMRU)
         // "Show switcher on" (multi-monitor placement) and the `\` tab peek + tab
         // expansion graduated to the Switcher tab once stable — see its "Display"
         // and "Tabs" sections.
@@ -115,6 +121,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
         mruWindowsSortSwitch.state = prefs.sortOrder == .mruWindows ? .on : .off
+        browserTabMRUSwitch.state = prefs.experimentalBrowserTabMRU ? .on : .off
         setSwipeSubOptionsEnabled(prefs.experimentalSwipeTrigger)
     }
 
@@ -151,6 +158,10 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleInstantSpace(_ sender: NSSwitch) {
         Preferences.shared.experimentalInstantSpaceSwitch = (sender.state == .on)
+    }
+
+    @objc private func toggleBrowserTabMRU(_ sender: NSSwitch) {
+        Preferences.shared.experimentalBrowserTabMRU = (sender.state == .on)
     }
 
     @objc private func toggleMRUWindowsSort(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -121,6 +121,7 @@ enum SearchID {
     static let sensitivity = "experimental.sensitivity"
     static let instantSpace = "experimental.instantSpace"
     static let mruWindowsSort = "experimental.mruWindowsSort"
+    static let browserTabMRU = "experimental.browserTabMRU"
 }
 
 @MainActor
@@ -360,6 +361,8 @@ enum SettingsCatalog {
              String(localized: "Switch Spaces without animation"), ["spaces", "space", "animation", "instant", "full screen"]),
         item(SearchID.mruWindowsSort, .experimental, SettingsAnchor.experimental, String(localized: "Experimental"), String(localized: "Experimental"),
              String(localized: "Most recent (windows) sort order"), ["sort", "window", "recent", "order", "mru", "windows"]),
+        item(SearchID.browserTabMRU, .experimental, SettingsAnchor.experimental, String(localized: "Experimental"), String(localized: "Experimental"),
+             String(localized: "Track browser tabs in recency"), ["browser", "tab", "tabs", "recent", "mru", "safari", "chrome"]),
     ]
 
     private static func item(

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -59,6 +59,10 @@ final class SwitcherController: SwitcherViewDelegate {
     private let spaceSwipeSuppressor = SpaceSwipeSuppressor()
     private let mru = MRUTracker()
     private let windowMRU = WindowMRUTracker()
+    /// Unified tab+window recency for the experimental browser-tab-MRU mode (#39),
+    /// fed by `tabFocusObserver`, `handleFocusChange`, and tab/window commits.
+    private let tabMRU = BrowserTabMRUTracker()
+    private lazy var tabFocusObserver = BrowserTabFocusObserver(tracker: tabMRU)
     private let cache = AppCatalogCache()
     /// Live-refreshes Dock badges (unread counts) while the panel is open. Armed
     /// only between reveal and close, so it costs nothing when the switcher is shut.
@@ -528,6 +532,18 @@ final class SwitcherController: SwitcherViewDelegate {
         cache.onVisibleTitleChanged = { [weak self] in
             self?.scheduleVisibleTitleRefresh()
         }
+        // Experimental browser-tab MRU (#39): the always-on browser title observer
+        // only runs when both the feature and tab-expansion are on. Driven live from
+        // the pref pair; off by default, so a disabled feature costs nothing.
+        updateBrowserTabMRUObserver()
+        Preferences.shared.$experimentalBrowserTabMRU
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.updateBrowserTabMRUObserver() }
+            .store(in: &cancellables)
+        Preferences.shared.$expandBrowserTabsAsWindows
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.updateBrowserTabMRUObserver() }
+            .store(in: &cancellables)
         // A Dock badge (unread count) changed while the panel is open — re-read
         // the badges and repaint so counts stay live without reopening.
         dockBadgeObserver.onBadgesChanged = { [weak self] in
@@ -2457,8 +2473,18 @@ final class SwitcherController: SwitcherViewDelegate {
         // Expand inline browser-tab rows from the persisted per-session cache so a
         // re-open shows tabs immediately instead of windows-then-flicker. The
         // background re-scan re-derives its collapsed source from `baseRows`.
-        let expandedAtReveal = expandBrowserTabs(baseRows)
-        if expandedAtReveal.count != baseRows.count {
+        let expandedAtReveal = applyBrowserTabMRU(expandBrowserTabs(baseRows))
+        if browserTabMRUActive {
+            // Tab-MRU reorders the expanded rows by unified tab+window recency, so
+            // row 0 is the current tab; step from there by `primedStepDelta` exactly
+            // like the window sort. Rebuild unconditionally — the order can change
+            // even when no browser expanded (windows re-rank by their .window keys).
+            baseRows = expandedAtReveal
+            baseLabels = RowLabels.labels(for: baseRows)
+            rows = baseRows
+            labels = baseLabels
+            index = rows.isEmpty ? 0 : ((primedStepDelta % rows.count) + rows.count) % rows.count
+        } else if expandedAtReveal.count != baseRows.count {
             // Window-level mode anchors on the selected *window*; matching by pid
             // would snap a non-first window back to its app's first row. Preserve
             // it by row identity instead. App-grouped modes keep the pid anchor.
@@ -2642,6 +2668,48 @@ final class SwitcherController: SwitcherViewDelegate {
         return CatalogFilter.pinnedToFront(bucketed, Preferences.shared.pinnedBundleIDs)
     }
 
+    /// Whether the experimental browser-tab MRU is fully active: the feature on,
+    /// tabs expanded (not collapsed to apps), and the window-recency sort selected
+    /// (the only sort `applyBrowserTabMRU` reorders within). Read live off the main
+    /// actor like the other hot-path pref reads.
+    private var browserTabMRUActive: Bool {
+        browserTabMRUEnabled
+            && !Preferences.shared.applicationsOnly
+            && Preferences.shared.sortOrder == .mruWindows
+    }
+
+    /// The feature + tab-expansion are on, so the tab MRU should be *fed* (observer,
+    /// focus changes, commits) and the timeline kept warm. Distinct from
+    /// `browserTabMRUActive`, which additionally requires the window-recency sort be
+    /// selected before that order is *consumed* — feeding under a narrower gate
+    /// would leave gaps in the timeline whenever the sort momentarily differs.
+    private var browserTabMRUEnabled: Bool {
+        Preferences.shared.experimentalBrowserTabMRU && Preferences.shared.expandBrowserTabsAsWindows
+    }
+
+    /// Start/stop the always-on browser title observer to match the pref pair.
+    private func updateBrowserTabMRUObserver() {
+        tabFocusObserver.setEnabled(browserTabMRUEnabled)
+    }
+
+    /// Re-order already-expanded rows by unified tab+window recency so ⌘Tab steps
+    /// per tab, not per window (#39). A no-op unless `browserTabMRUActive`. Runs
+    /// AFTER `expandBrowserTabs` (unlike `applyWindowMRUSort`, which runs before),
+    /// then re-buckets status and re-pins exactly like the window sort so hidden/
+    /// minimized rows still sink and pinned apps stay at the front.
+    private func applyBrowserTabMRU(_ rows: [SwitcherRow]) -> [SwitcherRow] {
+        guard browserTabMRUActive else { return rows }
+        let ranked = tabMRU.sortRows(rows)
+        let bucketed = ranked.enumerated()
+            .sorted { lhs, rhs in
+                let lp = AppCatalogCache.statusPriority(lhs.element)
+                let rp = AppCatalogCache.statusPriority(rhs.element)
+                return lp != rp ? lp < rp : lhs.offset < rhs.offset
+            }
+            .map(\.element)
+        return CatalogFilter.pinnedToFront(bucketed, Preferences.shared.pinnedBundleIDs)
+    }
+
     private func applyFullSnapshot(_ fresh: [SwitcherRow], anchorPid: pid_t?) {
         guard phase == .visible else { return }
         if fresh.isEmpty {
@@ -2685,7 +2753,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // scan any browser window that newly appeared. Collapse to one row per app
         // AFTER the window-MRU sort — matching `reveal()` — so the representative
         // window each app keeps is identical across the reveal→refresh transition.
-        baseRows = expandBrowserTabs(applyApplicationsOnly(applyWindowMRUSort(next)))
+        baseRows = applyBrowserTabMRU(expandBrowserTabs(applyApplicationsOnly(applyWindowMRUSort(next))))
         baseLabels = RowLabels.labels(for: baseRows)
         refreshDisplay(anchorPid: anchorPid)
         scheduleBrowserTabExpansion()
@@ -2701,12 +2769,27 @@ final class SwitcherController: SwitcherViewDelegate {
     private func handleFocusChange(pid: pid_t) {
         guard !focusSyncInFlight.contains(pid) else { return }
         focusSyncInFlight.insert(pid)
+        // Feed the unified tab MRU too when the feature is on: an app/window switch
+        // (including to/from a browser) is part of the same recency timeline as
+        // in-browser tab switches (#39). Browsers key by (wid, active-tab title), so
+        // resolve the title in the same off-main pass; others key by wid alone.
+        let feedTabMRU = browserTabMRUEnabled
+        let isBrowser = feedTabMRU
+            && BrowserTabs.Family.from(bundleID: NSRunningApplication(processIdentifier: pid)?.bundleIdentifier) != nil
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            let wid = WindowMRUTracker.focusedWindowID(pid: pid)
+            let info = isBrowser ? BrowserTabFocusObserver.focusedWindowInfo(pid: pid) : nil
+            let wid = info?.wid ?? WindowMRUTracker.focusedWindowID(pid: pid)
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.focusSyncInFlight.remove(pid)
                 if wid != 0 { self.windowMRU.bump(pid: pid, wid: wid) }
+                if feedTabMRU, wid != 0 {
+                    if isBrowser, let title = info?.title, !title.isEmpty {
+                        self.tabMRU.bump(.tab(wid, title))
+                    } else if !isBrowser {
+                        self.tabMRU.bump(.window(wid))
+                    }
+                }
             }
         }
     }
@@ -2897,6 +2980,10 @@ final class SwitcherController: SwitcherViewDelegate {
         let apps = Array(byApp.values)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             var fetched: [AXRef: [String]] = [:]
+            // Browsers whose scan hit a script error (Automation denied / timeout)
+            // rather than genuinely having no tabs — surface the permission hint and
+            // skip negative-caching so a grant + re-open retries at once (#39).
+            var failedApps: [NSRunningApplication] = []
             for entry in apps {
                 // A browser window's AX kAXTitleAttribute reflects its ACTIVE TAB,
                 // not the AppleScript window title (e.g. Arc reports "Arc" as the
@@ -2904,7 +2991,9 @@ final class SwitcherController: SwitcherViewDelegate {
                 // titles against each window's active-tab title first, then the
                 // window title, then fall back to a direct 1:1 map for a single
                 // window. Titles that aren't unique are left collapsed (cached []).
-                let perWindow = BrowserTabs.allWindowTabs(for: entry.app)
+                let result = BrowserTabs.allWindowTabs(for: entry.app)
+                if result.failed { failedApps.append(entry.app); continue }
+                let perWindow = result.windows
                 var activeCounts: [String: Int] = [:]
                 var byActive: [String: [String]] = [:]
                 var titleCounts: [String: Int] = [:]
@@ -2933,11 +3022,14 @@ final class SwitcherController: SwitcherViewDelegate {
             DispatchQueue.main.async {
                 guard let self else { return }
                 let stamp = ProcessInfo.processInfo.systemUptime
+                // Clear in-flight for every dispatched window; cache only the ones we
+                // resolved, so a failed app's windows re-scan on the next open.
+                for entry in apps { for t in entry.wins { self.browserTabsFetchInFlight.remove(t.key) } }
                 for (k, v) in fetched {
-                    self.browserTabsFetchInFlight.remove(k)
                     self.browserTabsCache[k] = v
                     self.browserTabsCacheStamp[k] = stamp
                 }
+                if let failed = failedApps.first { self.showTabDrillHint(forApp: failed) }
                 onDone?()
             }
         }
@@ -2977,7 +3069,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `force` re-renders regardless (used after closing a tab).
     private func reExpandBrowserTabs(force: Bool = false) {
         guard phase == .visible else { return }
-        let expanded = expandBrowserTabs(collapsedBrowserSource())
+        let expanded = applyBrowserTabMRU(expandBrowserTabs(collapsedBrowserSource()))
         guard force || Self.rowsDifferVisibly(expanded, baseRows) else { return }
         baseRows = expanded
         baseLabels = RowLabels.labels(for: baseRows)
@@ -3054,11 +3146,55 @@ final class SwitcherController: SwitcherViewDelegate {
         return sorted[idx]
     }
 
+    /// The row a browser-tab-MRU fast tap-release should activate: the fully
+    /// expanded, tab-recency-sorted rows stepped by `primedStepDelta` from row 0
+    /// (the current tab/window), mirroring the selection `reveal()` lands on. May
+    /// be a browser-tab row, so the caller routes it through `activation(for:)`.
+    private func primedBrowserTabMRUTargetRow() -> SwitcherRow? {
+        let sorted = Log.reveal.withIntervalSignpost("primed.tabMRU") {
+            applyBrowserTabMRU(expandBrowserTabs(applyApplicationsOnly(applyWindowMRUSort(cache.rows(orderedBy: mru.order)))))
+        }
+        guard !sorted.isEmpty else { return nil }
+        let idx = ((primedStepDelta % sorted.count) + sorted.count) % sorted.count
+        return sorted[idx]
+    }
+
     private func bumpWindowMRUIfPossible(for row: SwitcherRow) {
         guard let win = row.window, let pid = row.pid else { return }
         let wid = PrivateAPI.cgWindowId(of: win)
         guard wid != 0 else { return }
         windowMRU.bump(pid: pid, wid: wid)
+    }
+
+    /// Bump the unified tab+window MRU for a committed row (#39). No-op unless the
+    /// experimental mode is active. A tab row keys by (parent wid, tab title); any
+    /// other windowed row by its CGWindowID.
+    private func bumpTabMRUIfPossible(for row: SwitcherRow) {
+        guard browserTabMRUEnabled, let key = BrowserTabMRUTracker.key(for: row) else { return }
+        tabMRU.bump(key)
+    }
+
+    /// Build the activation closure for a committed `row`, bumping every MRU
+    /// tracker so the next ⌘Tab returns here. A browser-tab row selects its tab via
+    /// Apple Events (it's not a real window) and bumps only the app + tab MRU — all
+    /// of a window's tab rows share one CGWindowID, so the window MRU would be the
+    /// wrong granularity. Any other row raises its window. Shared by the visible and
+    /// primed commit paths so a fast tap and a held-open panel agree.
+    private func activation(for row: SwitcherRow, instantSpace: Bool) -> (() -> Void)? {
+        if let pid = row.pid { mru.bump(pid) }
+        if let bt = row.browserTab, let app = row.app, let window = row.window {
+            bumpTabMRUIfPossible(for: row)
+            let tabIndex = bt.index
+            let parentTitle = bt.parentTitle
+            return {
+                DispatchQueue.global(qos: .userInitiated).async {
+                    _ = BrowserTabs.activateTab(at: tabIndex, in: app, window: window, title: parentTitle)
+                }
+            }
+        }
+        bumpWindowMRUIfPossible(for: row)
+        bumpTabMRUIfPossible(for: row)
+        return { Activator.activate(row, instantSpace: instantSpace) }
     }
 
     private func commit() {
@@ -3079,24 +3215,9 @@ final class SwitcherController: SwitcherViewDelegate {
         switch currentPhase {
         case .visible:
             if rows.indices.contains(index) {
-                let row = rows[index]
-                if let bt = row.browserTab, let app = row.app, let window = row.window {
-                    // Inline browser-tab row: select the tab via Apple Events
-                    // (it isn't a real window). Bump the app MRU but not window
-                    // MRU — all of a window's tab rows share one cgWindowID.
-                    if let pid = row.pid { mru.bump(pid) }
-                    let tabIndex = bt.index
-                    let parentTitle = bt.parentTitle
-                    pendingActivation = {
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            _ = BrowserTabs.activateTab(at: tabIndex, in: app, window: window, title: parentTitle)
-                        }
-                    }
-                } else {
-                    if let pid = row.pid { mru.bump(pid) }
-                    bumpWindowMRUIfPossible(for: row)
-                    pendingActivation = { Activator.activate(row, instantSpace: instantSpace) }
-                }
+                // `activation(for:)` handles the browser-tab vs. window split and
+                // bumps the app / window / tab MRU trackers.
+                pendingActivation = activation(for: rows[index], instantSpace: instantSpace)
             }
         case .primed:
             if windowsOnlyMode, let pid = windowsOnlyPid {
@@ -3111,6 +3232,11 @@ final class SwitcherController: SwitcherViewDelegate {
                     mru.bump(pid)
                     pendingActivation = { Activator.activateApp(app) }
                 }
+            } else if browserTabMRUActive, let row = primedBrowserTabMRUTargetRow() {
+                // Tab-level fast tap-release: activate the tab/window the visible
+                // switcher would have selected, stepped by unified tab recency, so a
+                // quick ⌘⇥ returns to the previous *tab* exactly like the panel.
+                pendingActivation = activation(for: row, instantSpace: instantSpace)
             } else if Preferences.shared.sortOrder == .mruWindows,
                       let row = primedWindowMRUTargetRow() {
                 // Window-level fast tap-release: activate the window the visible

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -2784,8 +2784,9 @@ final class SwitcherController: SwitcherViewDelegate {
                 self.focusSyncInFlight.remove(pid)
                 if wid != 0 { self.windowMRU.bump(pid: pid, wid: wid) }
                 if feedTabMRU, wid != 0 {
-                    if isBrowser, let title = info?.title, !title.isEmpty {
-                        self.tabMRU.bump(.tab(wid, title))
+                    if isBrowser, let title = info?.title,
+                       !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        self.tabMRU.bump(BrowserTabMRUTracker.tabKey(wid: wid, title: title))
                     } else if !isBrowser {
                         self.tabMRU.bump(.window(wid))
                     }

--- a/BetterCmdTab/Windows/BrowserTabFocusObserver.swift
+++ b/BetterCmdTab/Windows/BrowserTabFocusObserver.swift
@@ -71,6 +71,20 @@ final class BrowserTabFocusObserver {
             }
         }
         for app in NSWorkspace.shared.runningApplications { addObserver(for: app) }
+        // Seed the current tab so the FIRST ⌘Tab after enabling/launch already has
+        // it as most-recent (row 0), before any focus change is observed — otherwise
+        // an as-yet-unseen current tab sinks to the back and the first step lands
+        // wrong until the tracker warms.
+        seedFrontmost()
+    }
+
+    /// Bump the frontmost browser's active tab to MRU front, once, on enable.
+    private func seedFrontmost() {
+        guard enabled,
+              let front = NSWorkspace.shared.frontmostApplication,
+              front.processIdentifier != getpid(),
+              BrowserTabs.Family.from(bundleID: front.bundleIdentifier) != nil else { return }
+        handleChange(pid: front.processIdentifier)
     }
 
     private func stop() {
@@ -143,8 +157,9 @@ final class BrowserTabFocusObserver {
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.inFlight.remove(pid)
-                guard self.enabled, let info, info.wid != 0, !info.title.isEmpty else { return }
-                self.tracker.bump(.tab(info.wid, info.title))
+                guard self.enabled, let info, info.wid != 0,
+                      !info.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                self.tracker.bump(BrowserTabMRUTracker.tabKey(wid: info.wid, title: info.title))
             }
         }
     }

--- a/BetterCmdTab/Windows/BrowserTabFocusObserver.swift
+++ b/BetterCmdTab/Windows/BrowserTabFocusObserver.swift
@@ -1,0 +1,169 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+
+/// Always-on AX observation of running browsers' active-tab changes, feeding
+/// `BrowserTabMRUTracker` so the experimental browser-tab-MRU mode can return ⌘Tab
+/// to the previously used *tab*, not just the previous window (#39).
+///
+/// A browser tab switch makes the window's AX title flip to the new active tab,
+/// but `AppCatalogCache` deliberately DROPS `kAXTitleChangedNotification` while the
+/// panel is hidden (title churn is the loudest notification) — so tab switches the
+/// user makes between ⌘Tab presses are invisible to it. This observer fills that
+/// gap, but ONLY for browser apps and ONLY while the pref is on, so the cost is
+/// strictly opt-in. It reads the focused window's AX title (a cheap attribute) on
+/// each change — never Apple Events — and bumps the tracker.
+///
+/// One `AXObserver` per running browser, created off-main (the AX add can block on
+/// a slow app) and its run-loop source installed on main. Lifecycle follows
+/// NSWorkspace launch/terminate.
+@MainActor
+final class BrowserTabFocusObserver {
+    private unowned let tracker: BrowserTabMRUTracker
+    private var observers: [pid_t: AXObserver] = [:]
+    /// pids whose observer is being built off-main, so a second launch/scan can't
+    /// double-create before the first install lands.
+    private var building: Set<pid_t> = []
+    /// pids with a focused-window read in flight, coalescing a burst of title
+    /// notifications for one app into a single off-main AX read.
+    private var inFlight: Set<pid_t> = []
+    private var launchObs: NSObjectProtocol?
+    private var termObs: NSObjectProtocol?
+    private var enabled = false
+
+    nonisolated private static let notifications: [String] = [
+        kAXTitleChangedNotification as String,
+        kAXFocusedWindowChangedNotification as String,
+        kAXMainWindowChangedNotification as String,
+    ]
+
+    init(tracker: BrowserTabMRUTracker) { self.tracker = tracker }
+
+    nonisolated deinit {
+        MainActor.assumeIsolated {
+            if enabled { stop() }
+        }
+    }
+
+    /// Turn observation on/off. Idempotent. Off tears down every observer and the
+    /// workspace hooks, so a disabled feature costs nothing.
+    func setEnabled(_ on: Bool) {
+        guard on != enabled else { return }
+        enabled = on
+        if on { start() } else { stop() }
+    }
+
+    private func start() {
+        let nc = NSWorkspace.shared.notificationCenter
+        launchObs = nc.addObserver(forName: NSWorkspace.didLaunchApplicationNotification,
+                                   object: nil, queue: .main) { [weak self] note in
+            guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            MainActor.assumeIsolated { self?.addObserver(for: app) }
+        }
+        termObs = nc.addObserver(forName: NSWorkspace.didTerminateApplicationNotification,
+                                 object: nil, queue: .main) { [weak self] note in
+            guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+            let pid = app.processIdentifier
+            MainActor.assumeIsolated {
+                self?.removeObserver(pid: pid)
+                // The window's tabs are gone with the app — but we don't know its
+                // wids here; the tracker's cap + dead-key harmlessness covers it.
+            }
+        }
+        for app in NSWorkspace.shared.runningApplications { addObserver(for: app) }
+    }
+
+    private func stop() {
+        let nc = NSWorkspace.shared.notificationCenter
+        if let o = launchObs { nc.removeObserver(o); launchObs = nil }
+        if let o = termObs { nc.removeObserver(o); termObs = nil }
+        for pid in Array(observers.keys) { removeObserver(pid: pid) }
+        observers.removeAll()
+        building.removeAll()
+        inFlight.removeAll()
+    }
+
+    private func addObserver(for app: NSRunningApplication) {
+        let pid = app.processIdentifier
+        guard enabled,
+              observers[pid] == nil, !building.contains(pid),
+              pid != getpid(),
+              BrowserTabs.Family.from(bundleID: app.bundleIdentifier) != nil else { return }
+        building.insert(pid)
+        // Encode the refcon as a bit-pattern integer so it crosses the queue
+        // boundary as a Sendable value (mirrors AppCatalogCache).
+        let refconBits = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
+        DispatchQueue.global(qos: .utility).async {
+            guard let refcon = UnsafeMutableRawPointer(bitPattern: refconBits) else { return }
+            let observer = Self.buildObserver(pid: pid, refcon: refcon)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.building.remove(pid)
+                guard self.enabled, self.observers[pid] == nil, let observer else { return }
+                CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+                self.observers[pid] = observer
+            }
+        }
+    }
+
+    private func removeObserver(pid: pid_t) {
+        building.remove(pid)
+        inFlight.remove(pid)
+        guard let observer = observers.removeValue(forKey: pid) else { return }
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+    }
+
+    /// Off-main AX work: create the observer and register the notifications. The
+    /// returned observer isn't bound to a run loop yet — the caller installs the
+    /// source on main. Mirrors `AppCatalogCache.buildAXObserver`.
+    nonisolated private static func buildObserver(pid: pid_t, refcon: UnsafeMutableRawPointer) -> AXObserver? {
+        var observer: AXObserver?
+        let cb: AXObserverCallback = { _, element, _, refcon in
+            guard let refcon else { return }
+            let me = Unmanaged<BrowserTabFocusObserver>.fromOpaque(refcon).takeUnretainedValue()
+            var pid: pid_t = 0
+            AXUIElementGetPid(element, &pid)
+            // The callback fires on the main run loop (the source is added there).
+            MainActor.assumeIsolated { me.handleChange(pid: pid) }
+        }
+        guard AXObserverCreate(pid, cb, &observer) == .success, let observer else { return nil }
+        let axApp = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(axApp, 0.2)
+        for name in notifications { _ = AXObserverAddNotification(observer, axApp, name as CFString, refcon) }
+        return observer
+    }
+
+    /// A browser fired a title/focus change — resolve its focused window's active
+    /// tab off-main and bump it to MRU front. Coalesced per pid.
+    private func handleChange(pid: pid_t) {
+        guard enabled, !inFlight.contains(pid) else { return }
+        inFlight.insert(pid)
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let info = Self.focusedWindowInfo(pid: pid)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.inFlight.remove(pid)
+                guard self.enabled, let info, info.wid != 0, !info.title.isEmpty else { return }
+                self.tracker.bump(.tab(info.wid, info.title))
+            }
+        }
+    }
+
+    /// The pid's focused window's CGWindowID and AX title (its active tab's title
+    /// for a browser). `nonisolated` so it runs off the main thread — the AX reads
+    /// can stall for the messaging timeout on an unresponsive app.
+    nonisolated static func focusedWindowInfo(pid: pid_t) -> (wid: CGWindowID, title: String)? {
+        let axApp = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(axApp, 0.05)
+        var focused: AnyObject?
+        guard AXUIElementCopyAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, &focused) == .success,
+              let focusedVal = focused,
+              CFGetTypeID(focusedVal) == AXUIElementGetTypeID() else { return nil }
+        let window = focusedVal as! AXUIElement
+        let wid = PrivateAPI.cgWindowId(of: window)
+        var titleVal: AnyObject?
+        let title = (AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleVal) == .success
+            ? titleVal as? String : nil) ?? ""
+        return (wid, title)
+    }
+}

--- a/BetterCmdTab/Windows/BrowserTabMRUTracker.swift
+++ b/BetterCmdTab/Windows/BrowserTabMRUTracker.swift
@@ -55,12 +55,22 @@ final class BrowserTabMRUTracker {
         order.removeAll { $0.wid == wid }
     }
 
-    /// The MRU key for a displayed row: a tab row keys by (parent wid, tab title);
-    /// any other windowed row keys by its CGWindowID. Windowless rows (placeholder
-    /// / launchable / recently-closed, `cgWindowID == 0`) have no recency → nil.
+    /// A tab key with a normalized title. Tab titles reach the tracker from two
+    /// sources — the AX window title (observer / focus) and the osascript tab list
+    /// (displayed rows) — which the cache already matches on a *trimmed* basis. Trim
+    /// here too so a stray whitespace difference between the two can't split one tab
+    /// into two recency entries (the current tab would then miss row 0).
+    static func tabKey(wid: CGWindowID, title: String) -> Key {
+        .tab(wid, title.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// The MRU key for a displayed row: a tab row keys by (parent wid, trimmed tab
+    /// title); any other windowed row keys by its CGWindowID. Windowless rows
+    /// (placeholder / launchable / recently-closed, `cgWindowID == 0`) have no
+    /// recency → nil.
     static func key(for row: SwitcherRow) -> Key? {
         guard row.cgWindowID != 0 else { return nil }
-        if row.browserTab != nil { return .tab(row.cgWindowID, row.windowTitle) }
+        if row.browserTab != nil { return tabKey(wid: row.cgWindowID, title: row.windowTitle) }
         return .window(row.cgWindowID)
     }
 

--- a/BetterCmdTab/Windows/BrowserTabMRUTracker.swift
+++ b/BetterCmdTab/Windows/BrowserTabMRUTracker.swift
@@ -1,0 +1,85 @@
+import ApplicationServices
+import CoreGraphics
+
+/// Unified most-recently-used ordering that treats each **browser tab** as a
+/// first-class entry alongside ordinary windows, backing the experimental
+/// "browser tab MRU" mode (#39). The flat `.mruWindows` sort keys every row by
+/// its CGWindowID, so all tabs of one browser window collapse to a single
+/// recency slot and ⌘Tab can only return to the previous *window*, never the
+/// previous *tab*. This tracker distinguishes the two:
+///
+/// - `.window(wid)` — an ordinary window (or a browser window whose tabs aren't
+///   expanded), keyed by its CGWindowID, exactly like `WindowMRUTracker`.
+/// - `.tab(wid, title)` — one browser tab. Tabs share their parent window's
+///   CGWindowID, so the active tab's title is the only cheap per-tab identity we
+///   have (read straight off the window's AX title — no Apple Events). Title
+///   churn on navigation just renames the entry the user is already on, which is
+///   harmless: it still points at "the tab they're looking at".
+///
+/// Fed by `BrowserTabFocusObserver` (in-browser tab switches) and the switcher's
+/// focus/commit paths. Pure ordering — no AX/Apple Events here, so it's unit
+/// testable. Dead ids/titles never match a live row, so stale entries are
+/// harmless; the cap is the only cleanup needed.
+@MainActor
+final class BrowserTabMRUTracker {
+    enum Key: Hashable {
+        case window(CGWindowID)
+        case tab(CGWindowID, String)
+
+        var wid: CGWindowID {
+            switch self {
+            case .window(let w), .tab(let w, _): return w
+            }
+        }
+    }
+
+    /// Flat unified recency, newest first.
+    private(set) var order: [Key] = []
+    /// Hard ceiling. `bump` only prepends, so without a cap a long session that
+    /// cycles many tabs would grow unbounded. Dead entries never match a row, so
+    /// the cap (plus `forgetWindow` on close) is the only cleanup.
+    private let cap = 300
+
+    /// Promote `key` to the front. A no-op-free move: existing occurrences are
+    /// removed first so recency is exact, not duplicated.
+    func bump(_ key: Key) {
+        guard key.wid != 0 else { return }
+        order.removeAll { $0 == key }
+        order.insert(key, at: 0)
+        if order.count > cap { order.removeLast(order.count - cap) }
+    }
+
+    /// Drop every entry (window slot and all tab slots) for a closed window id.
+    func forgetWindow(_ wid: CGWindowID) {
+        guard wid != 0 else { return }
+        order.removeAll { $0.wid == wid }
+    }
+
+    /// The MRU key for a displayed row: a tab row keys by (parent wid, tab title);
+    /// any other windowed row keys by its CGWindowID. Windowless rows (placeholder
+    /// / launchable / recently-closed, `cgWindowID == 0`) have no recency → nil.
+    static func key(for row: SwitcherRow) -> Key? {
+        guard row.cgWindowID != 0 else { return nil }
+        if row.browserTab != nil { return .tab(row.cgWindowID, row.windowTitle) }
+        return .window(row.cgWindowID)
+    }
+
+    /// Re-order already-expanded `rows` by unified tab+window recency, newest
+    /// first. Rows whose key is unknown (never focused) or windowless fall to the
+    /// back at `rank = Int.max`, stable on their incoming offset so they keep the
+    /// caller's prior order. Mirrors `WindowMRUTracker.sortRows` so the two sorts
+    /// behave identically apart from the richer key.
+    func sortRows(_ rows: [SwitcherRow]) -> [SwitcherRow] {
+        guard !order.isEmpty, rows.count > 1 else { return rows }
+        var rank: [Key: Int] = [:]
+        rank.reserveCapacity(order.count)
+        for (i, k) in order.enumerated() { rank[k] = i }
+        let indexed = rows.enumerated().map { offset, row -> (rank: Int, offset: Int, row: SwitcherRow) in
+            let r = Self.key(for: row).flatMap { rank[$0] } ?? Int.max
+            return (r, offset, row)
+        }
+        return indexed.sorted { lhs, rhs in
+            lhs.rank != rhs.rank ? lhs.rank < rhs.rank : lhs.offset < rhs.offset
+        }.map(\.row)
+    }
+}

--- a/BetterCmdTab/Windows/BrowserTabs.swift
+++ b/BetterCmdTab/Windows/BrowserTabs.swift
@@ -409,19 +409,39 @@ enum BrowserTabs {
     /// and lighter on CPU than calling `tabTitles` per window. No `AXRaise`, so
     /// it never reorders the user's windows.
     ///
-    /// Returns `(windowTitle, tabTitles)` per window, in window order. Empty on
-    /// no windows / failure / unsupported (the caller negative-caches). The
-    /// caller maps results back to its AX window elements by (trimmed) title;
-    /// windows whose title isn't unique are left for the caller to skip.
+    /// Per-window tab listing plus a `failed` flag distinguishing a script error
+    /// (Automation permission denied / timeout) from a browser that genuinely has
+    /// no windows or tabs. The expand-as-windows scan needs that split to surface
+    /// the "grant Automation access" hint (#39) — an empty result alone can't tell
+    /// "denied" from "nothing to show".
+    struct AllWindowTabs {
+        let windows: [(title: String, activeTab: String, tabs: [String])]
+        /// True only when the osascript spawn itself failed (nil result) — a
+        /// permission/timeout signal, not an empty browser.
+        let failed: Bool
+        static let empty = AllWindowTabs(windows: [], failed: false)
+        static let failure = AllWindowTabs(windows: [], failed: true)
+    }
+
+    /// List every window of `app` together with its tab titles in a **single**
+    /// Apple Events round-trip (one `osascript` spawn per browser, not one per
+    /// window). The process spawn dominates the cost, so batching is both faster
+    /// and lighter on CPU than calling `tabTitles` per window. No `AXRaise`, so
+    /// it never reorders the user's windows.
+    ///
+    /// Returns `(windowTitle, activeTab, tabTitles)` per window, in window order,
+    /// plus `failed` (osascript error vs. genuinely empty). The caller maps results
+    /// back to its AX window elements by (trimmed) title; windows whose title isn't
+    /// unique are left for the caller to skip.
     ///
     /// Records are framed with ASCII control chars that can't appear in titles:
     /// GS (29) between windows, RS (30) between a window's title, its active-tab
     /// title, and its tab list, US (31) between tabs. Run off-main.
-    static func allWindowTabs(for app: NSRunningApplication) -> [(title: String, activeTab: String, tabs: [String])] {
-        // Sending an Apple Event to a quit app relaunches it — bail if terminated.
+    static func allWindowTabs(for app: NSRunningApplication) -> AllWindowTabs {
+        // A quit / non-browser app is not a permission failure — nothing to grant.
         guard !app.isTerminated,
               let family = Family.from(bundleID: app.bundleIdentifier),
-              let bid = app.bundleIdentifier else { return [] }
+              let bid = app.bundleIdentifier else { return .empty }
         let appLit = appLiteral(bid)
         let attr: String = (family == .safari) ? "name" : "title"
         // A browser window's AX title reflects its active tab, so also capture the
@@ -454,9 +474,9 @@ enum BrowserTabs {
         """
         guard let raw = runScript(source) else {
             Log.activator.error("BrowserTabs: allWindowTabs \(bid) failed (permission/timeout?)")
-            return []
+            return .failure
         }
-        if raw == "NOWINDOWS" || raw.isEmpty { return [] }
+        if raw == "NOWINDOWS" || raw.isEmpty { return .empty }
         var out: [(title: String, activeTab: String, tabs: [String])] = []
         for block in raw.components(separatedBy: "\u{1D}") {
             let parts = block.components(separatedBy: "\u{1E}")
@@ -464,7 +484,7 @@ enum BrowserTabs {
             let tabs = parts[2].isEmpty ? [] : parts[2].components(separatedBy: "\u{1F}")
             out.append((title: parts[0], activeTab: parts[1], tabs: tabs))
         }
-        return out
+        return AllWindowTabs(windows: out, failed: false)
     }
 
     /// Switch the row window's browser tab to `tabIndex` (0-based here, 1-based

--- a/BetterCmdTabTests/BrowserTabMRUTrackerTests.swift
+++ b/BetterCmdTabTests/BrowserTabMRUTrackerTests.swift
@@ -1,0 +1,90 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Testing
+@testable import BetterCmdTab
+
+/// Pure-logic coverage for the experimental browser-tab MRU (#39): tabs are
+/// first-class recency entries interleaved with ordinary windows, so ⌘Tab can
+/// return to the previously used *tab*, not just the previous window. Exercises
+/// the key mapping and the unified sort without any AX/Apple Events.
+@MainActor
+@Suite("Browser tab MRU")
+struct BrowserTabMRUTrackerTests {
+    private var hostApp: NSRunningApplication { .current }
+    private func axElement() -> AXUIElement { AXUIElementCreateApplication(getpid()) }
+
+    private func windowRow(wid: CGWindowID, title: String = "W") -> SwitcherRow {
+        SwitcherRow(app: hostApp, window: axElement(), windowTitle: title, isMinimized: false, cgWindowID: wid)
+    }
+    /// Expand one browser window (wid) into per-tab rows, mirroring the live path.
+    private func tabRows(wid: CGWindowID, titles: [String]) -> [SwitcherRow] {
+        let parent = SwitcherRow(app: hostApp, window: axElement(),
+                                 windowTitle: titles.first ?? "", isMinimized: false, cgWindowID: wid)
+        return parent.browserTabRows(tabTitles: titles)
+    }
+
+    @Test func keyDistinguishesTabWindowAndWindowless() {
+        #expect(BrowserTabMRUTracker.key(for: windowRow(wid: 10)) == .window(10))
+        let tabs = tabRows(wid: 20, titles: ["A", "B"])
+        #expect(BrowserTabMRUTracker.key(for: tabs[0]) == .tab(20, "A"))
+        #expect(BrowserTabMRUTracker.key(for: tabs[1]) == .tab(20, "B"))
+        // Windowless row (cgWindowID 0) has no recency key.
+        let windowless = SwitcherRow(app: hostApp, window: nil, windowTitle: "", isMinimized: false)
+        #expect(BrowserTabMRUTracker.key(for: windowless) == nil)
+    }
+
+    @Test func sortRowsOrdersByTabRecency() {
+        let t = BrowserTabMRUTracker()
+        let tabs = tabRows(wid: 5, titles: ["Inbox", "Docs", "News"])
+        // The user last viewed News, then Docs — Inbox never focused.
+        t.bump(.tab(5, "News"))
+        t.bump(.tab(5, "Docs"))
+        // Docs (newest), News, then Inbox (unknown → back, stable on incoming order).
+        #expect(t.sortRows(tabs).map(\.windowTitle) == ["Docs", "News", "Inbox"])
+    }
+
+    @Test func unknownKeysKeepIncomingOrderAtBack() {
+        let t = BrowserTabMRUTracker()
+        t.bump(.window(3))   // only window 3 is known
+        let sorted = t.sortRows([windowRow(wid: 1), windowRow(wid: 2), windowRow(wid: 3)])
+        // 3 floats to the front; 1 and 2 (unknown) keep their incoming order.
+        #expect(sorted.map(\.cgWindowID) == [3, 1, 2])
+    }
+
+    @Test func tabsAndWindowsShareOneTimeline() {
+        let t = BrowserTabMRUTracker()
+        let finder = windowRow(wid: 1, title: "Finder")
+        let tabs = tabRows(wid: 9, titles: ["T1", "T2"])
+        // Focus T1, then Finder, then T2 → recency T2, Finder, T1. A tab can rank
+        // between two windows — the whole point versus the window-only sort.
+        t.bump(.tab(9, "T1"))
+        t.bump(.window(1))
+        t.bump(.tab(9, "T2"))
+        #expect(t.sortRows([finder, tabs[0], tabs[1]]).map(\.windowTitle) == ["T2", "Finder", "T1"])
+    }
+
+    @Test func bumpDeduplicatesSoRecencyIsExact() {
+        let t = BrowserTabMRUTracker()
+        t.bump(.tab(2, "A"))
+        t.bump(.tab(2, "B"))
+        t.bump(.tab(2, "A"))   // re-focusing A moves it back to front, not a 2nd copy
+        #expect(t.order == [.tab(2, "A"), .tab(2, "B")])
+    }
+
+    @Test func forgetWindowDropsAllItsEntries() {
+        let t = BrowserTabMRUTracker()
+        t.bump(.tab(7, "A"))
+        t.bump(.window(7))
+        t.bump(.tab(8, "X"))
+        t.forgetWindow(7)
+        #expect(t.order.allSatisfy { $0.wid != 7 })
+        #expect(t.order == [.tab(8, "X")])
+    }
+
+    @Test func windowlessAndZeroWidAreIgnored() {
+        let t = BrowserTabMRUTracker()
+        t.bump(.window(0))   // a 0 wid is windowless — never tracked
+        #expect(t.order.isEmpty)
+    }
+}

--- a/BetterCmdTabTests/BrowserTabMRUTrackerTests.swift
+++ b/BetterCmdTabTests/BrowserTabMRUTrackerTests.swift
@@ -87,4 +87,15 @@ struct BrowserTabMRUTrackerTests {
         t.bump(.window(0))   // a 0 wid is windowless — never tracked
         #expect(t.order.isEmpty)
     }
+
+    @Test func tabKeyTrimsTitleSoWhitespaceDoesNotSplitEntries() {
+        // The observer (AX title) and the displayed rows (osascript title) can
+        // differ by stray whitespace; trimming both onto one key keeps the current
+        // tab from being a separate entry that misses row 0.
+        #expect(BrowserTabMRUTracker.tabKey(wid: 3, title: "  Inbox \n") == .tab(3, "Inbox"))
+        let t = BrowserTabMRUTracker()
+        t.bump(BrowserTabMRUTracker.tabKey(wid: 3, title: " Inbox "))   // whitespacey AX title
+        // Clean osascript row titles — the trimmed bump still matches "Inbox".
+        #expect(t.sortRows(tabRows(wid: 3, titles: ["Inbox", "Docs"])).first?.windowTitle == "Inbox")
+    }
 }


### PR DESCRIPTION
Fixes the remaining half of #39 — the browser-tab concerns, under **Show browser tabs as separate entries**. Companion to #69 (Bug 1). Two parts.

## Permission hint for expand-as-windows (2a)

When the batched tab scan hit a script error (Automation access denied or a timeout) it was indistinguishable from a browser that genuinely has no tabs — `allWindowTabs` returned `[]` either way — so the reporter saw a **single collapsed browser** with no hint that Automation access was needed. The `\` tab-drill path already shows a "Grant Automation access…" hint on failure; the expand-as-windows path never did.

`allWindowTabs` now reports a `failed` flag (script error vs. genuinely empty). The scan surfaces the same hint for the expand path and **skips negative-caching** the failed windows, so granting access and re-opening retries immediately instead of waiting out the 3 s cache TTL.

## Browser-tab MRU (2b — experimental, off by default)

The flat *Most recent (windows)* sort keys every row by its `CGWindowID`, and all tabs of one browser window share that id, so the browser collapses to a single recency slot — ⌘Tab could only return to the previous **window**, never the previous **tab** ("does not switch to the previously used browser tab" in the report).

A new opt-in mode treats each tab as a first-class MRU entry:

- **`BrowserTabMRUTracker`** — unified window/tab recency (`.window(wid)` / `.tab(wid, title)`); a pure sort over the expanded rows, so a tab can rank *between* two windows.
- **`BrowserTabFocusObserver`** — one `AXObserver` per running browser, **active only while the pref is on**, that reads the focused window's AX title (its active tab — a cheap attribute, **no Apple Events**) on title/focus changes and bumps the tracker. `kAXTitleChangedNotification` is otherwise dropped while the panel is hidden (it's the loudest AX notification), so this always-on observation is the cost the feature trades for fidelity — hence the Experimental gate and the off-by-default.
- **`SwitcherController`** re-sorts the expanded rows by this recency (reveal, background refresh, re-expand), routes the fast tap-release through the same order (`primedBrowserTabMRUTargetRow` + a shared `activation(for:)`), and feeds the tracker from focus changes and tab/window commits. A Combine sink starts/stops the observer with the pref pair.

### Settings

A **Track browser tabs in recency** toggle in the Experimental pane — off by default, dependent on tab expansion + the windows sort order.

## Cost / safety

- The observer and the extra focus-time title read are **gated behind the pref**; with it off the feature costs nothing (no observers, no extra AX). Browser-only, coalesced one-read-per-pid in flight, `.utility` QoS, 50 ms AX timeout.
- The unified sort is a pure rank/partition, same shape as the existing window sort (re-buckets status, re-pins). Dead keys never match a live row; a cap bounds growth.
- Reviewed for AXObserver run-loop source balance, enable/disable + launch/terminate consistency, and the refcon/`MainActor.assumeIsolated` callback — no leak/UAF found.

## Tests

New `BrowserTabMRUTrackerTests` (7 cases): key mapping (tab vs window vs windowless), recency sort, unknown-key tail order, tab/window interleaving in one timeline, dedupe, `forgetWindow`. Full suite: **271 passing**.

The live AX observation + the actual ⌘Tab-returns-to-previous-tab behavior need manual verification (a real WindowServer + Accessibility + a browser with Automation granted), per the project's test policy.

> Note: new `String(localized:)` labels render in English via the key fallback; their `Localizable.xcstrings` entries can be added with Xcode's string export in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
