### PR TITLE
feat: add visible-Spaces scope for multi-monitor switching

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -191,6 +191,28 @@ enum SwitcherSortOrder: String, CaseIterable {
     }
 }
 
+/// Which Spaces the switcher shows windows from (#57). Raw values are
+/// persisted under `Keys.spaceScope`, so don't rename cases. Supersedes the
+/// legacy `Keys.currentSpaceOnly` bool, which is kept in sync for older
+/// builds/exports and used as the fallback when the new key is absent.
+enum SpaceScope: String, CaseIterable, Sendable {
+    /// Every window on every Space (default — classic ⌘Tab).
+    case allSpaces
+    /// Only windows on the single Space that has keyboard focus.
+    case currentSpace
+    /// Windows on every Space currently on screen — the active Space of each
+    /// display (#57, multi-monitor "what I can see").
+    case visibleSpaces
+
+    var displayName: String {
+        switch self {
+        case .allSpaces: return String(localized: "All Spaces")
+        case .currentSpace: return String(localized: "Current Space")
+        case .visibleSpaces: return String(localized: "Visible Spaces")
+        }
+    }
+}
+
 /// The subset of windows a scoped custom shortcut opens the switcher onto.
 /// Each user-defined scoped shortcut (Shortcuts settings) carries one of these;
 /// triggering it opens the switcher already filtered to that subset instead of
@@ -215,23 +237,26 @@ enum SwitchScope: String, CaseIterable {
     }
 }
 
-/// Per-shortcut override of the Space-scope behavioral option (#74). Tri-state so
-/// a shortcut can force "this Space only", force "all Spaces", or inherit the
-/// global `currentSpaceOnly` toggle. Stored as a raw string on `ShortcutOverride`.
+/// Per-shortcut override of the Space-scope behavioral option (#74). A shortcut
+/// can force any concrete `SpaceScope` or inherit the global `spaceScope`
+/// preference. Stored as a raw string on `ShortcutOverride` — don't rename cases.
 enum SpaceScopeOverride: String, CaseIterable, Sendable {
-    /// Use the global `currentSpaceOnly` preference. (Default.)
+    /// Use the global `spaceScope` preference. (Default.)
     case inherit
     /// Force the shortcut to only show windows on the current Space.
     case currentSpace
     /// Force the shortcut to show windows across all Spaces.
     case allSpaces
+    /// Force the shortcut to show windows on every visible Space (#57).
+    case visibleSpaces
 
-    /// The concrete `currentSpaceOnly` value, or `nil` when inheriting the global.
-    var resolvedCurrentSpaceOnly: Bool? {
+    /// The concrete scope, or `nil` when inheriting the global.
+    var resolvedScope: SpaceScope? {
         switch self {
         case .inherit: return nil
-        case .currentSpace: return true
-        case .allSpaces: return false
+        case .currentSpace: return .currentSpace
+        case .allSpaces: return .allSpaces
+        case .visibleSpaces: return .visibleSpaces
         }
     }
 
@@ -240,6 +265,7 @@ enum SpaceScopeOverride: String, CaseIterable, Sendable {
         case .inherit: return String(localized: "Use global default")
         case .currentSpace: return String(localized: "This Space only")
         case .allSpaces: return String(localized: "All Spaces")
+        case .visibleSpaces: return String(localized: "Visible Spaces")
         }
     }
 }
@@ -682,7 +708,12 @@ final class Preferences: ObservableObject {
         static let panelCornerRadius = "Switcher.panelCornerRadius"
         static let customAccentHex = "Switcher.customAccentHex"
         static let backdropMaterial = "Switcher.backdropMaterial"
+        /// Legacy pre-#57 bool ("only current Space"). Still written (in sync
+        /// with `spaceScope`) so older builds and old exports stay coherent;
+        /// read only as the fallback when `spaceScope` is absent.
         static let currentSpaceOnly = "Switcher.currentSpaceOnly"
+        /// `SpaceScope` raw value — which Spaces the switcher shows (#57).
+        static let spaceScope = "Switcher.spaceScope"
         static let directActivationBindings = "Switcher.directActivationBindings"
         static let scopedShortcutScopes = "Switcher.scopedShortcutScopes"
         /// The dynamic scoped-switch list (#74), as `[[String: String]]` of
@@ -1244,13 +1275,17 @@ final class Preferences: ObservableObject {
         }
     }
 
-    /// Show only windows that live on the currently active Space. Default off.
+    /// Which Spaces the switcher shows windows from (#57). Default all Spaces.
     /// Reads window Space membership via the same private APIs as instant Space
     /// switching; degrades to showing everything when those are unavailable.
-    @Published var currentSpaceOnly: Bool {
+    @Published var spaceScope: SpaceScope {
         didSet {
-            guard oldValue != currentSpaceOnly else { return }
-            UserDefaults.standard.set(currentSpaceOnly, forKey: Keys.currentSpaceOnly)
+            guard oldValue != spaceScope else { return }
+            let defaults = UserDefaults.standard
+            defaults.set(spaceScope.rawValue, forKey: Keys.spaceScope)
+            // Keep the legacy bool in step so pre-#57 builds and settings
+            // exports read a consistent value.
+            defaults.set(spaceScope == .currentSpace, forKey: Keys.currentSpaceOnly)
         }
     }
 
@@ -1331,6 +1366,19 @@ final class Preferences: ObservableObject {
 
     static func decodeScopedShortcuts(_ raw: [[String: String]]?) -> [ScopedShortcut] {
         (raw ?? []).compactMap(ScopedShortcut.init(dictionary:))
+    }
+
+    /// The stored Space scope (#57): the `spaceScope` key when present, else
+    /// derived from the legacy pre-#57 `currentSpaceOnly` bool (true → current
+    /// Space, absent/false → all Spaces). Pure read, no persisting — the key is
+    /// only written when the user changes the setting, so old-format settings
+    /// imports keep applying through the fallback. `nonisolated` because the
+    /// off-main catalog path (`CatalogFilter.config()`) shares it.
+    nonisolated static func storedSpaceScope(_ defaults: UserDefaults) -> SpaceScope {
+        if let scope = defaults.string(forKey: Keys.spaceScope).flatMap(SpaceScope.init(rawValue:)) {
+            return scope
+        }
+        return (defaults.object(forKey: Keys.currentSpaceOnly) as? Bool ?? false) ? .currentSpace : .allSpaces
     }
 
     /// Build the initial list from the legacy fixed `scopedShortcutScopes` (the
@@ -1647,7 +1695,7 @@ final class Preferences: ObservableObject {
         self.customAccentHex = defaults.string(forKey: Keys.customAccentHex)
         let materialRaw = defaults.string(forKey: Keys.backdropMaterial)
         self.backdropMaterial = materialRaw.flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
-        self.currentSpaceOnly = defaults.object(forKey: Keys.currentSpaceOnly) as? Bool ?? false
+        self.spaceScope = Self.storedSpaceScope(defaults)
         self.directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
         let legacyScopes = Self.loadScopes(defaults.stringArray(forKey: Keys.scopedShortcutScopes))
         self.scopedShortcutScopes = legacyScopes
@@ -1758,7 +1806,7 @@ final class Preferences: ObservableObject {
         panelCornerRadius = Self.clampCornerRadius(defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0)
         customAccentHex = defaults.string(forKey: Keys.customAccentHex)
         backdropMaterial = defaults.string(forKey: Keys.backdropMaterial).flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
-        currentSpaceOnly = defaults.object(forKey: Keys.currentSpaceOnly) as? Bool ?? false
+        spaceScope = Self.storedSpaceScope(defaults)
         directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
         let reloadedScopes = Self.loadScopes(defaults.stringArray(forKey: Keys.scopedShortcutScopes))
         scopedShortcutScopes = reloadedScopes

--- a/BetterCmdTab/App/SettingsPortability.swift
+++ b/BetterCmdTab/App/SettingsPortability.swift
@@ -119,6 +119,13 @@ extension Preferences {
             guard PropertyListSerialization.propertyList(value, isValidFor: .binary) else { continue }
             defaults.set(value, forKey: key)
         }
+        // Pre-#57 exports carry only the legacy `currentSpaceOnly` bool. Clear
+        // any locally stored `spaceScope` so the reload's legacy fallback
+        // derives the scope from the imported bool instead of keeping this
+        // machine's stale enum value.
+        if values[Preferences.Keys.currentSpaceOnly] != nil, values[Preferences.Keys.spaceScope] == nil {
+            defaults.removeObject(forKey: Preferences.Keys.spaceScope)
+        }
         reloadFromDefaults()
         // The import may have introduced scoped shortcuts with ids that didn't
         // exist at launch; install their Carbon handlers now (idempotent) so a

--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -19,12 +19,12 @@ enum CatalogFilter {
         let showMinimized: Bool
         let showHidden: Bool
         let showWindowless: Bool
-        let currentSpaceOnly: Bool
+        let spaceScope: SpaceScope
         let sortOrder: SwitcherSortOrder
 
         /// No filtering and no reordering — lets callers skip work entirely.
         var isIdentity: Bool {
-            hideModes.isEmpty && pinned.isEmpty && showMinimized && showHidden && showWindowless && !currentSpaceOnly && sortOrder == .mru
+            hideModes.isEmpty && pinned.isEmpty && showMinimized && showHidden && showWindowless && spaceScope == .allSpaces && sortOrder == .mru
         }
     }
 
@@ -45,7 +45,7 @@ enum CatalogFilter {
             showMinimized: defaults.object(forKey: Preferences.Keys.showMinimizedWindows) as? Bool ?? true,
             showHidden: defaults.object(forKey: Preferences.Keys.showHiddenApps) as? Bool ?? true,
             showWindowless: defaults.object(forKey: Preferences.Keys.showWindowlessApps) as? Bool ?? true,
-            currentSpaceOnly: defaults.object(forKey: Preferences.Keys.currentSpaceOnly) as? Bool ?? false,
+            spaceScope: Preferences.storedSpaceScope(defaults),
             sortOrder: sortRaw.flatMap(SwitcherSortOrder.init(rawValue:)) ?? .mru
         )
     }
@@ -62,7 +62,7 @@ enum CatalogFilter {
             showMinimized: ov.showMinimized ?? base.showMinimized,
             showHidden: ov.showHidden ?? base.showHidden,
             showWindowless: ov.showWindowless ?? base.showWindowless,
-            currentSpaceOnly: ov.spaceScope.resolvedCurrentSpaceOnly ?? base.currentSpaceOnly,
+            spaceScope: ov.spaceScope.resolvedScope ?? base.spaceScope,
             sortOrder: ov.sortOrder ?? base.sortOrder
         )
     }
@@ -72,19 +72,19 @@ enum CatalogFilter {
     /// (cache-warm rows) are never filtered or reordered.
     static func filteredRows(_ rows: [SwitcherRow], _ cfg: Config) -> [SwitcherRow] {
         // Resolve Space membership once and share it across both Space-based
-        // filters so a reveal never queries the same window's Space twice. The
-        // current-Space filter needs every window's Space; the phantom filter
-        // only cares about off-screen windows, so when current-Space is off we
+        // filters so a reveal never queries the same window's Space twice. A
+        // narrowing Space scope needs every window's Space; the phantom filter
+        // only cares about off-screen windows, so under the all-Spaces scope we
         // resolve just those (see resolveSpaces).
         //
         // Gate the whole thing behind a pure, IPC-free precheck: a phantom can
         // only be dropped when some app has two or more window-bearing rows (the
         // never-shown helper always coexists with the app's real window — see
-        // phantomWindowOffsets). When that's impossible and current-Space is off,
-        // skip resolveSpaces entirely so a default-config reveal pays zero
-        // WindowServer round-trips on the ⌘Tab hot path.
+        // phantomWindowOffsets). When that's impossible and the scope is all
+        // Spaces, skip resolveSpaces entirely so a default-config reveal pays
+        // zero WindowServer round-trips on the ⌘Tab hot path.
         let spaces = needsSpaceResolution(rows, cfg)
-            ? resolveSpaces(rows, needsAllWindows: cfg.currentSpaceOnly)
+            ? resolveSpaces(rows, scope: cfg.spaceScope)
             : .unavailable
 
         // Drop Electron-style phantom windows first, unconditionally. These are
@@ -99,19 +99,19 @@ enum CatalogFilter {
             filtered = applySortOrder(filtered, cfg.sortOrder, name: { $0.appName }, pid: { $0.pid })
         }
         filtered = pinnedToFront(filtered, cfg.pinned)
-        if cfg.currentSpaceOnly {
-            filtered = filterToCurrentSpace(filtered, spaces)
+        if cfg.spaceScope != .allSpaces {
+            filtered = filterToAllowedSpaces(filtered, spaces)
         }
         return filtered
     }
 
-    /// Whether this reveal needs any WindowServer Space resolution. The
-    /// current-Space filter always does; otherwise it's needed only when a
+    /// Whether this reveal needs any WindowServer Space resolution. A narrowing
+    /// Space scope always does; otherwise it's needed only when a
     /// phantom could exist — i.e. some app has two or more window-bearing rows,
     /// since `phantomWindowOffsets` can never drop an app's lone window. Pure and
     /// IPC-free, so the common "nothing to drop" reveal skips `resolveSpaces`.
     static func needsSpaceResolution(_ rows: [SwitcherRow], _ cfg: Config) -> Bool {
-        cfg.currentSpaceOnly || hasMultiWindowApp(pids: rows.map { $0.cgWindowID != 0 ? $0.pid : nil })
+        cfg.spaceScope != .allSpaces || hasMultiWindowApp(pids: rows.map { $0.cgWindowID != 0 ? $0.pid : nil })
     }
 
     /// Pure core of `needsSpaceResolution`: true when any pid appears on two or
@@ -162,29 +162,42 @@ enum CatalogFilter {
     }
 
     /// Space membership resolved once per `filteredRows` call and shared by the
-    /// phantom filter and the current-Space filter, so neither re-queries
+    /// phantom filter and the Space-scope filter, so neither re-queries
     /// WindowServer for the same window. `spaceByWindow` maps each *resolved*
     /// window id to its single Space; `confirmedSpaceless` is the set of wids
     /// WindowServer positively reports as belonging to no Space (the phantom
     /// signal — never multi-Space/sticky or failed queries); `onScreen` is the
-    /// set of currently visible window ids; `activeSpace` is nil when the private
-    /// Space API is unavailable, in which case both filters no-op.
+    /// set of currently visible window ids; `allowedSpaces` is the set the
+    /// scope filter keeps (the focused Space, or every display's visible Space
+    /// — see `resolveSpaces`), and is empty when the private Space API is
+    /// unavailable, in which case both filters no-op.
     struct SpaceResolution {
         let spaceByWindow: [CGWindowID: UInt64]
         let confirmedSpaceless: Set<CGWindowID>
         let onScreen: Set<CGWindowID>
-        let activeSpace: UInt64?
+        let allowedSpaces: Set<UInt64>
 
         /// Space API unavailable — callers degrade to showing every window.
-        static let unavailable = SpaceResolution(spaceByWindow: [:], confirmedSpaceless: [], onScreen: [], activeSpace: nil)
+        static let unavailable = SpaceResolution(spaceByWindow: [:], confirmedSpaceless: [], onScreen: [], allowedSpaces: [])
     }
 
-    /// Resolve Space membership for `rows`. When `needsAllWindows` is true (the
-    /// current-Space filter is active) every window is queried; otherwise only
+    /// Resolve Space membership for `rows` under `scope`. A narrowing scope
+    /// (current/visible Spaces) queries every window; under `.allSpaces` only
     /// off-screen windows are — an on-screen window is by definition on a Space,
     /// so the phantom filter doesn't need it and we skip that per-window IPC.
-    static func resolveSpaces(_ rows: [SwitcherRow], needsAllWindows: Bool) -> SpaceResolution {
+    ///
+    /// `allowedSpaces` is the focused Space for `.currentSpace` (and
+    /// `.allSpaces`, where it only marks API availability), plus each display's
+    /// visible Space for `.visibleSpaces` (#57). The focused Space is always
+    /// included, so the visible-Spaces filter can never hide the Space the user
+    /// is looking at even if the display-spaces query comes back partial.
+    static func resolveSpaces(_ rows: [SwitcherRow], scope: SpaceScope) -> SpaceResolution {
         guard let active = PrivateAPI.activeSpace() else { return .unavailable }
+        var allowed: Set<UInt64> = [active]
+        if scope == .visibleSpaces {
+            allowed.formUnion(PrivateAPI.visibleSpaces())
+        }
+        let needsAllWindows = scope != .allSpaces
         let onScreen = onScreenWindowIDs()
         // Unique wids to resolve (browser-tab rows can share a parent wid).
         var wids = Set<CGWindowID>()
@@ -200,29 +213,30 @@ enum CatalogFilter {
             spaceByWindow: membership.resolved,
             confirmedSpaceless: membership.spaceless,
             onScreen: onScreen,
-            activeSpace: active
+            allowedSpaces: allowed
         )
     }
 
     /// Convenience for standalone callers outside the `filteredRows` pipeline
     /// (e.g. the windows-only scope path) that don't already hold a shared
-    /// `SpaceResolution`. Resolves every window's Space, then filters.
+    /// `SpaceResolution`. Resolves every window's Space, then filters to the
+    /// focused Space only.
     static func filterToCurrentSpace(_ rows: [SwitcherRow]) -> [SwitcherRow] {
-        filterToCurrentSpace(rows, resolveSpaces(rows, needsAllWindows: true))
+        filterToAllowedSpaces(rows, resolveSpaces(rows, scope: .currentSpace))
     }
 
-    /// Drop windows that live on a Space other than the one in focus. Rows
+    /// Drop windows that live on a Space outside `allowedSpaces`. Rows
     /// without a real window (windowless apps, launchables, recents) and any
     /// window whose Space can't be resolved — including multi-Space (All
     /// Desktops / sticky) windows, which `PrivateAPI.spaceMembership(forWindows:)`
     /// leaves unresolved — are kept, so the filter only ever hides windows it's
     /// certain are elsewhere. Reads Space membership from the shared
     /// `SpaceResolution`; degrades to a no-op when it's unavailable.
-    static func filterToCurrentSpace(_ rows: [SwitcherRow], _ spaces: SpaceResolution) -> [SwitcherRow] {
-        guard let active = spaces.activeSpace, !spaces.spaceByWindow.isEmpty else { return rows }
+    static func filterToAllowedSpaces(_ rows: [SwitcherRow], _ spaces: SpaceResolution) -> [SwitcherRow] {
+        guard !spaces.allowedSpaces.isEmpty, !spaces.spaceByWindow.isEmpty else { return rows }
         var dropOffsets = Set<Int>()
         for (offset, row) in rows.enumerated() where row.cgWindowID != 0 {
-            if let space = spaces.spaceByWindow[row.cgWindowID], space != active {
+            if let space = spaces.spaceByWindow[row.cgWindowID], !spaces.allowedSpaces.contains(space) {
                 dropOffsets.insert(offset)
             }
         }
@@ -259,7 +273,7 @@ enum CatalogFilter {
     /// Reads Space membership from the shared `SpaceResolution`; degrades to a
     /// no-op when it's unavailable.
     static func filterPhantomWindows(_ rows: [SwitcherRow], _ spaces: SpaceResolution) -> [SwitcherRow] {
-        guard spaces.activeSpace != nil else { return rows }
+        guard !spaces.allowedSpaces.isEmpty else { return rows }
 
         // Every window-bearing row tagged with whether WindowServer currently
         // shows it and whether it's minimized. The wid is the one captured at

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -4624,34 +4624,6 @@
         }
       }
     },
-    "Only current Space" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur aktueller Space"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solo el espacio actual"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Espace actuel uniquement"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tylko bieżące biurko"
-          }
-        }
-      }
-    },
     "Open Accessibility Settings" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6729,34 +6701,6 @@
         }
       }
     },
-    "Show only windows on the Space you're currently viewing." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeigt nur Fenster auf dem Space an, den du gerade anzeigst."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra solo las ventanas del espacio que estás viendo actualmente."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affiche uniquement les fenêtres de l’espace que vous consultez actuellement."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokazuj tylko okna na biurku, które aktualnie oglądasz."
-          }
-        }
-      }
-    },
     "Show recently closed apps" : {
       "localizations" : {
         "de" : {
@@ -8601,6 +8545,174 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Powiększ okno"
+          }
+        }
+      }
+    },
+    "All Spaces" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Spaces"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los espacios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les espaces"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wszystkie biurka"
+          }
+        }
+      }
+    },
+    "Current Space" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktueller Space"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espacio actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace actuel"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bieżące biurko"
+          }
+        }
+      }
+    },
+    "Visible Spaces" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichtbare Spaces"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espacios visibles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaces visibles"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widoczne biurka"
+          }
+        }
+      }
+    },
+    "Show windows from" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster anzeigen von"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar ventanas de"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les fenêtres de"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuj okna z"
+          }
+        }
+      }
+    },
+    "All Spaces shows everything; Current Space only the Space you're viewing; Visible Spaces what's on screen across all your displays." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Alle Spaces“ zeigt alles; „Aktueller Space“ nur den Space, den du gerade siehst; „Sichtbare Spaces“ das, was auf all deinen Bildschirmen zu sehen ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Todos los espacios» muestra todo; «Espacio actual» solo el espacio que estás viendo; «Espacios visibles» lo que se ve en todas tus pantallas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "« Tous les espaces » affiche tout ; « Espace actuel » uniquement l'espace affiché ; « Espaces visibles » ce qui est à l'écran sur tous vos moniteurs."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Wszystkie biurka” pokazuje wszystko; „Bieżące biurko” tylko biurko, które właśnie widzisz; „Widoczne biurka” to, co widać na wszystkich monitorach."
+          }
+        }
+      }
+    },
+    "Limit this shortcut to the current Space, every visible Space, or show every Space." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beschränke diesen Kurzbefehl auf den aktuellen Space, alle sichtbaren Spaces oder zeige jeden Space."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita este atajo al espacio actual o a los espacios visibles, o muestra todos los espacios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limitez ce raccourci à l'espace actuel ou aux espaces visibles, ou affichez tous les espaces."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogranicz ten skrót do bieżącego biurka lub widocznych biurek, albo pokazuj wszystkie biurka."
           }
         }
       }

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -84,7 +84,7 @@ enum SearchID {
     static let showWindowless = "switcher.showWindowless"
     static let applicationsOnly = "switcher.applicationsOnly"
     static let showBadges = "switcher.showBadges"
-    static let currentSpaceOnly = "switcher.currentSpaceOnly"
+    static let spaceScope = "switcher.spaceScope"
     static let sortOrder = "switcher.sortOrder"
     static let showRecentlyClosed = "switcher.showRecentlyClosed"
     static let recentlyClosedLimit = "switcher.recentlyClosedLimit"
@@ -355,8 +355,8 @@ enum SettingsCatalog {
              ["applications only", "apps only", "one per app", "per app", "command tab", "classic", "group windows"]),
         item(SearchID.showBadges, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
              String(localized: "Show unread badges"), ["badge", "unread", "dock badge", "count"]),
-        item(SearchID.currentSpaceOnly, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
-             String(localized: "Only current Space"), ["space", "current space", "desktop", "filter"]),
+        item(SearchID.spaceScope, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
+             String(localized: "Show windows from"), ["space", "current space", "visible spaces", "desktop", "display", "monitor", "filter"]),
         item(SearchID.sortOrder, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
              String(localized: "Sort order"), ["sort", "order", "mru", "most recent", "alphabetical", "launch order", "windows", "window recency"]),
         item(SearchID.showRecentlyClosed, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),

--- a/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
+++ b/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
@@ -56,8 +56,8 @@ final class ShortcutOptionsFormView: NSView {
         let behavior = SettingsSectionView(title: String(localized: "Behavior"))
         if includeSpaceScope {
             addEnumRow(to: behavior, title: String(localized: "Spaces"),
-                       subtitle: String(localized: "Limit this shortcut to the current Space, or show every Space."),
-                       options: [.currentSpace, .allSpaces] as [SpaceScopeOverride],
+                       subtitle: String(localized: "Limit this shortcut to the current Space, every visible Space, or show every Space."),
+                       options: [.currentSpace, .visibleSpaces, .allSpaces] as [SpaceScopeOverride],
                        display: { $0.displayName },
                        current: override.spaceScope == .inherit ? nil : override.spaceScope) { [weak self] in
                 self?.override.spaceScope = $0 ?? .inherit; self?.persist()

--- a/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
+++ b/BetterCmdTab/Settings/SwitcherSettingsViewController.swift
@@ -20,7 +20,8 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
     private let windowlessSwitch = NSSwitch()
     private let applicationsOnlySwitch = NSSwitch()
     private let badgesSwitch = NSSwitch()
-    private let currentSpaceSwitch = NSSwitch()
+    private let spaceScopePopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let spaceScopes: [SpaceScope] = SpaceScope.allCases
     private let recentlyClosedSwitch = NSSwitch()
     private let recentlyClosedLimitPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let recentlyClosedLimits: [Int] = [3, 5, 10, 15, 20]
@@ -97,10 +98,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         addRow(to: contents, title: String(localized: "Show unread badges"),
                subtitle: String(localized: "Show each app's Dock badge count (e.g. Mail's unread mail) on its row."),
                accessory: badgesSwitch, searchItemID: SearchID.showBadges)
-        configureSwitch(currentSpaceSwitch, action: #selector(toggleCurrentSpace(_:)))
-        addRow(to: contents, title: String(localized: "Only current Space"),
-               subtitle: String(localized: "Show only windows on the Space you're currently viewing."),
-               accessory: currentSpaceSwitch, searchItemID: SearchID.currentSpaceOnly)
+        configurePopup(spaceScopePopup, titles: spaceScopes.map(\.displayName), action: #selector(spaceScopeChanged))
+        addRow(to: contents, title: String(localized: "Show windows from"),
+               subtitle: String(localized: "All Spaces shows everything; Current Space only the Space you're viewing; Visible Spaces what's on screen across all your displays."),
+               accessory: spaceScopePopup, searchItemID: SearchID.spaceScope)
         configurePopup(sortOrderPopup, titles: sortOrders.map(\.displayName), action: #selector(sortOrderChanged))
         addRow(to: contents, title: String(localized: "Sort order"),
                subtitle: String(localized: "Most recent keeps the classic ⌘Tab order; Most recent (windows) interleaves windows from all apps by last focus; the others stay put as you switch."),
@@ -274,7 +275,7 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         windowlessSwitch.state = prefs.showWindowlessApps ? .on : .off
         applicationsOnlySwitch.state = prefs.applicationsOnly ? .on : .off
         badgesSwitch.state = prefs.showUnreadBadges ? .on : .off
-        currentSpaceSwitch.state = prefs.currentSpaceOnly ? .on : .off
+        if let i = spaceScopes.firstIndex(of: prefs.spaceScope) { spaceScopePopup.selectItem(at: i) }
         selectSortOrder(prefs.sortOrder)
         recentlyClosedSwitch.state = prefs.showRecentlyClosed ? .on : .off
         selectRecentlyClosedLimit(prefs.recentlyClosedLimit)
@@ -485,8 +486,10 @@ final class SwitcherSettingsViewController: SettingsTabViewController {
         Preferences.shared.showUnreadBadges = (sender.state == .on)
     }
 
-    @objc private func toggleCurrentSpace(_ sender: NSSwitch) {
-        Preferences.shared.currentSpaceOnly = (sender.state == .on)
+    @objc private func spaceScopeChanged() {
+        let idx = spaceScopePopup.indexOfSelectedItem
+        guard spaceScopes.indices.contains(idx) else { return }
+        Preferences.shared.spaceScope = spaceScopes[idx]
     }
 
     @objc private func sortOrderChanged() {

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1732,10 +1732,10 @@ final class SwitcherController: SwitcherViewDelegate {
     }
 
     /// Filter `rows` to the active scope. Operates on already content-filtered
-    /// rows (the user's hide/minimized/space toggles still apply); the scope
-    /// narrows further. `.allAppsAllSpaces` only escapes the current-Space
-    /// toggle when that toggle is off (the cache already dropped other-Space
-    /// windows otherwise — documented edge case).
+    /// rows (the user's hide/minimized/Space-scope settings still apply); the
+    /// scope narrows further. `.allAppsAllSpaces` only escapes the global
+    /// Space scope when that scope is "all Spaces" (the cache already dropped
+    /// out-of-scope windows otherwise — documented edge case).
     private func scopeFiltered(_ rows: [SwitcherRow], scope: SwitchScope) -> [SwitcherRow] {
         let windowed = rows.filter { $0.window != nil }
         let filtered: [SwitcherRow]

--- a/BetterCmdTab/System/PrivateAPIs.swift
+++ b/BetterCmdTab/System/PrivateAPIs.swift
@@ -133,6 +133,25 @@ enum PrivateAPI {
         return space == 0 ? nil : space
     }
 
+    /// The Spaces currently on screen: each display's "Current Space" from
+    /// `CGSCopyManagedDisplaySpaces` (#57 — the "visible Spaces" switcher
+    /// filter). One id per connected display; a single-monitor setup yields the
+    /// same id as `activeSpace()`. Empty when the private API is unavailable —
+    /// callers must treat that as "unknown" and degrade, same as a nil
+    /// `activeSpace()`. One CGS round-trip, no per-window IPC.
+    static func visibleSpaces() -> Set<UInt64> {
+        guard let mainConnection = mainConnectionFn,
+              let copyDisplays = copyManagedDisplaySpacesFn,
+              let cfDisplays = copyDisplays(mainConnection())?.takeRetainedValue() else { return [] }
+        var spaces = Set<UInt64>()
+        for display in (cfDisplays as NSArray).compactMap({ $0 as? [String: Any] }) {
+            if let current = display["Current Space"] as? [String: Any], let id = spaceId(current) {
+                spaces.insert(id)
+            }
+        }
+        return spaces
+    }
+
     /// The CoreGraphics display id of the monitor whose menu bar is currently
     /// active (the bright one) — i.e. the display the user is working on. This is
     /// the *focused* display: it follows keyboard focus / the frontmost window,

--- a/BetterCmdTabTests/CatalogFilterTests.swift
+++ b/BetterCmdTabTests/CatalogFilterTests.swift
@@ -13,10 +13,10 @@ struct CatalogFilterTests {
         showMinimized: Bool = true,
         showHidden: Bool = true,
         showWindowless: Bool = true,
-        currentSpaceOnly: Bool = false,
+        spaceScope: SpaceScope = .allSpaces,
         sortOrder: SwitcherSortOrder = .mru
     ) -> CatalogFilter.Config {
-        CatalogFilter.Config(hideModes: hideModes, pinned: pinned, showMinimized: showMinimized, showHidden: showHidden, showWindowless: showWindowless, currentSpaceOnly: currentSpaceOnly, sortOrder: sortOrder)
+        CatalogFilter.Config(hideModes: hideModes, pinned: pinned, showMinimized: showMinimized, showHidden: showHidden, showWindowless: showWindowless, spaceScope: spaceScope, sortOrder: sortOrder)
     }
 
     // MARK: - isIdentity
@@ -29,6 +29,8 @@ struct CatalogFilterTests {
         #expect(!config(showMinimized: false).isIdentity)
         #expect(!config(showHidden: false).isIdentity)
         #expect(!config(showWindowless: false).isIdentity)
+        #expect(!config(spaceScope: .currentSpace).isIdentity)
+        #expect(!config(spaceScope: .visibleSpaces).isIdentity)
         #expect(!config(sortOrder: .alphabetical).isIdentity)
         #expect(!config(sortOrder: .launchOrder).isIdentity)
         // .mruWindows is not identity: the full filter path must run so the
@@ -325,16 +327,17 @@ struct CatalogFilterTests {
         #expect(!CatalogFilter.hasMultiWindowApp(pids: []))
     }
 
-    @Test("current-Space-only forces resolution; otherwise empty/windowless rows skip it")
+    @Test("a narrowing Space scope forces resolution; otherwise empty/windowless rows skip it")
     func needsSpaceResolutionGate() {
-        #expect(CatalogFilter.needsSpaceResolution([], config(currentSpaceOnly: true)))
+        #expect(CatalogFilter.needsSpaceResolution([], config(spaceScope: .currentSpace)))
+        #expect(CatalogFilter.needsSpaceResolution([], config(spaceScope: .visibleSpaces)))
         #expect(!CatalogFilter.needsSpaceResolution([], config()))
         // Launchable rows carry cgWindowID 0 → never counted, so the IPC sweep is
         // skipped even with two rows sharing nothing.
         #expect(!CatalogFilter.needsSpaceResolution([launchRow("com.a"), launchRow("com.b")], config()))
     }
 
-    // MARK: - filterToCurrentSpace (cached-wid path) + degrade
+    // MARK: - filterToAllowedSpaces (cached-wid path) + degrade
 
     /// A window-bearing row for the current process carrying an explicit wid.
     /// Only `cgWindowID` is read by the Space filters; `window` can be nil.
@@ -342,35 +345,45 @@ struct CatalogFilterTests {
         SwitcherRow(app: .current, window: nil, windowTitle: "", isMinimized: false, cgWindowID: wid)
     }
 
-    private func resolution(spaceByWindow: [CGWindowID: UInt64], activeSpace: UInt64?) -> CatalogFilter.SpaceResolution {
-        CatalogFilter.SpaceResolution(spaceByWindow: spaceByWindow, confirmedSpaceless: [], onScreen: [], activeSpace: activeSpace)
+    private func resolution(spaceByWindow: [CGWindowID: UInt64], allowedSpaces: Set<UInt64>) -> CatalogFilter.SpaceResolution {
+        CatalogFilter.SpaceResolution(spaceByWindow: spaceByWindow, confirmedSpaceless: [], onScreen: [], allowedSpaces: allowedSpaces)
     }
 
     @Test("current-Space filter drops a window on another Space, keeps active-Space")
     func currentSpaceDropsOtherSpace() {
         let active: UInt64 = 100
         let rows = [spaceRow(10), spaceRow(20)]   // 10 on active space, 20 elsewhere
-        let res = resolution(spaceByWindow: [10: active, 20: 200], activeSpace: active)
-        let kept = CatalogFilter.filterToCurrentSpace(rows, res)
+        let res = resolution(spaceByWindow: [10: active, 20: 200], allowedSpaces: [active])
+        let kept = CatalogFilter.filterToAllowedSpaces(rows, res)
         #expect(kept.map(\.cgWindowID) == [10])
     }
 
-    @Test("current-Space filter keeps rows whose wid didn't resolve")
+    @Test("visible-Spaces filter keeps each display's on-screen Space, drops the rest")
+    func visibleSpacesKeepsEveryDisplaysSpace() {
+        // Two displays: active Space 100 (display 1) and visible Space 300
+        // (display 2); Space 200 is a background Space of display 1 (#57).
+        let rows = [spaceRow(10), spaceRow(20), spaceRow(30)]
+        let res = resolution(spaceByWindow: [10: 100, 20: 200, 30: 300], allowedSpaces: [100, 300])
+        let kept = CatalogFilter.filterToAllowedSpaces(rows, res)
+        #expect(kept.map(\.cgWindowID) == [10, 30])
+    }
+
+    @Test("Space filter keeps rows whose wid didn't resolve")
     func currentSpaceKeepsUnresolved() {
         let active: UInt64 = 100
         let rows = [spaceRow(10), spaceRow(20)]   // 20 absent from the map
-        let res = resolution(spaceByWindow: [10: 200], activeSpace: active)
+        let res = resolution(spaceByWindow: [10: 200], allowedSpaces: [active])
         // 10 resolves to another space → dropped; 20 unresolved → kept.
-        let kept = CatalogFilter.filterToCurrentSpace(rows, res)
+        let kept = CatalogFilter.filterToAllowedSpaces(rows, res)
         #expect(kept.map(\.cgWindowID) == [20])
     }
 
-    @Test("current-Space filter keeps wid-0 (windowless) rows regardless")
+    @Test("Space filter keeps wid-0 (windowless) rows regardless")
     func currentSpaceKeepsWindowlessRows() {
         let active: UInt64 = 100
         let rows = [spaceRow(10), launchRow("com.a")]   // launchRow carries wid 0
-        let res = resolution(spaceByWindow: [10: 200], activeSpace: active)
-        let kept = CatalogFilter.filterToCurrentSpace(rows, res)
+        let res = resolution(spaceByWindow: [10: 200], allowedSpaces: [active])
+        let kept = CatalogFilter.filterToAllowedSpaces(rows, res)
         #expect(kept.contains { $0.isLaunchable })       // wid-0 row always kept
         #expect(!kept.contains { $0.cgWindowID == 10 })  // other-space window dropped
     }
@@ -378,7 +391,7 @@ struct CatalogFilterTests {
     @Test("both Space filters no-op on the unavailable resolution")
     func unavailableResolutionDegradesToNoOp() {
         let rows = [spaceRow(10), spaceRow(20)]
-        #expect(CatalogFilter.filterToCurrentSpace(rows, .unavailable).count == 2)
+        #expect(CatalogFilter.filterToAllowedSpaces(rows, .unavailable).count == 2)
         #expect(CatalogFilter.filterPhantomWindows(rows, .unavailable).count == 2)
     }
 }

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -6,6 +6,30 @@ import Testing
 @Suite("Preferences enums")
 struct PreferencesEnumTests {
 
+    @Test("storedSpaceScope prefers the enum key, falls back to the legacy bool")
+    func storedSpaceScopeMigration() throws {
+        let defaults = try #require(UserDefaults(suiteName: "storedSpaceScopeMigrationTests"))
+        defer { defaults.removePersistentDomain(forName: "storedSpaceScopeMigrationTests") }
+
+        // Fresh install: neither key → all Spaces.
+        #expect(Preferences.storedSpaceScope(defaults) == .allSpaces)
+
+        // Legacy bool only (pre-#57 upgrade / old settings import).
+        defaults.set(true, forKey: Preferences.Keys.currentSpaceOnly)
+        #expect(Preferences.storedSpaceScope(defaults) == .currentSpace)
+        defaults.set(false, forKey: Preferences.Keys.currentSpaceOnly)
+        #expect(Preferences.storedSpaceScope(defaults) == .allSpaces)
+
+        // Enum key wins over a contradicting legacy bool.
+        defaults.set(true, forKey: Preferences.Keys.currentSpaceOnly)
+        defaults.set(SpaceScope.visibleSpaces.rawValue, forKey: Preferences.Keys.spaceScope)
+        #expect(Preferences.storedSpaceScope(defaults) == .visibleSpaces)
+
+        // Garbage enum value falls back to the legacy bool.
+        defaults.set("bogus", forKey: Preferences.Keys.spaceScope)
+        #expect(Preferences.storedSpaceScope(defaults) == .currentSpace)
+    }
+
     @Test("PanelSize scale ordering: small < standard < large")
     func panelSizeOrdering() {
         // Scale remap (2026-05-28): small=1.0, standard=1.2, large=1.5.

--- a/BetterCmdTabTests/SettingsPortabilityTests.swift
+++ b/BetterCmdTabTests/SettingsPortabilityTests.swift
@@ -62,6 +62,41 @@ struct SettingsPortabilityTests {
         #expect(prefs.pinnedBundleIDs == ["com.apple.finder", "com.apple.Safari"])
     }
 
+    @Test("pre-#57 import (legacy currentSpaceOnly bool, no spaceScope) applies through the fallback")
+    func legacySpaceScopeImport() throws {
+        let prefs = Preferences.shared
+        let saved = prefs.spaceScope
+        defer {
+            try? prefs.importSettings(from: envelope([
+                Preferences.Keys.spaceScope: saved.rawValue,
+                Preferences.Keys.currentSpaceOnly: saved == .currentSpace,
+            ]))
+        }
+
+        // Local state has the new enum key set to a non-legacy value…
+        prefs.spaceScope = .visibleSpaces
+        // …then an old export carrying only the legacy bool is imported. The
+        // stale local enum key must not shadow the imported bool.
+        try prefs.importSettings(from: envelope([
+            Preferences.Keys.currentSpaceOnly: true
+        ]))
+        #expect(prefs.spaceScope == .currentSpace)
+
+        // Same with the bool off → all Spaces.
+        prefs.spaceScope = .visibleSpaces
+        try prefs.importSettings(from: envelope([
+            Preferences.Keys.currentSpaceOnly: false
+        ]))
+        #expect(prefs.spaceScope == .allSpaces)
+
+        // A new-format export carries both keys; the enum wins.
+        try prefs.importSettings(from: envelope([
+            Preferences.Keys.spaceScope: SpaceScope.visibleSpaces.rawValue,
+            Preferences.Keys.currentSpaceOnly: false,
+        ]))
+        #expect(prefs.spaceScope == .visibleSpaces)
+    }
+
     @Test("round-trip: switcherDisplayMode survives export/import")
     func displayModeRoundTrip() throws {
         let prefs = Preferences.shared

--- a/BetterCmdTabTests/ShortcutOverrideTests.swift
+++ b/BetterCmdTabTests/ShortcutOverrideTests.swift
@@ -66,11 +66,12 @@ struct ShortcutOverrideTests {
 
     // MARK: - SpaceScopeOverride
 
-    @Test("space-scope override maps to currentSpaceOnly")
+    @Test("space-scope override maps to the concrete SpaceScope")
     func spaceScopeMapping() {
-        #expect(SpaceScopeOverride.inherit.resolvedCurrentSpaceOnly == nil)
-        #expect(SpaceScopeOverride.currentSpace.resolvedCurrentSpaceOnly == true)
-        #expect(SpaceScopeOverride.allSpaces.resolvedCurrentSpaceOnly == false)
+        #expect(SpaceScopeOverride.inherit.resolvedScope == nil)
+        #expect(SpaceScopeOverride.currentSpace.resolvedScope == .currentSpace)
+        #expect(SpaceScopeOverride.allSpaces.resolvedScope == .allSpaces)
+        #expect(SpaceScopeOverride.visibleSpaces.resolvedScope == .visibleSpaces)
     }
 
     // MARK: - ShortcutOverride dictionary round-trip
@@ -134,7 +135,7 @@ struct ShortcutOverrideTests {
 
     private func baseConfig(
         showMinimized: Bool = true,
-        currentSpaceOnly: Bool = false,
+        spaceScope: SpaceScope = .allSpaces,
         sortOrder: SwitcherSortOrder = .mru
     ) -> CatalogFilter.Config {
         CatalogFilter.Config(
@@ -143,7 +144,7 @@ struct ShortcutOverrideTests {
             showMinimized: showMinimized,
             showHidden: true,
             showWindowless: true,
-            currentSpaceOnly: currentSpaceOnly,
+            spaceScope: spaceScope,
             sortOrder: sortOrder
         )
     }
@@ -152,19 +153,21 @@ struct ShortcutOverrideTests {
     func overlayEmpty() {
         let base = baseConfig()
         let result = CatalogFilter.overlay(base, ShortcutOverride())
-        #expect(result.currentSpaceOnly == base.currentSpaceOnly)
+        #expect(result.spaceScope == base.spaceScope)
         #expect(result.showMinimized == base.showMinimized)
         #expect(result.sortOrder == base.sortOrder)
         #expect(result.hideModes == base.hideModes)
         #expect(result.pinned == base.pinned)
     }
 
-    @Test("space-scope override forces currentSpaceOnly either way")
+    @Test("space-scope override forces the scope in any direction")
     func overlaySpaceScope() {
         var toCurrent = ShortcutOverride(); toCurrent.spaceScope = .currentSpace
-        #expect(CatalogFilter.overlay(baseConfig(currentSpaceOnly: false), toCurrent).currentSpaceOnly == true)
+        #expect(CatalogFilter.overlay(baseConfig(spaceScope: .allSpaces), toCurrent).spaceScope == .currentSpace)
         var toAll = ShortcutOverride(); toAll.spaceScope = .allSpaces
-        #expect(CatalogFilter.overlay(baseConfig(currentSpaceOnly: true), toAll).currentSpaceOnly == false)
+        #expect(CatalogFilter.overlay(baseConfig(spaceScope: .currentSpace), toAll).spaceScope == .allSpaces)
+        var toVisible = ShortcutOverride(); toVisible.spaceScope = .visibleSpaces
+        #expect(CatalogFilter.overlay(baseConfig(spaceScope: .allSpaces), toVisible).spaceScope == .visibleSpaces)
     }
 
     @Test("behavioral fields override when set and inherit when nil")
@@ -183,7 +186,7 @@ struct ShortcutOverrideTests {
 
     @Test("overlaying an empty override preserves an identity config")
     func overlayKeepsIdentity() {
-        let identity = CatalogFilter.Config(hideModes: [:], pinned: [], showMinimized: true, showHidden: true, showWindowless: true, currentSpaceOnly: false, sortOrder: .mru)
+        let identity = CatalogFilter.Config(hideModes: [:], pinned: [], showMinimized: true, showHidden: true, showWindowless: true, spaceScope: .allSpaces, sortOrder: .mru)
         #expect(identity.isIdentity)
         #expect(CatalogFilter.overlay(identity, ShortcutOverride()).isIdentity)
     }


### PR DESCRIPTION
## Summary

Adds the option requested in #57: show apps/windows from all **visible** Spaces — the Space each display is currently showing — instead of only the single focused Space or every Space.

- New three-way scope replacing the "Only current Space" checkbox: **All Spaces / Current Space / Visible Spaces**, as a "Show windows from" popup in Switcher → Contents.
- Visible Spaces resolves each display's on-screen Space via `CGSCopyManagedDisplaySpaces` — one CGS round-trip, no extra per-window IPC. The focused Space is always kept, so a partial query can never hide what the user is looking at.
- Per-shortcut Space override (#74) gains a "Visible Spaces" option.
- Migration: the legacy `Switcher.currentSpaceOnly` bool remains the fallback and is written in sync with the new enum key, so pre-existing settings, old exports, and older builds stay coherent; importing a pre-#57 `.cmdtab` file clears a stale enum key so the imported bool applies.
- Hot path unchanged: the default config (All Spaces, no phantom candidates) still skips Space resolution entirely.
- New strings localized (de/es/fr/pl); stale catalog entries removed.

## Tests

- `filterToAllowedSpaces` keeps each display's visible Space, drops background Spaces, keeps unresolved/sticky and wid-0 rows, no-ops when the private API is unavailable.
- `storedSpaceScope` migration matrix (enum key wins, legacy bool fallback, garbage value).
- Settings-portability round-trips incl. pre-#57 import shim.
- Shortcut-override mapping/overlay for the new case.

Full suite: 364/364 pass. UI verified paths need a live WindowServer — manual check: two displays with "Displays have separate Spaces", scope set to Visible Spaces, switcher lists windows from both on-screen Spaces and omits background ones.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)