### PR TITLE
fix: return ⌘Tab to an app's most recent window, not AX scan order

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -2575,9 +2575,9 @@ final class SwitcherController: SwitcherViewDelegate {
         // cold placeholder rows have no windows yet, so `applyFullSnapshot`
         // applies the scope once the real scan lands. nil scope (normal ⌘Tab)
         // leaves rows untouched.
-        var sortedRows = applyWindowMRUSort(
+        var sortedRows = applyPerAppWindowMRU(applyWindowMRUSort(
             Log.reveal.withIntervalSignpost("catalog.rows") { cache.rows(orderedBy: mru.order, filter: activeFilterConfig) }
-        )
+        ))
         let hadCachedRows = !sortedRows.isEmpty
         if let scope = activeScope, hadCachedRows {
             sortedRows = scopeFiltered(sortedRows, scope: scope)
@@ -2853,6 +2853,17 @@ final class SwitcherController: SwitcherViewDelegate {
         return CatalogFilter.pinnedToFront(bucketed, Preferences.shared.pinnedBundleIDs)
     }
 
+    /// App-grouped sorts only: re-order each app's window rows by per-app
+    /// window recency, so the row an app entry leads with — the one
+    /// `collapseToApplications` elects, the pid anchor selects, and an app
+    /// commit activates — is the app's most recently used window rather than
+    /// the AX scan order (#83, #30). `.mruWindows` ranks every window globally
+    /// instead, so it must pass through untouched.
+    private func applyPerAppWindowMRU(_ rows: [SwitcherRow]) -> [SwitcherRow] {
+        guard effective.sortOrder != .mruWindows else { return rows }
+        return windowMRU.sortRowsWithinAppRuns(rows)
+    }
+
     /// Whether the experimental browser-tab MRU is fully active: the feature on,
     /// tabs expanded (not collapsed to apps), and the window-recency sort selected
     /// (the only sort `applyBrowserTabMRU` reorders within). Read live off the main
@@ -2943,7 +2954,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // scan any browser window that newly appeared. Collapse to one row per app
         // AFTER the window-MRU sort — matching `reveal()` — so the representative
         // window each app keeps is identical across the reveal→refresh transition.
-        baseRows = applyBrowserTabMRU(expandBrowserTabs(applyApplicationsOnly(applyWindowMRUSort(next))))
+        baseRows = applyBrowserTabMRU(expandBrowserTabs(applyApplicationsOnly(applyPerAppWindowMRU(applyWindowMRUSort(next)))))
         baseLabels = RowLabels.labels(for: baseRows)
         refreshDisplay(anchorPid: anchorPid)
         scheduleBrowserTabExpansion()
@@ -3313,18 +3324,19 @@ final class SwitcherController: SwitcherViewDelegate {
         return candidates[target]
     }
 
-    /// The row the visible switcher would activate for `app`: its frontmost
-    /// catalogued window. The catalog gives an app either one windowless row or
-    /// one row per window (windowed rows sort first), so the first windowed row
-    /// for the pid is the frontmost — matching reveal()'s `firstIndex(by: pid)`
-    /// pick. Reads the warm cache ONLY: this runs inside commit() on the main
+    /// The row the visible switcher would activate for `app`: its most recently
+    /// used catalogued window. Runs the same `applyPerAppWindowMRU` pass as
+    /// reveal(), so the first windowed row for the pid is the app's window-MRU
+    /// front (#83) — a fast ⌘⇥ tap and a held-open panel agree on the target.
+    /// Reads the warm cache ONLY: this runs inside commit() on the main
     /// actor (the hottest path), so it must never trigger a synchronous
     /// cross-process AppCatalog.snapshot(). nil — a windowless app, or the brief
     /// cold-cache window at boot/AX-regrant — makes the caller fall back to the
     /// cheap, main-safe `activateApp`.
     private func primedAppTargetRow(for app: NSRunningApplication) -> SwitcherRow? {
         let pid = app.processIdentifier
-        return cache.rows(orderedBy: mru.order, filter: activeFilterConfig).first(where: { $0.pid == pid && $0.window != nil })
+        return applyPerAppWindowMRU(cache.rows(orderedBy: mru.order, filter: activeFilterConfig))
+            .first(where: { $0.pid == pid && $0.window != nil })
     }
 
     /// The window row a `.mruWindows` fast tap-release should activate: the
@@ -4248,7 +4260,7 @@ final class SwitcherController: SwitcherViewDelegate {
                 // Collapse to one row per app when "Applications only" is on — the
                 // reveal paths do this; without it the first in-panel window action's
                 // refresh would re-expand the panel to one row per window.
-                self.baseRows = self.expandBrowserTabs(self.applyApplicationsOnly(fresh))
+                self.baseRows = self.expandBrowserTabs(self.applyApplicationsOnly(self.applyPerAppWindowMRU(fresh)))
                 self.baseLabels = RowLabels.labels(for: self.baseRows)
                 self.refreshDisplay()
                 self.scheduleBrowserTabExpansion()

--- a/BetterCmdTab/Windows/WindowMRUTracker.swift
+++ b/BetterCmdTab/Windows/WindowMRUTracker.swift
@@ -100,6 +100,47 @@ final class WindowMRUTracker {
         return sortRows(rows, by: list)
     }
 
+    /// Re-orders each contiguous run of same-pid windowed rows by that app's
+    /// per-app recency (`sortRows(forPid:)`), leaving run boundaries and every
+    /// other row in place. The app-grouped sorts (.mru / alphabetical / launch
+    /// order) apply this so each app's leading row — the one
+    /// `collapseToApplications` elects, the pid selection anchor lands on, and
+    /// a ⌘Tab app commit activates — is the app's most recently used window
+    /// instead of the AX scan order (#83, #30). Runs never span status buckets
+    /// (the catalog orders buckets before any app's rows repeat), so a recently
+    /// focused but since-minimized window can't jump ahead of a visible one.
+    func sortRowsWithinAppRuns(_ rows: [SwitcherRow]) -> [SwitcherRow] {
+        guard !order.isEmpty, rows.count > 1 else { return rows }
+        let ranges = Self.windowRunRanges(
+            pids: rows.map(\.pid),
+            windowed: rows.map { $0.window != nil || $0.cgWindowID != 0 }
+        )
+        guard !ranges.isEmpty else { return rows }
+        var result = rows
+        for range in ranges {
+            guard let pid = result[range.lowerBound].pid, order[pid] != nil else { continue }
+            result.replaceSubrange(range, with: sortRows(Array(result[range]), forPid: pid))
+        }
+        return result
+    }
+
+    /// Pure index-level core of `sortRowsWithinAppRuns`, split out so run
+    /// detection is unit-testable without live AX rows: the maximal contiguous
+    /// ranges (length ≥ 2) of windowed rows sharing one non-nil pid. A
+    /// windowless row — or a different pid — ends the run it interrupts.
+    static func windowRunRanges(pids: [pid_t?], windowed: [Bool]) -> [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        var i = 0
+        while i < pids.count {
+            guard let pid = pids[i], windowed[i] else { i += 1; continue }
+            var j = i + 1
+            while j < pids.count, pids[j] == pid, windowed[j] { j += 1 }
+            if j - i > 1 { ranges.append(i..<j) }
+            i = j
+        }
+        return ranges
+    }
+
     /// Re-orders `rows` by flat cross-app window recency (the `.mruWindows`
     /// sort): each window sorts by its rank in `globalOrder`, newest first,
     /// interleaving windows of different apps. Windowless rows (`cgWindowID == 0`)

--- a/BetterCmdTabTests/WindowMRUTrackerTests.swift
+++ b/BetterCmdTabTests/WindowMRUTrackerTests.swift
@@ -135,4 +135,52 @@ struct WindowMRUTrackerTests {
         let sorted = tracker.sortRowsGlobally([row(0, title: "wl"), row(10)])
         #expect(sorted.map(\.cgWindowID) == [10, 0])
     }
+
+    // MARK: - Per-app run sort (`sortRowsWithinAppRuns`, #83)
+
+    @Test("run detection finds maximal same-pid windowed runs of length ≥ 2")
+    func runRangesDetected() {
+        let ranges = WindowMRUTracker.windowRunRanges(
+            pids: [1, 1, 2, 1, 1, 1],
+            windowed: [true, true, true, true, true, true]
+        )
+        #expect(ranges == [0..<2, 3..<6])
+    }
+
+    @Test("a windowless row splits its app's run")
+    func runRangesSplitByWindowless() {
+        let ranges = WindowMRUTracker.windowRunRanges(
+            pids: [1, 1, 1, 1],
+            windowed: [true, false, true, true]
+        )
+        #expect(ranges == [2..<4])
+    }
+
+    @Test("nil pids and single-row runs produce no ranges")
+    func runRangesSkipNilAndSingles() {
+        let ranges = WindowMRUTracker.windowRunRanges(
+            pids: [nil, 1, 2, 2, nil],
+            windowed: [false, true, true, true, false]
+        )
+        #expect(ranges == [2..<4])
+    }
+
+    @Test("per-app run sort floats the app's MRU window to the run's front")
+    func runSortFloatsMRUWindow() {
+        let tracker = WindowMRUTracker()
+        let pid = NSRunningApplication.current.processIdentifier
+        tracker.bump(pid: pid, wid: 30)
+        tracker.bump(pid: pid, wid: 20) // 20 focused last
+        // Scan order [10, 20, 30] → recency floats 20, unseen 10 sinks.
+        let sorted = tracker.sortRowsWithinAppRuns([row(10), row(20), row(30)])
+        #expect(sorted.map(\.cgWindowID) == [20, 30, 10])
+    }
+
+    @Test("per-app run sort leaves apps the tracker never saw untouched")
+    func runSortUnseenAppUntouched() {
+        let tracker = WindowMRUTracker()
+        tracker.bump(pid: 999_999, wid: 77) // recency known only for another app
+        let sorted = tracker.sortRowsWithinAppRuns([row(10), row(20)])
+        #expect(sorted.map(\.cgWindowID) == [10, 20])
+    }
 }


### PR DESCRIPTION
## Problem

Switching back to a multi-window app (⌘Tab, quick tap or held panel) focused the wrong window — whichever the AX scan listed first, not the one last used (#83, #30; same wrong-window symptom family as #39).

## Root cause

App-entry activation always picked the app's **first catalogued window**. The catalog stores windows in AX scan order, and nothing on the app-grouped sorts ever consumed the per-app window MRU that the focus observers (`AppCatalogCache` → `handleFocusChange` → `WindowMRUTracker`) already keep fresh. Both pick paths were affected:

- fast-tap commit: `primedAppTargetRow` took the first windowed row for the pid straight from cache order
- held panel: the pid anchor + `collapseToApplications` elected the first cache-ordered row per app

## Fix

- `WindowMRUTracker.sortRowsWithinAppRuns` — re-orders each contiguous run of same-pid windowed rows by that app's recency, with a pure, unit-testable core (`windowRunRanges`) for run detection. Runs never span status buckets, so a recently focused but since-minimized window can't jump ahead of a visible one.
- Applied via `applyPerAppWindowMRU` in `reveal()`, `applyFullSnapshot()`, `scheduleVisibleRefresh()`, and `primedAppTargetRow` — a quick ⌘⇥ tap and a held-open panel now agree on the target.
- `.mruWindows` sort passes through untouched (it already ranks every window globally).

Hot-path cost: one O(N) pass over ~50 rows per reveal/commit plus per-run sorts — no new AX calls, no polling, no main-thread blocking.

## Tests

5 new cases in `WindowMRUTrackerTests` (run detection incl. windowless/nil-pid splits, MRU float, unseen-app no-op). Full suite: 324/324 pass.

Closes #83
Closes #30
Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)