### PR TITLE
feat: reorderable pinned apps list (#98)

### DIFF
--- a/BetterCmdTab/Settings/AppsSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppsSettingsViewController.swift
@@ -28,8 +28,10 @@ final class AppsSettingsViewController: SettingsTabViewController {
 
     private let rulesCard = SettingsSectionView()
 
-    private let pinnedButton = NSButton(title: String(localized: "Manage apps"), target: nil, action: nil)
-    private var pinnedRow: SettingsRowView!
+    private let pinnedCard = SettingsSectionView()
+    private let pinnedList = PinnedAppsListView()
+    /// Working copy of the pin order, persisted to `Preferences` on every mutation.
+    private var pinned: [String] = Preferences.shared.pinnedBundleIDs
     private var appsSheet: AppsPickerSheetWindowController?
     private var addSheet: AppsPickerSheetWindowController?
 
@@ -82,12 +84,60 @@ final class AppsSettingsViewController: SettingsTabViewController {
             directButtons.append(button)
         }
 
-        // Pinned apps — a lightweight chooser (a picker, not an editor).
-        let pinned = addSection(title: String(localized: "Pinned"), anchor: SettingsAnchor.pinned)
-        configureManageButton(pinnedButton, action: #selector(managePinned))
-        pinnedRow = addRow(to: pinned, title: String(localized: "Pinned apps"),
-                           subtitle: Self.pinnedDescription(Preferences.shared.pinnedBundleIDs.count),
-                           accessory: pinnedButton, searchItemID: SearchID.pinnedApps)
+        // Pinned apps — a titled group above a reorderable card. Drag rows to set
+        // the order pinned apps appear at the front of the switcher; "Add App…"
+        // opens the picker for bulk add/remove.
+        let pinnedHeader = makeGroupHeader(
+            title: String(localized: "Pinned"),
+            description: String(localized: "Pinned apps are forced to the front of the switcher, before recents. Drag to set their order.")
+        )
+        let pinnedBlock = NSStackView(views: [pinnedHeader, pinnedCard])
+        pinnedBlock.orientation = .vertical
+        pinnedBlock.alignment = .leading
+        pinnedBlock.spacing = 10
+        pinnedBlock.translatesAutoresizingMaskIntoConstraints = false
+        addArrangedSubview(pinnedBlock)
+        pinnedHeader.widthAnchor.constraint(equalTo: pinnedBlock.widthAnchor).isActive = true
+        pinnedCard.widthAnchor.constraint(equalTo: pinnedBlock.widthAnchor).isActive = true
+        register(section: pinnedBlock, anchor: SettingsAnchor.pinned)
+        register(searchTarget: pinnedCard, itemID: SearchID.pinnedApps)
+        pinnedList.onReorder = { [weak self] order in
+            self?.pinned = order
+            Preferences.shared.pinnedBundleIDs = order
+        }
+        pinnedList.onRemove = { [weak self] bundleID in
+            guard let self else { return }
+            self.pinned.removeAll { $0 == bundleID }
+            Preferences.shared.pinnedBundleIDs = self.pinned
+            self.rebuildPinnedCard()
+        }
+        rebuildPinnedCard()
+    }
+
+    /// Rebuild the pinned card: the reorderable list (or an empty-state label)
+    /// above an "Add App…" row. Called on add/remove and on external changes —
+    /// not during a drag, where the table animates in place.
+    private func rebuildPinnedCard() {
+        let stack = pinnedCard.contentStack
+        for sub in stack.arrangedSubviews {
+            stack.removeArrangedSubview(sub)
+            sub.removeFromSuperview()
+        }
+
+        if pinned.isEmpty {
+            let empty = NSTextField(labelWithString: String(localized: "No pinned apps yet."))
+            empty.font = .systemFont(ofSize: 12)
+            empty.textColor = .tertiaryLabelColor
+            pinnedCard.addContent(empty)
+        } else {
+            pinnedList.reload(pinned)
+            pinnedCard.addContent(pinnedList)
+        }
+        pinnedCard.addDivider()
+
+        let addRow = AddAppRowView()
+        addRow.onClick = { [weak self] in self?.managePinned() }
+        pinnedCard.addContent(addRow)
     }
 
     // MARK: - Direct activation slots
@@ -154,13 +204,6 @@ final class AppsSettingsViewController: SettingsTabViewController {
         stack.edgeInsets = NSEdgeInsets(top: 0, left: 4, bottom: 0, right: 4)
         descLabel.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -8).isActive = true
         return stack
-    }
-
-    private func configureManageButton(_ button: NSButton, action: Selector) {
-        button.bezelStyle = .rounded
-        button.controlSize = .small
-        button.target = self
-        button.action = action
     }
 
     // MARK: - App rules card
@@ -275,10 +318,20 @@ final class AppsSettingsViewController: SettingsTabViewController {
             rebuildRulesCard()
         }
         refreshDirectSlots()
-        updatePinnedCount()
+        // Same stale-snapshot guard for the pin order (Import / other panes).
+        if Preferences.shared.pinnedBundleIDs != pinned {
+            pinned = Preferences.shared.pinnedBundleIDs
+            rebuildPinnedCard()
+        }
         Preferences.shared.$pinnedBundleIDs
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.pinnedRow?.update(subtitle: Self.pinnedDescription($0.count)) }
+            .sink { [weak self] ids in
+                // Skip our own writes (reorder/remove already updated the view);
+                // rebuild only for external changes.
+                guard let self, ids != self.pinned else { return }
+                self.pinned = ids
+                self.rebuildPinnedCard()
+            }
             .store(in: &cancellables)
     }
 
@@ -310,21 +363,14 @@ final class AppsSettingsViewController: SettingsTabViewController {
             Preferences.shared.pinnedBundleIDs = order
         }
         controller.onDidDismiss = { [weak self] in
-            self?.appsSheet = nil
-            self?.updatePinnedCount()
+            guard let self else { return }
+            self.appsSheet = nil
+            self.pinned = Preferences.shared.pinnedBundleIDs
+            self.rebuildPinnedCard()
         }
         appsSheet = controller
         trackForRelease(controller)
         controller.present(asSheetFor: window)
-    }
-
-    private func updatePinnedCount() {
-        pinnedRow?.update(subtitle: Self.pinnedDescription(Preferences.shared.pinnedBundleIDs.count))
-    }
-
-    private static func pinnedDescription(_ count: Int) -> String {
-        let prefix = count == 0 ? String(localized: "None") : "\(count) app\(count == 1 ? "" : "s")"
-        return "\(prefix)\(String(localized: " — always shown first."))"
     }
 
     // MARK: - Helpers
@@ -333,7 +379,7 @@ final class AppsSettingsViewController: SettingsTabViewController {
     /// `nonisolated` so it can run off the main actor: it only touches
     /// `NSWorkspace.shared`, whose `urlForApplication`/`icon(forFile:)` are
     /// thread-safe, plus an `NSImage` symbol lookup.
-    nonisolated private static func appInfo(for bundleID: String) -> (name: String, icon: NSImage) {
+    nonisolated static func appInfo(for bundleID: String) -> (name: String, icon: NSImage) {
         if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
             return (url.deletingPathExtension().lastPathComponent, NSWorkspace.shared.icon(forFile: url.path))
         }

--- a/BetterCmdTab/Settings/PinnedAppsListView.swift
+++ b/BetterCmdTab/Settings/PinnedAppsListView.swift
@@ -1,0 +1,235 @@
+import AppKit
+
+/// Pure array-move for the pinned-apps drag reorder. Extracted from the view so
+/// the drop-index math is unit-testable without a live `NSTableView`.
+enum PinnedReorder {
+    /// Move the element at `from` to the `.above` drop slot `to`.
+    ///
+    /// `NSTableView` reports `to` in the *pre-removal* index space (the slot the
+    /// dragged row would land in front of), so a downward move has to shift the
+    /// destination left by one once the row is pulled out. Out-of-range `from`
+    /// is a no-op.
+    static func apply(_ ids: [String], movingRowAt from: Int, to row: Int) -> [String] {
+        guard ids.indices.contains(from) else { return ids }
+        var result = ids
+        let item = result.remove(at: from)
+        let dest = from < row ? row - 1 : row
+        result.insert(item, at: min(max(dest, 0), result.count))
+        return result
+    }
+}
+
+/// A reorderable list of pinned apps, rendered as a content-sized, header-less
+/// `NSTableView` so it can sit inside a settings card and let the pane's own
+/// scroll view handle overflow. Dragging a row changes the pin order; each row
+/// carries a remove button. Ordering is the app's contract — the array index is
+/// the switcher pin rank (see `CatalogFilter.pinnedToFront`).
+@MainActor
+final class PinnedAppsListView: NSView {
+
+    /// Fired with the full new order after a drag reorder.
+    var onReorder: (([String]) -> Void)?
+    /// Fired with the bundle ID when its remove button is clicked.
+    var onRemove: ((String) -> Void)?
+
+    private var bundleIDs: [String] = []
+    private let tableView = NSTableView()
+    private let scrollView = NSScrollView()
+    private var heightConstraint: NSLayoutConstraint!
+
+    private static let rowHeight: CGFloat = 36
+    private static let cellID = NSUserInterfaceItemIdentifier("PinnedAppRowCell")
+    private static let dragType = NSPasteboard.PasteboardType("pro.bettercmdtab.pinnedapp.row")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    /// Replace the list contents and resize to fit (no inner scrolling).
+    func reload(_ ids: [String]) {
+        bundleIDs = ids
+        tableView.reloadData()
+        updateHeight()
+    }
+
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("app"))
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.rowHeight = Self.rowHeight
+        tableView.backgroundColor = .clear
+        tableView.gridStyleMask = []
+        tableView.intercellSpacing = NSSize(width: 0, height: 2)
+        tableView.selectionHighlightStyle = .none
+        tableView.style = .plain
+        tableView.usesAutomaticRowHeights = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.registerForDraggedTypes([Self.dragType])
+        tableView.setDraggingSourceOperationMask(.move, forLocal: true)
+
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.verticalScrollElasticity = .none
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+
+        heightConstraint = scrollView.heightAnchor.constraint(equalToConstant: Self.rowHeight)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            heightConstraint,
+        ])
+    }
+
+    private func updateHeight() {
+        // N rows = N*rowHeight + (N-1) gaps; no trailing gap after the last row.
+        let rows = max(bundleIDs.count, 1)
+        let spacing = tableView.intercellSpacing.height
+        heightConstraint.constant = CGFloat(rows) * Self.rowHeight + CGFloat(rows - 1) * spacing
+    }
+}
+
+extension PinnedAppsListView: NSTableViewDataSource, NSTableViewDelegate {
+
+    func numberOfRows(in tableView: NSTableView) -> Int { bundleIDs.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard bundleIDs.indices.contains(row) else { return nil }
+        let bundleID = bundleIDs[row]
+        let cell: PinnedAppRowCellView
+        if let reused = tableView.makeView(withIdentifier: Self.cellID, owner: self) as? PinnedAppRowCellView {
+            cell = reused
+        } else {
+            cell = PinnedAppRowCellView(frame: .zero)
+            cell.identifier = Self.cellID
+        }
+        cell.configure(bundleID: bundleID)
+        cell.onRemove = { [weak self] in self?.onRemove?(bundleID) }
+        return cell
+    }
+
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
+        let item = NSPasteboardItem()
+        item.setString(String(row), forType: Self.dragType)
+        return item
+    }
+
+    func tableView(_ tableView: NSTableView, validateDrop info: NSDraggingInfo,
+                   proposedRow row: Int, proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
+        dropOperation == .above ? .move : []
+    }
+
+    func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo,
+                   row: Int, dropOperation: NSTableView.DropOperation) -> Bool {
+        guard let item = info.draggingPasteboard.pasteboardItems?.first,
+              let raw = item.string(forType: Self.dragType),
+              let from = Int(raw), bundleIDs.indices.contains(from) else { return false }
+        let reordered = PinnedReorder.apply(bundleIDs, movingRowAt: from, to: row)
+        guard reordered != bundleIDs else { return false }
+        bundleIDs = reordered
+        let dest = from < row ? row - 1 : row
+        tableView.beginUpdates()
+        tableView.moveRow(at: from, to: dest)
+        tableView.endUpdates()
+        onReorder?(bundleIDs)
+        return true
+    }
+}
+
+/// One pinned-app row: a drag-handle affordance, the app icon and name, and a
+/// trailing remove button. Name and icon are resolved off the main actor and
+/// spliced in — a cold LaunchServices lookup can hitch the UI (mirrors
+/// `AppRuleRowView` / `AppsSettingsViewController.makeRow`).
+@MainActor
+final class PinnedAppRowCellView: NSTableCellView {
+
+    /// Fired when the remove button is clicked.
+    var onRemove: (() -> Void)?
+
+    private let handle = NSImageView()
+    private let iconView = NSImageView()
+    private let nameLabel = NSTextField(labelWithString: "")
+    private let removeButton = NSButton()
+    private var bundleID = ""
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    func configure(bundleID: String) {
+        self.bundleID = bundleID
+        // Placeholder now; resolve the real name + icon off the main actor.
+        iconView.image = NSImage(systemSymbolName: "app.dashed", accessibilityDescription: nil)
+        nameLabel.stringValue = bundleID
+        DispatchQueue.global(qos: .userInitiated).async {
+            let info = AppsSettingsViewController.appInfo(for: bundleID)
+            DispatchQueue.main.async { [weak self] in
+                // Cell reuse: only splice if this cell still represents the same app.
+                guard let self, self.bundleID == bundleID else { return }
+                info.icon.size = NSSize(width: 22, height: 22)
+                self.iconView.image = info.icon
+                self.nameLabel.stringValue = info.name
+            }
+        }
+    }
+
+    private func setup() {
+        handle.image = NSImage(systemSymbolName: "line.3.horizontal", accessibilityDescription: String(localized: "Drag to reorder"))?
+            .withSymbolConfiguration(.init(pointSize: 12, weight: .regular))
+        handle.contentTintColor = .tertiaryLabelColor
+        handle.toolTip = String(localized: "Drag to reorder")
+        handle.setContentHuggingPriority(.required, for: .horizontal)
+
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        iconView.setContentHuggingPriority(.required, for: .horizontal)
+
+        nameLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        nameLabel.textColor = .labelColor
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        removeButton.isBordered = false
+        removeButton.bezelStyle = .accessoryBarAction
+        removeButton.imagePosition = .imageOnly
+        removeButton.image = NSImage(systemSymbolName: "minus.circle.fill", accessibilityDescription: String(localized: "Remove from pinned"))?
+            .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
+        removeButton.contentTintColor = .tertiaryLabelColor
+        removeButton.toolTip = String(localized: "Remove from pinned")
+        removeButton.target = self
+        removeButton.action = #selector(removeClicked)
+        removeButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        let stack = NSStackView(views: [handle, iconView, nameLabel, NSView(), removeButton])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 10
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            iconView.widthAnchor.constraint(equalToConstant: 22),
+            iconView.heightAnchor.constraint(equalToConstant: 22),
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+        ])
+    }
+
+    @objc private func removeClicked() { onRemove?() }
+}

--- a/BetterCmdTabTests/PinnedReorderTests.swift
+++ b/BetterCmdTabTests/PinnedReorderTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import BetterCmdTab
+
+/// The pure array-move behind the pinned-apps drag reorder. `to` is the
+/// NSTableView `.above` drop index in pre-removal space, so downward moves shift
+/// the destination by one.
+@Suite("PinnedReorder")
+struct PinnedReorderTests {
+
+    @Test("drop below shifts destination left by one")
+    func moveDown() {
+        let ids = ["a", "b", "c", "d"]
+        // Drag "a" (0) to sit above index 2 (before "c").
+        #expect(PinnedReorder.apply(ids, movingRowAt: 0, to: 2) == ["b", "a", "c", "d"])
+    }
+
+    @Test("move to bottom")
+    func moveToBottom() {
+        let ids = ["a", "b", "c"]
+        #expect(PinnedReorder.apply(ids, movingRowAt: 0, to: 3) == ["b", "c", "a"])
+    }
+
+    @Test("move up to a higher slot")
+    func moveUp() {
+        let ids = ["a", "b", "c"]
+        #expect(PinnedReorder.apply(ids, movingRowAt: 2, to: 0) == ["c", "a", "b"])
+    }
+
+    @Test("move to top from the middle")
+    func moveToTop() {
+        let ids = ["a", "b", "c"]
+        #expect(PinnedReorder.apply(ids, movingRowAt: 1, to: 0) == ["b", "a", "c"])
+    }
+
+    @Test("drop onto own slot is a no-op")
+    func dropOnSelf() {
+        let ids = ["a", "b", "c"]
+        #expect(PinnedReorder.apply(ids, movingRowAt: 1, to: 1) == ids)
+    }
+
+    @Test("drop just below own slot is a no-op")
+    func dropBelowSelf() {
+        let ids = ["a", "b", "c"]
+        // Dropping "b" (1) above index 2 lands it back where it started.
+        #expect(PinnedReorder.apply(ids, movingRowAt: 1, to: 2) == ids)
+    }
+
+    @Test("out-of-range source index leaves the list unchanged")
+    func outOfRange() {
+        let ids = ["a"]
+        #expect(PinnedReorder.apply(ids, movingRowAt: 5, to: 0) == ids)
+    }
+}


### PR DESCRIPTION
Closes #98.

## Highlights
Pinned apps can now be reordered. The Apps settings pane shows the pinned apps as a list you drag to arrange; that order is the order they appear at the front of the switcher.

### Added
- Drag-to-reorder list of pinned apps in Settings → Apps → Pinned, with a per-row remove button and an "Add App…" row.

### Changed
- The "Pinned apps — Manage apps" summary row is replaced by the inline reorderable card. Bulk add/remove still uses the existing picker sheet.

## Notes
- No storage or hot-path change: `pinnedBundleIDs` was already an ordered array and every consumer (CatalogFilter, SwitcherController) treats the index as the pin rank, so reordering the array is sufficient. Export/import round-trips the order unchanged.
- Drop-index math extracted into a pure `PinnedReorder.apply` with unit coverage (`PinnedReorderTests`, 7 cases).

## Verification
- `xcodebuild -scheme "BetterCmdTab Debug" build` — green.
- Full unit suite — 379 tests pass (7 new).
- Manual (live WindowServer + AX): drag reorder, switcher front order, persist across relaunch, remove — confirmed by author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)