### PR TITLE
feat: quick-tap stay-open for mouse-mapped shortcuts

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -362,6 +362,7 @@ struct ShortcutOverride: Equatable, Sendable {
     var applicationsOnly: Bool?
     var expandBrowserTabsAsWindows: Bool?
     var stayOpenOnRelease: Bool?
+    var stayOpenOnQuickTap: Bool?
     // Appearance (resolved into `EffectiveSettings`).
     var layoutMode: SwitcherLayoutMode?
     var panelSize: PanelSize?
@@ -386,6 +387,7 @@ struct ShortcutOverride: Equatable, Sendable {
         spaceScope == .inherit && showMinimized == nil && showHidden == nil
             && showWindowless == nil && sortOrder == nil && applicationsOnly == nil
             && expandBrowserTabsAsWindows == nil && stayOpenOnRelease == nil
+            && stayOpenOnQuickTap == nil
             && layoutMode == nil && panelSize == nil
             && gridMaxColumns == nil && accentChoice == nil && customAccentHex == nil
             && panelOpacity == nil && panelCornerRadius == nil && backdropMaterial == nil
@@ -409,6 +411,7 @@ struct ShortcutOverride: Equatable, Sendable {
         put("applicationsOnly", applicationsOnly)
         put("expandBrowserTabsAsWindows", expandBrowserTabsAsWindows)
         put("stayOpenOnRelease", stayOpenOnRelease)
+        put("stayOpenOnQuickTap", stayOpenOnQuickTap)
         if let layoutMode { d["layoutMode"] = layoutMode.rawValue }
         if let panelSize { d["panelSize"] = panelSize.rawValue }
         put("gridMaxColumns", gridMaxColumns)
@@ -439,6 +442,7 @@ struct ShortcutOverride: Equatable, Sendable {
         applicationsOnly = bool("applicationsOnly")
         expandBrowserTabsAsWindows = bool("expandBrowserTabsAsWindows")
         stayOpenOnRelease = bool("stayOpenOnRelease")
+        stayOpenOnQuickTap = bool("stayOpenOnQuickTap")
         layoutMode = dictionary["layoutMode"].flatMap(SwitcherLayoutMode.init(rawValue:))
         panelSize = dictionary["panelSize"].flatMap(PanelSize.init(rawValue:))
         gridMaxColumns = dictionary["gridMaxColumns"].flatMap(Int.init)
@@ -677,6 +681,7 @@ final class Preferences: ObservableObject {
         static let letterHintsEnabled = "Switcher.letterHintsEnabled"
         static let searchDismissMode = "Switcher.searchDismissMode"
         static let stayOpenOnRelease = "Switcher.stayOpenOnRelease"
+        static let stayOpenOnQuickTap = "Switcher.stayOpenOnQuickTap"
         static let searchIncludesLaunchableApps = "Switcher.searchIncludesLaunchableApps"
         static let showRecentlyClosed = "Switcher.showRecentlyClosed"
         static let recentlyClosedLimit = "Switcher.recentlyClosedLimit"
@@ -937,6 +942,18 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != stayOpenOnRelease else { return }
             UserDefaults.standard.set(stayOpenOnRelease, forKey: Keys.stayOpenOnRelease)
+        }
+    }
+
+    /// Also park the panel open when the trigger chord is released *before*
+    /// the panel appears (#91) — shortcuts mapped to mouse buttons or gestures
+    /// synthesize a quick press+release, so the release lands pre-visible and
+    /// would otherwise commit instantly. Only takes effect when
+    /// `stayOpenOnRelease` is also on. Default off.
+    @Published var stayOpenOnQuickTap: Bool {
+        didSet {
+            guard oldValue != stayOpenOnQuickTap else { return }
+            UserDefaults.standard.set(stayOpenOnQuickTap, forKey: Keys.stayOpenOnQuickTap)
         }
     }
 
@@ -1654,6 +1671,7 @@ final class Preferences: ObservableObject {
         let dismissRaw = defaults.string(forKey: Keys.searchDismissMode)
         self.searchDismissMode = dismissRaw.flatMap(SearchDismissMode.init(rawValue:)) ?? .holdModifier
         self.stayOpenOnRelease = defaults.object(forKey: Keys.stayOpenOnRelease) as? Bool ?? false
+        self.stayOpenOnQuickTap = defaults.object(forKey: Keys.stayOpenOnQuickTap) as? Bool ?? false
 
         self.searchIncludesLaunchableApps = defaults.object(forKey: Keys.searchIncludesLaunchableApps) as? Bool ?? true
         self.showRecentlyClosed = defaults.object(forKey: Keys.showRecentlyClosed) as? Bool ?? false
@@ -1782,6 +1800,7 @@ final class Preferences: ObservableObject {
         letterHintsEnabled = defaults.object(forKey: Keys.letterHintsEnabled) as? Bool ?? true
         searchDismissMode = defaults.string(forKey: Keys.searchDismissMode).flatMap(SearchDismissMode.init(rawValue:)) ?? .holdModifier
         stayOpenOnRelease = defaults.object(forKey: Keys.stayOpenOnRelease) as? Bool ?? false
+        stayOpenOnQuickTap = defaults.object(forKey: Keys.stayOpenOnQuickTap) as? Bool ?? false
         searchIncludesLaunchableApps = defaults.object(forKey: Keys.searchIncludesLaunchableApps) as? Bool ?? true
         showRecentlyClosed = defaults.object(forKey: Keys.showRecentlyClosed) as? Bool ?? false
         recentlyClosedLimit = defaults.object(forKey: Keys.recentlyClosedLimit) as? Int ?? 5

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -506,6 +506,34 @@
         }
       }
     },
+    "Also stay open after a quick tap" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auch nach kurzem Antippen geöffnet lassen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener abierto también tras un toque rápido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rester ouvert aussi après une pression rapide"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozostaw otwarte także po szybkim naciśnięciu"
+          }
+        }
+      }
+    },
     "Always" : {
       "localizations" : {
         "de" : {
@@ -3475,6 +3503,34 @@
         }
       }
     },
+    "Keep the switcher on screen even when the shortcut is pressed and released in one quick tap — for shortcuts mapped to mouse buttons or gestures. Requires “Stay open after releasing the modifier”." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Umschalter bleibt auch dann auf dem Bildschirm, wenn der Kurzbefehl mit einem kurzen Antippen gedrückt und losgelassen wird — für Kurzbefehle, die auf Maustasten oder Gesten gelegt sind. Erfordert „Nach dem Loslassen der Modifikatortaste geöffnet lassen“."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El selector permanece en pantalla incluso cuando el atajo se pulsa y se suelta en un solo toque rápido — para atajos asignados a botones del ratón o gestos. Requiere «Mantener abierto al soltar el modificador»."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le sélecteur reste à l’écran même quand le raccourci est pressé et relâché en une pression rapide — pour les raccourcis associés à des boutons de souris ou à des gestes. Nécessite « Rester ouvert après le relâchement du modificateur »."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przełącznik pozostaje na ekranie nawet po szybkim naciśnięciu i puszczeniu skrótu — dla skrótów mapowanych na przyciski myszy lub gesty. Wymaga „Pozostaw otwarte po puszczeniu modyfikatora”."
+          }
+        }
+      }
+    },
     "Keep the switcher on screen when you let go of the trigger — pick with Return, a quick-jump letter, or the mouse; Esc dismisses. A quick tap still switches instantly." : {
       "localizations" : {
         "pl" : {
@@ -4620,6 +4676,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
+          }
+        }
+      }
+    },
+    "Only applies while “Stay open after releasing the modifier” is on for this shortcut." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gilt nur, solange „Nach dem Loslassen der Modifikatortaste geöffnet lassen“ für diesen Kurzbefehl aktiviert ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo se aplica mientras «Mantener abierto al soltar el modificador» esté activado para este atajo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne s’applique que lorsque « Rester ouvert après le relâchement du modificateur » est activé pour ce raccourci."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Działa tylko, gdy „Pozostaw otwarte po puszczeniu modyfikatora” jest włączone dla tego skrótu."
           }
         }
       }

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -47,6 +47,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
 
     // Keyboard
     private let stayOpenSwitch = NSSwitch()
+    private let stayOpenQuickTapSwitch = NSSwitch()
     private let shiftTapBackSwitch = NSSwitch()
     private let vimNavSwitch = NSSwitch()
 
@@ -227,6 +228,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         addRow(to: keyboard, title: String(localized: "Stay open after releasing the modifier"),
                subtitle: String(localized: "Keep the switcher on screen when you let go of the trigger — pick with Return, a quick-jump letter, or the mouse; Esc dismisses. A quick tap still switches instantly."),
                accessory: stayOpenSwitch, searchItemID: SearchID.stayOpen)
+        configureSwitch(stayOpenQuickTapSwitch, action: #selector(toggleStayOpenQuickTap(_:)))
+        addRow(to: keyboard, title: String(localized: "Also stay open after a quick tap"),
+               subtitle: String(localized: "Keep the switcher on screen even when the shortcut is pressed and released in one quick tap — for shortcuts mapped to mouse buttons or gestures. Requires \u{201C}Stay open after releasing the modifier\u{201D}."),
+               accessory: stayOpenQuickTapSwitch, searchItemID: SearchID.stayOpenQuickTap)
         configureSwitch(shiftTapBackSwitch, action: #selector(toggleShiftTapBack(_:)))
         addRow(to: keyboard, title: String(localized: "Tap Shift to step backwards"),
                subtitle: String(localized: "While the switcher is open, a tap of the Shift key steps the selection backwards and holding Shift keeps stepping back until you let go — just like a held Tab. Turn this off to step back only with Shift held as you press the switch key (⌘⇧Tab)."),
@@ -326,6 +331,8 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         launcherSwitch.state = prefs.searchIncludesLaunchableApps ? .on : .off
         selectSearchMode(prefs.searchDismissMode)
         stayOpenSwitch.state = prefs.stayOpenOnRelease ? .on : .off
+        stayOpenQuickTapSwitch.state = prefs.stayOpenOnQuickTap ? .on : .off
+        stayOpenQuickTapSwitch.isEnabled = prefs.stayOpenOnRelease
         shiftTapBackSwitch.state = prefs.shiftTapStepsBackward ? .on : .off
         scrollSwitch.state = prefs.scrollToSwitch ? .on : .off
         scrollReverseSwitch.state = prefs.scrollReverseDirection ? .on : .off
@@ -431,7 +438,15 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
     }
 
     @objc private func toggleStayOpen(_ sender: NSSwitch) {
-        Preferences.shared.stayOpenOnRelease = (sender.state == .on)
+        let on = (sender.state == .on)
+        Preferences.shared.stayOpenOnRelease = on
+        // Quick-tap stay-open only takes effect while stay-open itself is on
+        // (#91), so gray it out to match.
+        stayOpenQuickTapSwitch.isEnabled = on
+    }
+
+    @objc private func toggleStayOpenQuickTap(_ sender: NSSwitch) {
+        Preferences.shared.stayOpenOnQuickTap = (sender.state == .on)
     }
 
     @objc private func toggleShiftTapBack(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -108,6 +108,7 @@ enum SearchID {
     static let scrollReverse = "switcher.scrollReverse"
     static let clickDismiss = "switcher.clickDismiss"
     static let stayOpen = "switcher.stayOpen"
+    static let stayOpenQuickTap = "switcher.stayOpenQuickTap"
     static let vimNavigation = "switcher.vimNavigation"
     static let hoverActions = "switcher.hoverActions"
     static let displayMonitor = "switcher.displayMonitor"
@@ -305,6 +306,8 @@ enum SettingsCatalog {
         // Behavior · Keyboard
         item(SearchID.stayOpen, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),
              String(localized: "Stay open after releasing the modifier"), ["stay open", "sticky", "release", "modifier", "keep open", "hold"]),
+        item(SearchID.stayOpenQuickTap, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),
+             String(localized: "Also stay open after a quick tap"), ["quick tap", "mouse", "mouse button", "gesture", "stay open", "sticky", "tap"]),
         item(SearchID.shiftTapBack, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),
              String(localized: "Tap Shift to step backwards"), ["shift", "backwards", "back", "reverse", "tap shift", "cmd shift tab", "windows"]),
         item(SearchID.vimNavigation, .switcher, SettingsAnchor.keyboard, String(localized: "Behavior"), String(localized: "Keyboard"),

--- a/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
+++ b/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
@@ -75,6 +75,9 @@ final class ShortcutOptionsFormView: NSView {
         addBoolRow(to: behavior, title: String(localized: "Stay open after releasing the modifier"),
                    subtitle: String(localized: "Pick with Return, a quick-jump letter, or the mouse; Esc dismisses."),
                    current: override.stayOpenOnRelease) { [weak self] in self?.override.stayOpenOnRelease = $0; self?.persist() }
+        addBoolRow(to: behavior, title: String(localized: "Also stay open after a quick tap"),
+                   subtitle: String(localized: "Only applies while \u{201C}Stay open after releasing the modifier\u{201D} is on for this shortcut."),
+                   current: override.stayOpenOnQuickTap) { [weak self] in self?.override.stayOpenOnQuickTap = $0; self?.persist() }
         addBoolRow(to: behavior, title: String(localized: "Expand browser tabs as windows"), current: override.expandBrowserTabsAsWindows) { [weak self] in self?.override.expandBrowserTabsAsWindows = $0; self?.persist() }
         addCard(behavior)
 

--- a/BetterCmdTab/Switcher/EffectiveSettings.swift
+++ b/BetterCmdTab/Switcher/EffectiveSettings.swift
@@ -31,6 +31,7 @@ struct EffectiveSettings {
     let expandBrowserTabsAsWindows: Bool
     let sortOrder: SwitcherSortOrder
     let stayOpenOnRelease: Bool
+    let stayOpenOnQuickTap: Bool
 
     /// The all-global snapshot (no override). Cheap; reads `Preferences.shared`.
     @MainActor static var defaults: EffectiveSettings {
@@ -70,7 +71,8 @@ extension Preferences {
             applicationsOnly: override.applicationsOnly ?? applicationsOnly,
             expandBrowserTabsAsWindows: override.expandBrowserTabsAsWindows ?? expandBrowserTabsAsWindows,
             sortOrder: override.sortOrder ?? sortOrder,
-            stayOpenOnRelease: override.stayOpenOnRelease ?? stayOpenOnRelease
+            stayOpenOnRelease: override.stayOpenOnRelease ?? stayOpenOnRelease,
+            stayOpenOnQuickTap: override.stayOpenOnQuickTap ?? stayOpenOnQuickTap
         )
     }
 }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1188,6 +1188,29 @@ final class SwitcherController: SwitcherViewDelegate {
         return phase == .visible && primedByHeldChord && (!stickyOpen || tabDrillActive)
     }
 
+    /// Pure: should a chord release that lands while still `.primed` (before the
+    /// panel is on screen) reveal + park the panel instead of committing (#91)?
+    /// Shortcuts mapped to mouse buttons/gestures synthesize a quick
+    /// press+release, so the release always lands pre-visible. The AND is
+    /// deliberate — the quick-tap instant flip is protected shipped behavior
+    /// (#77/0e61378), so parking a pre-visible release requires BOTH opt-ins.
+    /// Isolated so the gate stays unit-testable.
+    nonisolated static func quickReleaseParks(
+        stayOpenOnRelease: Bool,
+        stayOpenOnQuickTap: Bool
+    ) -> Bool {
+        stayOpenOnRelease && stayOpenOnQuickTap
+    }
+
+    /// `quickReleaseParks` over the firing shortcut's resolved settings — one
+    /// bool read on the release edge, nothing else.
+    private var quickReleaseParksSticky: Bool {
+        Self.quickReleaseParks(
+            stayOpenOnRelease: effective.stayOpenOnRelease,
+            stayOpenOnQuickTap: effective.stayOpenOnQuickTap
+        )
+    }
+
     /// Pure: on a backstop tick, should an idle `.visible` panel be force-closed?
     /// Fires while `CGEventSource.flagsState` can stick reporting ⌘-held — the sole
     /// state where the no-interaction ceiling is the only flagsState-independent way
@@ -2367,9 +2390,11 @@ final class SwitcherController: SwitcherViewDelegate {
         // tap now catches any *later* release — but a release that already happened
         // is only recoverable here: re-read the live modifier state and, if neither
         // hold modifier is still down, commit the primed pick now instead of
-        // revealing a stranded panel.
+        // revealing a stranded panel. Route through handleModifierRelease so the
+        // quick-tap stay-open opt-in (#91) can park instead — with the option
+        // off it reaches commit() through identical inert branches.
         if holdReleaseAlreadyMissed() {
-            commit()
+            handleModifierRelease()
             return
         }
         // Resolve the user's current window off-main now, while we wait out the
@@ -2517,7 +2542,9 @@ final class SwitcherController: SwitcherViewDelegate {
         // only: gesture/scoped sessions hold no modifier, so the live flags
         // read would always look like a missed release and commit instantly
         // instead of presenting (they open sticky and never release-commit).
-        if primedByHeldChord, holdReleaseAlreadyMissed() {
+        // With quick-tap stay-open (#91) a release landing during reveal()'s
+        // own run falls through to present; the post-present rescue parks it.
+        if primedByHeldChord, holdReleaseAlreadyMissed(), !quickReleaseParksSticky {
             commit()
             return
         }
@@ -4683,6 +4710,23 @@ final class SwitcherController: SwitcherViewDelegate {
         if stickyOpen { return }
         if searchActive, Preferences.shared.searchDismissMode == .stayOpen {
             stickyOpen = true
+            return
+        }
+        // Quick-tap stay-open (#91): a chord release landing while still
+        // `.primed` (mouse-mapped shortcuts synthesize press+release before the
+        // panel appears) reveals + parks instead of committing — but only when
+        // BOTH stay-open opt-ins are on (see `quickReleaseParks`). Guard the
+        // park on `.visible` like openScoped()/triggerFromGesture(): reveal()
+        // can cancel to `.idle` (empty rows) and an unguarded assignment would
+        // strand stickyOpen=true into the next session. Benign re-entrancy:
+        // the synchronous reveal() can reach the post-present rescue, which
+        // re-enters handleModifierRelease and parks via the `.visible` branch
+        // first — idempotent.
+        if phase == .primed, primedByHeldChord, quickReleaseParksSticky {
+            revealTimer?.invalidate()
+            revealTimer = nil
+            reveal()
+            if phase == .visible { stickyOpen = true }
             return
         }
         // Stay-open (#77): only a `.visible` panel parks sticky — a release

--- a/BetterCmdTabTests/ShortcutOverrideTests.swift
+++ b/BetterCmdTabTests/ShortcutOverrideTests.swift
@@ -94,6 +94,7 @@ struct ShortcutOverrideTests {
         ov.applicationsOnly = true
         ov.expandBrowserTabsAsWindows = false
         ov.stayOpenOnRelease = true
+        ov.stayOpenOnQuickTap = false
         ov.layoutMode = .list
         ov.panelSize = .large
         ov.gridMaxColumns = 7
@@ -280,6 +281,18 @@ struct ShortcutOverrideTests {
         #expect(prefs.effectiveSettings(for: ov).stayOpenOnRelease == target)
         // Unset inherits the global.
         #expect(prefs.effectiveSettings(for: ShortcutOverride()).stayOpenOnRelease == prefs.stayOpenOnRelease)
+    }
+
+    @Test("quick-tap stay-open resolves the override over the global (#91)")
+    func effectiveQuickTapOverride() {
+        let prefs = Preferences.shared
+        var ov = ShortcutOverride()
+        // Force the opposite of the current global so the assertion is real.
+        let target = !prefs.stayOpenOnQuickTap
+        ov.stayOpenOnQuickTap = target
+        #expect(prefs.effectiveSettings(for: ov).stayOpenOnQuickTap == target)
+        // Unset inherits the global.
+        #expect(prefs.effectiveSettings(for: ShortcutOverride()).stayOpenOnQuickTap == prefs.stayOpenOnQuickTap)
     }
 
     @Test("resolvedAccent honors an overridden custom hex")

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -42,6 +42,21 @@ struct SwitcherPhaseTests {
     }
 }
 
+/// Pure-logic coverage for the quick-tap stay-open gate (#91): a chord release
+/// landing while still `.primed` (mouse-mapped shortcuts synthesize a quick
+/// press+release before the panel appears) parks the panel only when BOTH
+/// stay-open opt-ins are on — the quick-tap instant flip is protected shipped
+/// behavior (#77), so neither option alone may change it.
+@Suite("Switcher quick-tap stay-open gate")
+struct SwitcherQuickReleaseParkTests {
+    @Test func quickReleaseParkGate() {
+        #expect(!SwitcherController.quickReleaseParks(stayOpenOnRelease: false, stayOpenOnQuickTap: false))
+        #expect(!SwitcherController.quickReleaseParks(stayOpenOnRelease: true, stayOpenOnQuickTap: false))
+        #expect(!SwitcherController.quickReleaseParks(stayOpenOnRelease: false, stayOpenOnQuickTap: true))
+        #expect(SwitcherController.quickReleaseParks(stayOpenOnRelease: true, stayOpenOnQuickTap: true))
+    }
+}
+
 /// Pure-logic coverage for the fast-tap rescue: when the ⌘-release was dropped by
 /// the tap (it gates `.releaseCmd` on `isSwitchingNow()`, set only once the main
 /// thread reaches `.primed`), the controller re-reads the live modifier state and


### PR DESCRIPTION
Shortcuts mapped to mouse buttons or gestures synthesize a quick press+release of the trigger chord; the release lands while the switcher is still pre-panel and unconditionally commits, so the panel never stays on screen.

Adds an opt-in **Also stay open after a quick tap** toggle (Behavior ▸ Keyboard, off by default) that reveals and parks the panel on a pre-visible release instead. It only takes effect while **Stay open after releasing the modifier** is also on — the classic quick-tap instant flip is untouched for everyone else. Comes with a per-shortcut override, settings search, de/es/fr/pl strings, and tests for the park gate and override plumbing.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)