### PR TITLE
feat: preview title alignment + bold-on-select toggle, fix short-title ellipsis (#72)

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -25,6 +25,23 @@ enum SwitcherLayoutMode: String, CaseIterable {
     }
 }
 
+/// Where the title (app icon + window title pair) sits under each
+/// window-preview tile (#72). The pair stays tight together; this only moves it
+/// to the leading edge, the centre (default), or the trailing edge of the tile.
+enum PreviewTitleAlignment: String, CaseIterable {
+    case leading
+    case center
+    case trailing
+
+    var displayName: String {
+        switch self {
+        case .leading: return String(localized: "Left")
+        case .center: return String(localized: "Center")
+        case .trailing: return String(localized: "Right")
+        }
+    }
+}
+
 /// Which display the switcher panel opens on (#22).
 enum SwitcherDisplayMode: String, CaseIterable {
     /// Screen under the mouse pointer. Default — matches pre-#22 behavior.
@@ -478,6 +495,8 @@ final class Preferences: ObservableObject {
         static let vimNavigationEnabled = "Switcher.vimNavigationEnabled"
         static let shiftTapStepsBackward = "Switcher.shiftTapStepsBackward"
         static let switcherDisplayMode = "Switcher.displayMode"
+        static let previewTitleAlignment = "Switcher.previewTitleAlignment"
+        static let boldSelectedLabel = "Switcher.boldSelectedLabel"
     }
 
     @Published var switcherLayoutMode: SwitcherLayoutMode {
@@ -935,6 +954,25 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Horizontal placement of the title (app icon + window title) under each
+    /// window-preview tile (#72). Default centred — unchanged from before.
+    @Published var previewTitleAlignment: PreviewTitleAlignment {
+        didSet {
+            guard oldValue != previewTitleAlignment else { return }
+            UserDefaults.standard.set(previewTitleAlignment.rawValue, forKey: Keys.previewTitleAlignment)
+        }
+    }
+
+    /// Bold the selected row's title in the Grid and Previews layouts. Default
+    /// on. When off, the selected title only brightens (white) with no weight or
+    /// width change — avoids the "text grows on select" wobble (#72).
+    @Published var boldSelectedLabel: Bool {
+        didSet {
+            guard oldValue != boldSelectedLabel else { return }
+            UserDefaults.standard.set(boldSelectedLabel, forKey: Keys.boldSelectedLabel)
+        }
+    }
+
     /// Show the application name in every switcher layout (List right column,
     /// Grid name-under-icon, and any app-name fallback in Previews). Default on.
     /// Off = strict icon-only.
@@ -1251,6 +1289,9 @@ final class Preferences: ObservableObject {
 
         self.showWindowTitleLabel = defaults.object(forKey: Keys.showWindowTitleLabel) as? Bool ?? true
         self.showApplicationNames = defaults.object(forKey: Keys.showApplicationNames) as? Bool ?? true
+        self.previewTitleAlignment = defaults.string(forKey: Keys.previewTitleAlignment)
+            .flatMap(PreviewTitleAlignment.init(rawValue:)) ?? .center
+        self.boldSelectedLabel = defaults.object(forKey: Keys.boldSelectedLabel) as? Bool ?? true
         let opacity = defaults.object(forKey: Keys.panelOpacity) as? Int ?? 100
         self.panelOpacity = Self.clampOpacity(opacity)
         let radius = defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0
@@ -1338,6 +1379,8 @@ final class Preferences: ObservableObject {
 
         showWindowTitleLabel = defaults.object(forKey: Keys.showWindowTitleLabel) as? Bool ?? true
         showApplicationNames = defaults.object(forKey: Keys.showApplicationNames) as? Bool ?? true
+        previewTitleAlignment = defaults.string(forKey: Keys.previewTitleAlignment).flatMap(PreviewTitleAlignment.init(rawValue:)) ?? .center
+        boldSelectedLabel = defaults.object(forKey: Keys.boldSelectedLabel) as? Bool ?? true
         panelOpacity = Self.clampOpacity(defaults.object(forKey: Keys.panelOpacity) as? Int ?? 100)
         panelCornerRadius = Self.clampCornerRadius(defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0)
         customAccentHex = defaults.string(forKey: Keys.customAccentHex)

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -7,12 +7,14 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
 
     private var layoutRadio: SettingsRadioGroupView!
     private var sizeRadio: SettingsRadioGroupView!
+    private var titleAlignmentRadio: SettingsRadioGroupView!
     private let gridPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let accentPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let delaySlider = NSSlider()
     private let delayValueLabel = NSTextField(labelWithString: "")
     private let windowTitleSwitch = NSSwitch()
     private let appNamesSwitch = NSSwitch()
+    private let boldSelectedSwitch = NSSwitch()
     private let opacitySlider = NSSlider()
     private let opacityValueLabel = NSTextField(labelWithString: "")
     private let radiusSlider = NSSlider()
@@ -37,6 +39,7 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
 
     // Ordered option models backing the popups (index ↔ value).
     private let layoutModes: [SwitcherLayoutMode] = [.gridView, .list, .windowPreview]
+    private let titleAlignments: [PreviewTitleAlignment] = [.leading, .center, .trailing]
     private let panelSizes: [PanelSize] = PanelSize.allCases
     private let gridValues: [Int] = [0, 2, 3, 4, 5, 6] // 0 = automatic
     private let accents: [SwitcherAccent] = SwitcherAccent.allCases
@@ -92,6 +95,16 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         addRow(to: section, title: String(localized: "Show window title"),
                subtitle: String(localized: "Show each window's title under the icon in the Grid and Previews layouts."),
                accessory: windowTitleSwitch, searchItemID: SearchID.windowTitle)
+
+        titleAlignmentRadio = makeTitleAlignmentRadio()
+        addRow(to: section, title: String(localized: "Title alignment"),
+               subtitle: String(localized: "Position of the title under each Previews tile."),
+               accessory: titleAlignmentRadio, searchItemID: SearchID.titleAlignment)
+
+        configureSwitch(boldSelectedSwitch, action: #selector(toggleBoldSelected(_:)))
+        addRow(to: section, title: String(localized: "Bold selected title"),
+               subtitle: String(localized: "Make the highlighted item's title bold in the Grid and Previews layouts. Off only brightens it."),
+               accessory: boldSelectedSwitch, searchItemID: SearchID.boldSelected)
 
         configureSwitch(appNamesSwitch, action: #selector(toggleApplicationNames(_:)))
         addRow(to: section, title: String(localized: "Show application names"),
@@ -239,6 +252,18 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         return group
     }
 
+    private func makeTitleAlignmentRadio() -> SettingsRadioGroupView {
+        let options = titleAlignments.map { alignment in
+            SettingsRadioGroupView.Option(identifier: alignment.rawValue, title: alignment.displayName)
+        }
+        let group = SettingsRadioGroupView(options: options, orientation: .horizontal)
+        group.onSelectionChange = { id in
+            guard let alignment = PreviewTitleAlignment(rawValue: id) else { return }
+            Preferences.shared.previewTitleAlignment = alignment
+        }
+        return group
+    }
+
     private func configurePopup(_ popup: NSPopUpButton, titles: [String], action: Selector) {
         popup.controlSize = .small
         popup.translatesAutoresizingMaskIntoConstraints = false
@@ -282,6 +307,14 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.windowTitleSwitch.state = $0 ? .on : .off }
             .store(in: &cancellables)
+        prefs.$previewTitleAlignment
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.selectTitleAlignment($0) }
+            .store(in: &cancellables)
+        prefs.$boldSelectedLabel
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.boldSelectedSwitch.state = $0 ? .on : .off }
+            .store(in: &cancellables)
         prefs.$showApplicationNames
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.appNamesSwitch.state = $0 ? .on : .off }
@@ -319,6 +352,8 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         applyDelay(prefs.revealDelayMs)
         selectAccent(prefs.accentChoice)
         windowTitleSwitch.state = prefs.showWindowTitleLabel ? .on : .off
+        selectTitleAlignment(prefs.previewTitleAlignment)
+        boldSelectedSwitch.state = prefs.boldSelectedLabel ? .on : .off
         appNamesSwitch.state = prefs.showApplicationNames ? .on : .off
         applyOpacity(prefs.panelOpacity)
         applyRadius(prefs.panelCornerRadius)
@@ -395,6 +430,14 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleApplicationNames(_ sender: NSSwitch) {
         Preferences.shared.showApplicationNames = (sender.state == .on)
+    }
+
+    @objc private func toggleBoldSelected(_ sender: NSSwitch) {
+        Preferences.shared.boldSelectedLabel = (sender.state == .on)
+    }
+
+    private func selectTitleAlignment(_ alignment: PreviewTitleAlignment) {
+        titleAlignmentRadio.select(identifier: alignment.rawValue)
     }
 
     @objc private func opacityChanged(_ sender: NSSlider) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -111,6 +111,8 @@ enum SearchID {
     static let accent = "appearance.accent"
     static let quickSwitchDelay = "appearance.quickSwitchDelay"
     static let windowTitle = "appearance.windowTitle"
+    static let titleAlignment = "appearance.titleAlignment"
+    static let boldSelected = "appearance.boldSelected"
     static let opacity = "appearance.opacity"
     static let cornerRadius = "appearance.cornerRadius"
     // Experimental
@@ -317,6 +319,10 @@ enum SettingsCatalog {
              String(localized: "Quick-switch delay"), ["delay", "reveal", "hold", "quick switch"]),
         item(SearchID.windowTitle, .appearance, SettingsAnchor.appearance, String(localized: "Appearance"), String(localized: "Switcher"),
              String(localized: "Show window title"), ["window title", "title", "label", "name"]),
+        item(SearchID.titleAlignment, .appearance, SettingsAnchor.appearance, String(localized: "Appearance"), String(localized: "Switcher"),
+             String(localized: "Title alignment"), ["title", "alignment", "align", "left", "center", "centre", "right", "position", "ellipsis"]),
+        item(SearchID.boldSelected, .appearance, SettingsAnchor.appearance, String(localized: "Appearance"), String(localized: "Switcher"),
+             String(localized: "Bold selected title"), ["bold", "selected", "title", "weight", "highlight", "label"]),
         item(SearchID.applicationNames, .appearance, SettingsAnchor.appearance, String(localized: "Appearance"), String(localized: "Switcher"),
              String(localized: "Show application names"),
              ["application names", "app name", "app names", "name", "label", "icon only", "hide name"]),

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -378,9 +378,12 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     private func applySelection() {
         selectionBackdrop.isHidden = !isSelected
         nameLabel.textColor = isSelected ? .labelColor : .secondaryLabelColor
+        // Bolding the selected name is optional (#72) — off keeps a steady weight
+        // so the label doesn't grow/shrink as selection moves; it still brightens.
+        let bold = isSelected && Preferences.shared.boldSelectedLabel
         nameLabel.font = NSFont.systemFont(
             ofSize: metrics.tileNameFontSize,
-            weight: isSelected ? .semibold : .medium
+            weight: bold ? .semibold : .medium
         )
         // The jump letter doesn't depend on selection, so it is rendered once in
         // `configure` rather than re-built on every selection move.

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -169,6 +169,12 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     private var currentLabel: String = ""
     private var currentPrefixLength: Int = 0
 
+    /// Horizontal padding a borderless NSTextFieldCell reserves around its text,
+    /// beyond the raw glyph bounding box returned by `size(withAttributes:)`. Near
+    /// constant (~4–5pt) across font sizes; added to the measured title width so a
+    /// title that fits isn't truncated to an ellipsis by the cell's own inset.
+    private static let labelCellInset: CGFloat = 5
+
     func prepareForIdle() {
         // Release the thumbnail and app-icon retains so WindowThumbnailCache /
         // IconCache can evict them; all are re-set by `configure` on reuse.
@@ -278,10 +284,26 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     private func applySelection() {
         selectionBackdrop.isHidden = !isSelected
         nameLabel.textColor = isSelected ? .labelColor : .secondaryLabelColor
+        // The selected title brightens to `labelColor`; bolding it is optional so
+        // users who dislike the on-select width wobble keep a steady weight (#72).
+        let bold = isSelected && Preferences.shared.boldSelectedLabel
         nameLabel.font = NSFont.systemFont(
             ofSize: metrics.previewNameFontSize,
-            weight: isSelected ? .semibold : .medium
+            weight: bold ? .semibold : .medium
         )
+    }
+
+    /// Leading edge of the tight icon+title group inside a tile of width
+    /// `tileWidth`, for the chosen alignment (#72). Leading hugs the left edge,
+    /// trailing the right, centre splits the slack. Clamped to ≥ 0 so an
+    /// over-wide group never starts off-tile.
+    static func titleGroupOriginX(alignment: PreviewTitleAlignment, groupWidth: CGFloat, tileWidth: CGFloat) -> CGFloat {
+        let slack = max(0, tileWidth - groupWidth)
+        switch alignment {
+        case .leading: return 0
+        case .center: return round(slack / 2)
+        case .trailing: return slack
+        }
     }
 
     private func renderLetter() {
@@ -362,14 +384,32 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
             // Measure the title width with a string-metrics query rather than
             // `nameLabel.sizeToFit()`, which lays out and resizes the whole
             // NSTextField just to read a width that's immediately clamped below.
-            // `nameLabel` is a plain single-line truncating field, so the glyph
-            // bounding box is equivalent; `nameLabel.frame` is set explicitly at
-            // the end of this method, so the skipped sizeToFit mutates nothing used.
-            let measureFont = nameLabel.font ?? NSFont.systemFont(ofSize: m.previewNameFontSize, weight: .medium)
+            // `nameLabel.frame` is set explicitly at the end of this method, so the
+            // skipped sizeToFit mutates nothing used.
+            //
+            // The glyph bounding box is NOT what the field needs to draw, though:
+            // the borderless NSTextFieldCell adds a small fixed horizontal inset
+            // (~4–5pt total, independent of font size). Sizing the frame to the bare
+            // glyph width left the cell ~4pt short and truncated a fitting title to an
+            // ellipsis ("ChatGPT" → "ChatG…"). Add the inset back so titles that fit
+            // aren't clipped; the outer `min` still clamps to the tile's free width.
+            //
+            // Measure the heaviest weight the title can ever take (.semibold), never
+            // the current one. A selected tile renders semibold via `applySelection`
+            // WITHOUT a relayout, and the bold-on-select pref can flip while the panel
+            // is open — so keying the measure off the live weight or pref risks a frame
+            // sized for .medium clipping a later semibold render. The bold width fits
+            // the medium render too (~1pt slack); the outer `min` still clamps to the
+            // tile's free width. Constant weight also keeps this off the pref read path.
+            let measureFont = NSFont.systemFont(ofSize: m.previewNameFontSize, weight: .semibold)
             let textW = (nameLabel.stringValue as NSString).size(withAttributes: [.font: measureFont]).width
-            let nameW = min(ceil(textW), w - iconSize - 6 - badgeSlot)
+            let nameW = min(ceil(textW) + Self.labelCellInset, w - iconSize - 6 - badgeSlot)
             let groupW = iconSize + 4 + nameW + badgeSlot
-            let startX = max(0, round((w - groupW) / 2))
+            let startX = Self.titleGroupOriginX(
+                alignment: Preferences.shared.previewTitleAlignment,
+                groupWidth: groupW,
+                tileWidth: w
+            )
             let rowMidY = labelAreaH / 2
             iconView.frame = NSRect(
                 x: startX,

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -60,6 +60,33 @@ struct PreferencesEnumTests {
         #expect(SwitcherDisplayMode.mainDisplay.rawValue == "mainDisplay")
     }
 
+    @Test("PreviewTitleAlignment raw values round-trip and unknown falls back")
+    func previewTitleAlignmentRoundTrip() {
+        for alignment in PreviewTitleAlignment.allCases {
+            #expect(PreviewTitleAlignment(rawValue: alignment.rawValue) == alignment)
+            #expect(!alignment.displayName.isEmpty)
+        }
+        #expect(PreviewTitleAlignment(rawValue: "garbage") == nil)
+        // Stable raw values (persisted to UserDefaults / exported settings).
+        #expect(PreviewTitleAlignment.leading.rawValue == "leading")
+        #expect(PreviewTitleAlignment.center.rawValue == "center")
+        #expect(PreviewTitleAlignment.trailing.rawValue == "trailing")
+    }
+
+    @MainActor
+    @Test("titleGroupOriginX places the preview title at the chosen edge")
+    func titleGroupOriginX() {
+        let tile: CGFloat = 200
+        let group: CGFloat = 80   // 120 pt of slack
+        #expect(SwitcherPreviewItemView.titleGroupOriginX(alignment: .leading, groupWidth: group, tileWidth: tile) == 0)
+        #expect(SwitcherPreviewItemView.titleGroupOriginX(alignment: .center, groupWidth: group, tileWidth: tile) == 60)
+        #expect(SwitcherPreviewItemView.titleGroupOriginX(alignment: .trailing, groupWidth: group, tileWidth: tile) == 120)
+
+        // A group wider than the tile never starts off-screen (slack clamps to 0).
+        #expect(SwitcherPreviewItemView.titleGroupOriginX(alignment: .trailing, groupWidth: 260, tileWidth: tile) == 0)
+        #expect(SwitcherPreviewItemView.titleGroupOriginX(alignment: .center, groupWidth: 260, tileWidth: tile) == 0)
+    }
+
     @Test("HideWindowsMode / IgnoreShortcutsMode round-trip through raw values")
     func exceptionModeRawValues() {
         for mode in HideWindowsMode.allCases {


### PR DESCRIPTION
Closes #72.

## Summary

Three related changes to the window-preview (alt-tab) tile titles, from issue #72.

### Fixed
- **Needless ellipsis on short titles** — preview tiles truncated titles that clearly fit ("ChatGPT" → "ChatG…"). The label frame was sized to the raw glyph bounding box from `size(withAttributes:)`, ~4–5pt short of what a borderless `NSTextFieldCell` actually needs to draw (measured: glyph 47.98pt vs `fittingSize` 52pt). The frame now adds that cell inset and is measured at `.semibold` (the heaviest weight a title can take), so it never clips in any selection or preference state — selection moves don't trigger a relayout, so the frame must fit the bold render too.

### Added
- **Title alignment** (Left / Center / Right) for the Previews layout — the app-icon + title pair stays tight and moves to the chosen edge of the tile. Default **Center** (unchanged look). New `previewTitleAlignment` preference; placement done by the pure, unit-tested `titleGroupOriginX` helper.
- **Bold selected title** toggle (default **on**) — when off, the highlighted item's title only brightens to white and keeps a steady `.medium` weight instead of switching to `.semibold`, removing the "text grows on select" wobble. Applies to Previews + Grid.

## Notes
- Both prefs are in the **Appearance** pane (alignment radio + bold switch), registered as searchable settings, and round-trip through the existing `Switcher.*` export/import.
- **Defaults preserve current behavior** — existing users see no change until they opt in.
- New user-facing strings fall back to their English source until the next Xcode string-catalog extraction adds translation slots.

## Test plan
- `xcodebuild test` — **277 tests / 33 suites pass**, including 2 new (`PreviewTitleAlignment` round-trip, `titleGroupOriginX` placement).
- Debug + the change build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
