### PR TITLE
[codex] add window shortcut reverse app stepping

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -739,6 +739,7 @@ final class Preferences: ObservableObject {
         static let hideFromScreenSharing = "Switcher.hideFromScreenSharing"
         static let vimNavigationEnabled = "Switcher.vimNavigationEnabled"
         static let shiftTapStepsBackward = "Switcher.shiftTapStepsBackward"
+        static let backtickReversesAppSwitching = "Switcher.backtickReversesAppSwitching"
         static let switcherDisplayMode = "Switcher.displayMode"
         static let previewTitleAlignment = "Switcher.previewTitleAlignment"
         static let boldSelectedLabel = "Switcher.boldSelectedLabel"
@@ -1086,6 +1087,17 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != shiftTapStepsBackward else { return }
             UserDefaults.standard.set(shiftTapStepsBackward, forKey: Keys.shiftTapStepsBackward)
+        }
+    }
+
+    /// While an app-switch session is already open, treat the window-switch key
+    /// (`⌘`` by default) as a backwards app step. Default off so the shortcut
+    /// keeps its existing window-switch meaning unless the user opts into
+    /// native-like app-switcher reverse navigation.
+    @Published var backtickReversesAppSwitching: Bool {
+        didSet {
+            guard oldValue != backtickReversesAppSwitching else { return }
+            UserDefaults.standard.set(backtickReversesAppSwitching, forKey: Keys.backtickReversesAppSwitching)
         }
     }
 
@@ -1666,6 +1678,7 @@ final class Preferences: ObservableObject {
         self.clickOutsideToDismiss = defaults.object(forKey: Keys.clickOutsideToDismiss) as? Bool ?? true
         self.vimNavigationEnabled = defaults.object(forKey: Keys.vimNavigationEnabled) as? Bool ?? false
         self.shiftTapStepsBackward = defaults.object(forKey: Keys.shiftTapStepsBackward) as? Bool ?? true
+        self.backtickReversesAppSwitching = defaults.object(forKey: Keys.backtickReversesAppSwitching) as? Bool ?? false
         self.cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false
         self.experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
         self.tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
@@ -1788,6 +1801,7 @@ final class Preferences: ObservableObject {
         clickOutsideToDismiss = defaults.object(forKey: Keys.clickOutsideToDismiss) as? Bool ?? true
         vimNavigationEnabled = defaults.object(forKey: Keys.vimNavigationEnabled) as? Bool ?? false
         shiftTapStepsBackward = defaults.object(forKey: Keys.shiftTapStepsBackward) as? Bool ?? true
+        backtickReversesAppSwitching = defaults.object(forKey: Keys.backtickReversesAppSwitching) as? Bool ?? false
         mouseHoverSelectionEnabled = defaults.object(forKey: Keys.mouseHoverSelectionEnabled) as? Bool ?? true
         mouseClickSelectionEnabled = defaults.object(forKey: Keys.mouseClickSelectionEnabled) as? Bool ?? true
         cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -8157,6 +8157,11 @@
         }
       }
     },
+    "Use window-switch shortcut to step backwards" : {
+      "localizations" : {
+
+      }
+    },
     "v%@  ·  Build %@" : {
       "localizations" : {
         "de" : {
@@ -8351,6 +8356,11 @@
             "value" : "Gdy ten program pojawia się w przełączniku"
           }
         }
+      }
+    },
+    "While the app switcher is open, press your window-switch shortcut (⌘` by default) to move backwards through apps. Opening the switcher with that shortcut still cycles windows." : {
+      "localizations" : {
+
       }
     },
     "While the switcher is open, a tap of the Shift key steps the selection backwards and holding Shift keeps stepping back until you let go — just like a held Tab. Turn this off to step back only with Shift held as you press the switch key (⌘⇧Tab)." : {

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -48,6 +48,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
     // Keyboard
     private let stayOpenSwitch = NSSwitch()
     private let shiftTapBackSwitch = NSSwitch()
+    private let backtickReverseSwitch = NSSwitch()
     private let vimNavSwitch = NSSwitch()
 
     // Mouse
@@ -231,6 +232,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         addRow(to: keyboard, title: String(localized: "Tap Shift to step backwards"),
                subtitle: String(localized: "While the switcher is open, a tap of the Shift key steps the selection backwards and holding Shift keeps stepping back until you let go — just like a held Tab. Turn this off to step back only with Shift held as you press the switch key (⌘⇧Tab)."),
                accessory: shiftTapBackSwitch, searchItemID: SearchID.shiftTapBack)
+        configureSwitch(backtickReverseSwitch, action: #selector(toggleBacktickReverse(_:)))
+        addRow(to: keyboard, title: String(localized: "Use window-switch shortcut to step backwards"),
+               subtitle: String(localized: "While the app switcher is open, press your window-switch shortcut (⌘` by default) to move backwards through apps. Opening the switcher with that shortcut still cycles windows."),
+               accessory: backtickReverseSwitch, searchItemID: SearchID.backtickReverse)
         configureSwitch(vimNavSwitch, action: #selector(toggleVimNavigation(_:)))
         addRow(to: keyboard, title: String(localized: "Vim keys (h j k l)"),
                subtitle: String(localized: "Use h / j / k / l like the arrow keys while the switcher is open. h overrides the Hide binding and j / k / l override letter-jump; search mode still types those letters."),
@@ -327,6 +332,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         selectSearchMode(prefs.searchDismissMode)
         stayOpenSwitch.state = prefs.stayOpenOnRelease ? .on : .off
         shiftTapBackSwitch.state = prefs.shiftTapStepsBackward ? .on : .off
+        backtickReverseSwitch.state = prefs.backtickReversesAppSwitching ? .on : .off
         scrollSwitch.state = prefs.scrollToSwitch ? .on : .off
         scrollReverseSwitch.state = prefs.scrollReverseDirection ? .on : .off
         scrollReverseSwitch.isEnabled = prefs.scrollToSwitch
@@ -436,6 +442,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleShiftTapBack(_ sender: NSSwitch) {
         Preferences.shared.shiftTapStepsBackward = (sender.state == .on)
+    }
+
+    @objc private func toggleBacktickReverse(_ sender: NSSwitch) {
+        Preferences.shared.backtickReversesAppSwitching = (sender.state == .on)
     }
 
     @objc private func toggleScroll(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -104,6 +104,7 @@ enum SearchID {
     static let searchMode = "switcher.searchMode"
     static let letterChainTimeout = "switcher.letterChainTimeout"
     static let shiftTapBack = "switcher.shiftTapBack"
+    static let backtickReverse = "switcher.backtickReverse"
     static let scroll = "switcher.scroll"
     static let scrollReverse = "switcher.scrollReverse"
     static let clickDismiss = "switcher.clickDismiss"
@@ -307,6 +308,8 @@ enum SettingsCatalog {
              String(localized: "Stay open after releasing the modifier"), ["stay open", "sticky", "release", "modifier", "keep open", "hold"]),
         item(SearchID.shiftTapBack, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),
              String(localized: "Tap Shift to step backwards"), ["shift", "backwards", "back", "reverse", "tap shift", "cmd shift tab", "windows"]),
+        item(SearchID.backtickReverse, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),
+             String(localized: "Use window-switch shortcut to step backwards"), ["backtick", "tilde", "cmd backtick", "command backtick", "window shortcut", "reverse", "backwards", "native"]),
         item(SearchID.vimNavigation, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),
              String(localized: "Vim keys (h j k l)"), ["vim", "hjkl", "h j k l", "keyboard", "arrows", "navigation"]),
         // Behavior · Mouse

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -26,6 +26,12 @@ final class SwitcherController: SwitcherViewDelegate {
         var isPrimed: Bool { self == .primed }
     }
 
+    enum SwitchSessionKind {
+        case none
+        case appSwitching
+        case windowSwitching
+    }
+
     private let hotkey = HotkeyTap()
     /// Secure-input-immune fallback trigger (see CarbonHotkeyTrigger). Opens and
     /// steps the switcher via a Carbon hot key when the tap is bypassed because
@@ -79,6 +85,7 @@ final class SwitcherController: SwitcherViewDelegate {
     private let view: SwitcherView
 
     private var _phase: Phase = .idle
+    private var switchSessionKind: SwitchSessionKind = .none
     private var primedApps: [NSRunningApplication] = []
     private var primedIndex: Int = 0
     /// Net number of primed ⌘Tab steps (forward positive, backward negative).
@@ -848,6 +855,7 @@ final class SwitcherController: SwitcherViewDelegate {
             primedIndex = primedApps.count == 1 ? 0 : (delta > 0 ? 1 : primedApps.count - 1)
             primedStepDelta = primedApps.count == 1 ? 0 : (delta > 0 ? 1 : -1)
             primedByHeldChord = false
+            switchSessionKind = .none
             phase = .primed
             reveal()
             // After reveal lands the panel in `.visible`, detach from any
@@ -1657,6 +1665,7 @@ final class SwitcherController: SwitcherViewDelegate {
             // ⌘Tab is unfiltered. Single chokepoint — every exit path (commit,
             // cancel, dismiss) flows through here.
             if newValue == .idle {
+                switchSessionKind = .none
                 activeScope = nil
                 scopeFrontPid = nil
                 // Drop the per-shortcut override (#74) so the next plain ⌘Tab
@@ -1721,6 +1730,7 @@ final class SwitcherController: SwitcherViewDelegate {
         primedApps = AppCatalog.fastAppList(orderedBy: mru.order, filter: activeFilterConfig)
         primedIndex = 0
         primedStepDelta = 0
+        switchSessionKind = .none
         // Scoped opens are sticky and never release-to-commit; the bound chord
         // may not include the trigger's hold modifier, so the missed-release
         // backstop must not run.
@@ -1889,9 +1899,9 @@ final class SwitcherController: SwitcherViewDelegate {
         case .prevApp:
             if tabDrillActive { advanceTab(by: -1) } else { advance(by: -1, wrap: true) }
         case .nextWindow:
-            if tabDrillActive { advanceTab(by: 1) } else { advanceWindowsOnly(by: 1) }
+            handleWindowTrigger(delta: 1)
         case .prevWindow:
-            if tabDrillActive { advanceTab(by: -1) } else { advanceWindowsOnly(by: -1) }
+            handleWindowTrigger(delta: -1)
         case .nextRow:
             advanceVerticalOrLinear(by: 1)
         case .prevRow:
@@ -1976,6 +1986,26 @@ final class SwitcherController: SwitcherViewDelegate {
             if let ch = KeyboardLayout.character(for: UInt16(keyCode)) {
                 handleSearchInput(ch)
             }
+        }
+    }
+
+    nonisolated static func windowTriggerStepsAppsBackward(
+        session: SwitchSessionKind,
+        backtickReversesAppSwitching: Bool
+    ) -> Bool {
+        backtickReversesAppSwitching && session == .appSwitching
+    }
+
+    private func handleWindowTrigger(delta: Int) {
+        if tabDrillActive {
+            advanceTab(by: delta)
+        } else if Self.windowTriggerStepsAppsBackward(
+            session: switchSessionKind,
+            backtickReversesAppSwitching: Preferences.shared.backtickReversesAppSwitching
+        ) {
+            advance(by: -1, wrap: true)
+        } else {
+            advanceWindowsOnly(by: delta)
         }
     }
 
@@ -2091,6 +2121,7 @@ final class SwitcherController: SwitcherViewDelegate {
             // timer), so it can land asynchronously and still order this chord.
             handleFocusChange(pid: front.processIdentifier)
             resolveActiveOptions(for: .switchWindows)
+            switchSessionKind = .windowSwitching
             windowsOnlyMode = true
             windowsOnlyPid = front.processIdentifier
             windowsOnlyPrimedDelta = delta
@@ -2119,6 +2150,7 @@ final class SwitcherController: SwitcherViewDelegate {
             resolveActiveOptions(for: .switchApps)
             primedApps = AppCatalog.fastAppList(orderedBy: mru.order, filter: activeFilterConfig)
             guard !primedApps.isEmpty else { return }
+            switchSessionKind = .appSwitching
             if primedApps.count == 1 {
                 primedIndex = 0
                 primedStepDelta = 0

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -2003,7 +2003,7 @@ final class SwitcherController: SwitcherViewDelegate {
             session: switchSessionKind,
             backtickReversesAppSwitching: Preferences.shared.backtickReversesAppSwitching
         ) {
-            advance(by: -1, wrap: true)
+            advance(by: -delta, wrap: true)
         } else {
             advanceWindowsOnly(by: delta)
         }

--- a/BetterCmdTabTests/SettingsPortabilityTests.swift
+++ b/BetterCmdTabTests/SettingsPortabilityTests.swift
@@ -163,6 +163,23 @@ struct SettingsPortabilityTests {
         #expect(prefs.shiftTapStepsBackward == false)
     }
 
+    @Test("round-trip: backtickReversesAppSwitching survives export/import")
+    func backtickReversesAppSwitchingRoundTrip() throws {
+        let prefs = Preferences.shared
+        let saved = prefs.backtickReversesAppSwitching
+        defer {
+            try? prefs.importSettings(from: envelope([
+                Preferences.Keys.backtickReversesAppSwitching: saved
+            ]))
+        }
+        // Flip away from the default (off), export, flip live back, import.
+        prefs.backtickReversesAppSwitching = true
+        let data = try prefs.exportedJSONData()
+        prefs.backtickReversesAppSwitching = false
+        try prefs.importSettings(from: data)
+        #expect(prefs.backtickReversesAppSwitching == true)
+    }
+
     @Test("import missing switcherDisplayMode leaves the current value untouched")
     func displayModePartialImport() throws {
         let prefs = Preferences.shared

--- a/BetterCmdTabTests/SwitcherSessionRoutingTests.swift
+++ b/BetterCmdTabTests/SwitcherSessionRoutingTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import BetterCmdTab
+
+@Suite("Switcher session routing")
+struct SwitcherSessionRoutingTests {
+    @Test func backtickReverseOnlyAppliesToAppSwitchSessionsWhenEnabled() {
+        #expect(SwitcherController.windowTriggerStepsAppsBackward(
+            session: .appSwitching,
+            backtickReversesAppSwitching: true
+        ))
+        #expect(!SwitcherController.windowTriggerStepsAppsBackward(
+            session: .appSwitching,
+            backtickReversesAppSwitching: false
+        ))
+        #expect(!SwitcherController.windowTriggerStepsAppsBackward(
+            session: .windowSwitching,
+            backtickReversesAppSwitching: true
+        ))
+        #expect(!SwitcherController.windowTriggerStepsAppsBackward(
+            session: .none,
+            backtickReversesAppSwitching: true
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- Add an opt-in Behavior > Keyboard setting: “Use window-switch shortcut to step backwards”.
- Track whether the current switcher session was opened for app switching or window switching.
- When enabled, pressing the window-switch shortcut while the app switcher is already open steps backwards through apps; opening with that shortcut still cycles windows.
- Include the new setting in settings export/import and Settings search.
- Gesture-opened and scoped-shortcut sessions intentionally do not get the reverse step: they open sticky, without the held-modifier app-switch session semantics this setting mirrors, so the window-switch shortcut keeps its normal meaning there.

## Research
I searched existing issues and PRs for backtick/tilde/Cmd+`/Cmd+~ reverse app switching and did not find a direct request or implementation. Related prior work: #45 / #66 for Shift reverse stepping, and #79 for shortcut matching behavior.

## Testing
- `jq empty BetterCmdTab/Localizable.xcstrings`
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:BetterCmdTabTests/SwitcherSessionRoutingTests -only-testing:BetterCmdTabTests/SettingsPortabilityTests` — passed, 16 tests in 2 suites
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test` — currently fails only existing `RowLabelsTests.secondaryAvoidsReserved`, `RowLabelsTests.reservedFirstSkipped`, and `RowLabelsTests.fReservedSkipped`

