### PR TITLE
fix: anchor first ⌘Tab step on frontmost app under stable sorts

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -189,6 +189,19 @@ enum SwitcherSortOrder: String, CaseIterable {
         case .launchOrder: return String(localized: "Launch order")
         }
     }
+
+    /// Sorts whose list order is independent of recency: the frontmost app is
+    /// not at index 0, so the first primed ⌘Tab step must anchor on its
+    /// position instead of the list head (#88). MRU sorts return false — the
+    /// frontmost app already leads the list after `mru.syncFrontmost()`, and
+    /// `.mruWindows` steps by `primedStepDelta` over windows, not apps.
+    /// Exhaustive on purpose: a new sort case must consciously pick a side.
+    var anchorsPrimedOnFrontmost: Bool {
+        switch self {
+        case .alphabetical, .launchOrder: return true
+        case .mru, .mruWindows: return false
+        }
+    }
 }
 
 /// Which Spaces the switcher shows windows from (#57). Raw values are

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -845,8 +845,12 @@ final class SwitcherController: SwitcherViewDelegate {
             cache.scheduleFullRefresh()
             primedApps = AppCatalog.fastAppList(orderedBy: mru.order)
             guard !primedApps.isEmpty else { return }
-            primedIndex = primedApps.count == 1 ? 0 : (delta > 0 ? 1 : primedApps.count - 1)
-            primedStepDelta = primedApps.count == 1 ? 0 : (delta > 0 ? 1 : -1)
+            // Anchor on the global sort: this path never resolves per-shortcut
+            // options, so `effective` is a stale snapshot here (#88).
+            let anchor = primedAnchor(for: Preferences.shared.sortOrder)
+            let step = primedApps.count == 1 ? 0 : (delta > 0 ? 1 : -1)
+            primedIndex = Self.primedStartIndex(count: primedApps.count, step: step, anchor: anchor)
+            primedStepDelta = step
             primedByHeldChord = false
             phase = .primed
             reveal()
@@ -2105,6 +2109,22 @@ final class SwitcherController: SwitcherViewDelegate {
         }
     }
 
+    /// Start index for the first primed step. `anchor` is the frontmost app's
+    /// position in the primed list under a stable sort (#88); nil reproduces
+    /// the legacy head-anchored start (step 1 → 1, step -1 → count-1).
+    nonisolated static func primedStartIndex(count: Int, step: Int, anchor: Int?) -> Int {
+        guard count > 1 else { return 0 }
+        return ((((anchor ?? 0) + step) % count) + count) % count
+    }
+
+    /// Position of the frontmost app in `primedApps` for sorts that anchor on
+    /// it; nil under MRU sorts (frontmost already leads the list) or when the
+    /// frontmost app was filtered out of the primed list.
+    private func primedAnchor(for sort: SwitcherSortOrder) -> Int? {
+        guard sort.anchorsPrimedOnFrontmost, let front = mru.order.first else { return nil }
+        return primedApps.firstIndex { $0.processIdentifier == front }
+    }
+
     private func advance(by delta: Int, wrap: Bool) {
         switch phase {
         case .idle:
@@ -2119,16 +2139,10 @@ final class SwitcherController: SwitcherViewDelegate {
             resolveActiveOptions(for: .switchApps)
             primedApps = AppCatalog.fastAppList(orderedBy: mru.order, filter: activeFilterConfig)
             guard !primedApps.isEmpty else { return }
-            if primedApps.count == 1 {
-                primedIndex = 0
-                primedStepDelta = 0
-            } else if delta > 0 {
-                primedIndex = 1
-                primedStepDelta = 1
-            } else {
-                primedIndex = primedApps.count - 1
-                primedStepDelta = -1
-            }
+            let anchor = primedAnchor(for: effective.sortOrder)
+            let step = primedApps.count == 1 ? 0 : (delta > 0 ? 1 : -1)
+            primedIndex = Self.primedStartIndex(count: primedApps.count, step: step, anchor: anchor)
+            primedStepDelta = step
             schedulePrimedReveal()
         case .primed:
             guard !primedApps.isEmpty else { return }

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -276,3 +276,45 @@ struct SwitcherActiveBrowserTabTests {
             in: rows, window: AXRef(element: win), activeTabIndex: 0) == nil)
     }
 }
+
+/// Under a stable sort (alphabetical / launch order) the primed list is not
+/// MRU-ordered, so the old `primedIndex = 1` start always landed on the second
+/// app A→Z regardless of which app was focused (#88). The first step now
+/// anchors on the frontmost app's position and wraps from there; a nil anchor
+/// (frontmost filtered out, or an MRU sort) reproduces the legacy start.
+@Suite("Primed start anchor (#88)")
+struct PrimedStartAnchorTests {
+    @Test func legacyHeadAnchor_whenAnchorNil() {
+        #expect(SwitcherController.primedStartIndex(count: 5, step: 1, anchor: nil) == 1)
+        #expect(SwitcherController.primedStartIndex(count: 5, step: -1, anchor: nil) == 4)
+    }
+
+    @Test func anchorForward_selectsNeighborAfterFrontmost() {
+        #expect(SwitcherController.primedStartIndex(count: 5, step: 1, anchor: 2) == 3)
+    }
+
+    @Test func anchorReverse_selectsNeighborBefore() {
+        #expect(SwitcherController.primedStartIndex(count: 5, step: -1, anchor: 2) == 1)
+    }
+
+    @Test func anchorWraps_bothDirections() {
+        // Frontmost is last A→Z → forward wraps to the head.
+        #expect(SwitcherController.primedStartIndex(count: 5, step: 1, anchor: 4) == 0)
+        // Frontmost is first → shift-reverse wraps to the tail.
+        #expect(SwitcherController.primedStartIndex(count: 5, step: -1, anchor: 0) == 4)
+    }
+
+    @Test func singleApp_alwaysZero() {
+        for step in [-1, 0, 1] {
+            #expect(SwitcherController.primedStartIndex(count: 1, step: step, anchor: nil) == 0)
+            #expect(SwitcherController.primedStartIndex(count: 1, step: step, anchor: 0) == 0)
+        }
+    }
+
+    @Test func gate_onlyStableSortsAnchor() {
+        #expect(SwitcherSortOrder.alphabetical.anchorsPrimedOnFrontmost)
+        #expect(SwitcherSortOrder.launchOrder.anchorsPrimedOnFrontmost)
+        #expect(!SwitcherSortOrder.mru.anchorsPrimedOnFrontmost)
+        #expect(!SwitcherSortOrder.mruWindows.anchorsPrimedOnFrontmost)
+    }
+}


### PR DESCRIPTION
Under alphabetical / launch-order sort the idle prime always selected index 1 — the second app A→Z — ignoring which app was focused. The first primed step now anchors on the frontmost app's position in the list and steps from there, wrapping; when the frontmost app is filtered out it falls back to the old head-anchored start. A quick ⌘Tab tap-release activates the alphabetically-next app for the same reason. MRU sorts, scoped opens and ⌘` are untouched.

Pure-logic core extracted as `SwitcherController.primedStartIndex` with a Swift Testing suite (6 cases).

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)