### PR TITLE
feat: adjustable switcher text size and font face

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -392,6 +392,8 @@ struct ShortcutOverride: Equatable, Sendable {
     // Appearance (resolved into `EffectiveSettings`).
     var layoutMode: SwitcherLayoutMode?
     var panelSize: PanelSize?
+    var fontScale: SwitcherFontScale?
+    var fontFace: SwitcherFontFace?
     var gridMaxColumns: Int?
     var accentChoice: SwitcherAccent?
     var customAccentHex: String?
@@ -416,6 +418,7 @@ struct ShortcutOverride: Equatable, Sendable {
             && expandBrowserTabsAsWindows == nil && stayOpenOnRelease == nil
             && stayOpenOnQuickTap == nil
             && layoutMode == nil && panelSize == nil
+            && fontScale == nil && fontFace == nil
             && gridMaxColumns == nil && accentChoice == nil && customAccentHex == nil
             && panelOpacity == nil && panelCornerRadius == nil && backdropMaterial == nil
             && showWindowTitleLabel == nil && previewTitleAlignment == nil
@@ -442,6 +445,8 @@ struct ShortcutOverride: Equatable, Sendable {
         put("stayOpenOnQuickTap", stayOpenOnQuickTap)
         if let layoutMode { d["layoutMode"] = layoutMode.rawValue }
         if let panelSize { d["panelSize"] = panelSize.rawValue }
+        if let fontScale { d["fontScale"] = fontScale.rawValue }
+        if let fontFace { d["fontFace"] = fontFace.rawValue }
         put("gridMaxColumns", gridMaxColumns)
         if let accentChoice { d["accentChoice"] = accentChoice.rawValue }
         if let customAccentHex { d["customAccentHex"] = customAccentHex }
@@ -474,6 +479,8 @@ struct ShortcutOverride: Equatable, Sendable {
         stayOpenOnQuickTap = bool("stayOpenOnQuickTap")
         layoutMode = dictionary["layoutMode"].flatMap(SwitcherLayoutMode.init(rawValue:))
         panelSize = dictionary["panelSize"].flatMap(PanelSize.init(rawValue:))
+        fontScale = dictionary["fontScale"].flatMap(SwitcherFontScale.init(rawValue:))
+        fontFace = dictionary["fontFace"].flatMap(SwitcherFontFace.init(rawValue:))
         gridMaxColumns = dictionary["gridMaxColumns"].flatMap(Int.init)
         accentChoice = dictionary["accentChoice"].flatMap(SwitcherAccent.init(rawValue:))
         customAccentHex = dictionary["customAccentHex"]
@@ -566,6 +573,67 @@ enum PanelSize: String, CaseIterable {
         case .small: return String(localized: "Small")
         case .standard: return String(localized: "Medium")
         case .large: return String(localized: "Large")
+        }
+    }
+}
+
+/// Multiplier applied to the switcher's name/title text only, independent of
+/// the panel size (#62). On very wide displays the screen-adaptive clamp in
+/// `SwitcherMetrics.forScreen` renders text at up to 1.8× base even at panel
+/// size Small; this lets users shrink (or grow) just the text while icons,
+/// tiles, and spacing keep following the panel size.
+enum SwitcherFontScale: String, CaseIterable, Sendable {
+    case extraSmall
+    case small
+    case standard
+    case large
+    case extraLarge
+
+    var multiplier: CGFloat {
+        switch self {
+        case .extraSmall: return 0.7
+        case .small: return 0.85
+        case .standard: return 1.0
+        case .large: return 1.15
+        case .extraLarge: return 1.3
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .extraSmall: return String(localized: "Extra small")
+        case .small: return String(localized: "Small")
+        case .standard: return String(localized: "Default")
+        case .large: return String(localized: "Large")
+        case .extraLarge: return String(localized: "Extra large")
+        }
+    }
+}
+
+/// Typeface for the switcher's name/title text (#62), expressed as a system
+/// font design so every weight/size stays available and nothing ships a font.
+/// Jump letters and count badges keep their dedicated system/monospaced fonts.
+enum SwitcherFontFace: String, CaseIterable, Sendable {
+    case system
+    case rounded
+    case serif
+    case monospaced
+
+    var systemDesign: NSFontDescriptor.SystemDesign {
+        switch self {
+        case .system: return .default
+        case .rounded: return .rounded
+        case .serif: return .serif
+        case .monospaced: return .monospaced
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .system: return String(localized: "System")
+        case .rounded: return String(localized: "Rounded")
+        case .serif: return String(localized: "Serif")
+        case .monospaced: return String(localized: "Monospaced")
         }
     }
 }
@@ -695,6 +763,8 @@ final class Preferences: ObservableObject {
         static let revealDelayMs = "Switcher.revealDelayMs"
         static let letterChainTimeoutMs = "Switcher.letterChainTimeoutMs"
         static let panelSize = "Switcher.panelSize"
+        static let fontScale = "Switcher.fontScale"
+        static let fontFace = "Switcher.fontFace"
         static let gridMaxColumns = "Switcher.gridMaxColumns"
         static let appExceptions = "Switcher.appExceptions"
         /// Pre-Exceptions key: a plain bundle-ID array of always-hidden apps.
@@ -850,6 +920,24 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != panelSize else { return }
             UserDefaults.standard.set(panelSize.rawValue, forKey: Keys.panelSize)
+        }
+    }
+
+    /// Multiplier applied to the switcher's name/title text only (#62) — icons,
+    /// tiles, and spacing keep following `panelSize`. Default `.standard` (1.0×,
+    /// identical to the pre-#62 rendering).
+    @Published var fontScale: SwitcherFontScale {
+        didSet {
+            guard oldValue != fontScale else { return }
+            UserDefaults.standard.set(fontScale.rawValue, forKey: Keys.fontScale)
+        }
+    }
+
+    /// Typeface for the switcher's name/title text (#62). Default `.system`.
+    @Published var fontFace: SwitcherFontFace {
+        didSet {
+            guard oldValue != fontFace else { return }
+            UserDefaults.standard.set(fontFace.rawValue, forKey: Keys.fontFace)
         }
     }
 
@@ -1681,6 +1769,9 @@ final class Preferences: ObservableObject {
         let sizeRaw = defaults.string(forKey: Keys.panelSize)
         self.panelSize = sizeRaw.flatMap(PanelSize.init(rawValue:)) ?? .standard
 
+        self.fontScale = defaults.string(forKey: Keys.fontScale).flatMap(SwitcherFontScale.init(rawValue:)) ?? .standard
+        self.fontFace = defaults.string(forKey: Keys.fontFace).flatMap(SwitcherFontFace.init(rawValue:)) ?? .system
+
         self.gridMaxColumns = defaults.object(forKey: Keys.gridMaxColumns) as? Int ?? 0
 
         // Exceptions: honor the new key if present, otherwise build a first-run
@@ -1824,6 +1915,8 @@ final class Preferences: ObservableObject {
         revealDelayMs = Self.clampDelay(defaults.object(forKey: Keys.revealDelayMs) as? Int ?? Self.defaultRevealDelayMs)
         letterChainTimeoutMs = Self.clampLetterChainTimeout(defaults.object(forKey: Keys.letterChainTimeoutMs) as? Int ?? Self.defaultLetterChainTimeoutMs)
         panelSize = defaults.string(forKey: Keys.panelSize).flatMap(PanelSize.init(rawValue:)) ?? .standard
+        fontScale = defaults.string(forKey: Keys.fontScale).flatMap(SwitcherFontScale.init(rawValue:)) ?? .standard
+        fontFace = defaults.string(forKey: Keys.fontFace).flatMap(SwitcherFontFace.init(rawValue:)) ?? .system
         gridMaxColumns = defaults.object(forKey: Keys.gridMaxColumns) as? Int ?? 0
 
         if let stored = defaults.array(forKey: Keys.appExceptions) as? [[String: String]] {

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -1,6 +1,286 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Default" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standard"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predeterminado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Par défaut"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domyślny"
+          }
+        }
+      }
+    },
+    "Extra large" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sehr groß"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muy grande"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Très grand"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bardzo duży"
+          }
+        }
+      }
+    },
+    "Extra small" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sehr klein"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muy pequeño"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Très petit"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bardzo mały"
+          }
+        }
+      }
+    },
+    "Font" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schrift"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de letra"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Police"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Czcionka"
+          }
+        }
+      }
+    },
+    "Monospaced" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monospace"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monoespaciada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À chasse fixe"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O stałej szerokości"
+          }
+        }
+      }
+    },
+    "Rounded" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abgerundet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redondeada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrondie"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaokrąglona"
+          }
+        }
+      }
+    },
+    "Serif" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serifen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serifa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sérif"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szeryfowa"
+          }
+        }
+      }
+    },
+    "Size of names and titles, independent of the panel size." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Größe der Namen und Titel, unabhängig von der Panelgröße."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamaño de los nombres y títulos, independiente del tamaño del panel."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taille des noms et des titres, indépendante de la taille du panneau."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozmiar nazw i tytułów, niezależny od rozmiaru panelu."
+          }
+        }
+      }
+    },
+    "Text size" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Textgröße"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamaño del texto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taille du texte"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozmiar tekstu"
+          }
+        }
+      }
+    },
+    "Typeface for names and titles." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schriftart für Namen und Titel."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de letra de los nombres y títulos."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Police des noms et des titres."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Krój pisma nazw i tytułów."
+          }
+        }
+      }
+    },
     "Use global default" : {
       "localizations" : {
         "de" : {

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -10,6 +10,8 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     private var titleAlignmentRadio: SettingsRadioGroupView!
     private var truncationRadio: SettingsRadioGroupView!
     private let gridPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let fontSizePopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let fontFacePopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let accentPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let windowTitleSwitch = NSSwitch()
     private let appNamesSwitch = NSSwitch()
@@ -25,6 +27,8 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     private let layoutModes: [SwitcherLayoutMode] = [.gridView, .list, .windowPreview]
     private let titleAlignments: [PreviewTitleAlignment] = [.leading, .center, .trailing]
     private let truncationModes: [TitleTruncationMode] = [.head, .middle, .tail]
+    private let fontScales: [SwitcherFontScale] = SwitcherFontScale.allCases
+    private let fontFaces: [SwitcherFontFace] = SwitcherFontFace.allCases
     private let panelSizes: [PanelSize] = PanelSize.allCases
     private let gridValues: [Int] = [0, 2, 3, 4, 5, 6] // 0 = automatic
     private let accents: [SwitcherAccent] = SwitcherAccent.allCases
@@ -47,6 +51,16 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
 
         // Labels section — the text on each row/tile.
         let labels = addSection(title: String(localized: "Labels"), anchor: SettingsAnchor.appearanceLabels)
+
+        configurePopup(fontSizePopup, titles: fontScales.map(\.displayName), action: #selector(fontScaleChanged))
+        addRow(to: labels, title: String(localized: "Text size"),
+               subtitle: String(localized: "Size of names and titles, independent of the panel size."),
+               accessory: fontSizePopup, searchItemID: SearchID.textSize)
+
+        configurePopup(fontFacePopup, titles: fontFaces.map(\.displayName), action: #selector(fontFaceChanged))
+        addRow(to: labels, title: String(localized: "Font"),
+               subtitle: String(localized: "Typeface for names and titles."),
+               accessory: fontFacePopup, searchItemID: SearchID.fontFace)
 
         configureSwitch(windowTitleSwitch, action: #selector(toggleWindowTitle(_:)))
         addRow(to: labels, title: String(localized: "Show window title"),
@@ -261,6 +275,14 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.selectTruncationMode($0) }
             .store(in: &cancellables)
+        prefs.$fontScale
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.selectFontScale($0) }
+            .store(in: &cancellables)
+        prefs.$fontFace
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.selectFontFace($0) }
+            .store(in: &cancellables)
         prefs.$boldSelectedLabel
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.boldSelectedSwitch.state = $0 ? .on : .off }
@@ -303,6 +325,8 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         windowTitleSwitch.state = prefs.showWindowTitleLabel ? .on : .off
         selectTitleAlignment(prefs.previewTitleAlignment)
         selectTruncationMode(prefs.titleTruncationMode)
+        selectFontScale(prefs.fontScale)
+        selectFontFace(prefs.fontFace)
         boldSelectedSwitch.state = prefs.boldSelectedLabel ? .on : .off
         appNamesSwitch.state = prefs.showApplicationNames ? .on : .off
         applyOpacity(prefs.panelOpacity)
@@ -373,6 +397,26 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
 
     private func selectTruncationMode(_ mode: TitleTruncationMode) {
         truncationRadio.select(identifier: mode.rawValue)
+    }
+
+    private func selectFontScale(_ scale: SwitcherFontScale) {
+        if let i = fontScales.firstIndex(of: scale) { fontSizePopup.selectItem(at: i) }
+    }
+
+    private func selectFontFace(_ face: SwitcherFontFace) {
+        if let i = fontFaces.firstIndex(of: face) { fontFacePopup.selectItem(at: i) }
+    }
+
+    @objc private func fontScaleChanged() {
+        let i = fontSizePopup.indexOfSelectedItem
+        guard fontScales.indices.contains(i) else { return }
+        Preferences.shared.fontScale = fontScales[i]
+    }
+
+    @objc private func fontFaceChanged() {
+        let i = fontFacePopup.indexOfSelectedItem
+        guard fontFaces.indices.contains(i) else { return }
+        Preferences.shared.fontFace = fontFaces[i]
     }
 
     @objc private func opacityChanged(_ sender: NSSlider) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -123,6 +123,8 @@ enum SearchID {
     static let windowTitle = "appearance.windowTitle"
     static let titleAlignment = "appearance.titleAlignment"
     static let titleTruncation = "appearance.titleTruncation"
+    static let textSize = "appearance.textSize"
+    static let fontFace = "appearance.fontFace"
     static let boldSelected = "appearance.boldSelected"
     static let opacity = "appearance.opacity"
     static let cornerRadius = "appearance.cornerRadius"
@@ -337,6 +339,10 @@ enum SettingsCatalog {
         item(SearchID.gridColumns, .appearance, SettingsAnchor.appearanceLayout, String(localized: "Appearance"), String(localized: "Layout"),
              String(localized: "Grid columns"), ["grid", "columns"]),
         // Appearance · Labels
+        item(SearchID.textSize, .appearance, SettingsAnchor.appearanceLabels, String(localized: "Appearance"), String(localized: "Labels"),
+             String(localized: "Text size"), ["text size", "font size", "smaller", "larger", "text", "scale"]),
+        item(SearchID.fontFace, .appearance, SettingsAnchor.appearanceLabels, String(localized: "Appearance"), String(localized: "Labels"),
+             String(localized: "Font"), ["font", "typeface", "face", "monospaced", "fixed width", "mono", "rounded", "serif"]),
         item(SearchID.windowTitle, .appearance, SettingsAnchor.appearanceLabels, String(localized: "Appearance"), String(localized: "Labels"),
              String(localized: "Show window title"), ["window title", "title", "label", "name"]),
         item(SearchID.titleAlignment, .appearance, SettingsAnchor.appearanceLabels, String(localized: "Appearance"), String(localized: "Labels"),

--- a/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
+++ b/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
@@ -85,6 +85,8 @@ final class ShortcutOptionsFormView: NSView {
         let appearance = SettingsSectionView(title: String(localized: "Appearance"))
         addEnumRow(to: appearance, title: String(localized: "Layout"), options: [.gridView, .list, .windowPreview] as [SwitcherLayoutMode], display: { $0.displayName }, current: override.layoutMode) { [weak self] in self?.override.layoutMode = $0; self?.persist() }
         addEnumRow(to: appearance, title: String(localized: "Size"), options: PanelSize.allCases, display: { $0.displayName }, current: override.panelSize) { [weak self] in self?.override.panelSize = $0; self?.persist() }
+        addEnumRow(to: appearance, title: String(localized: "Text size"), options: SwitcherFontScale.allCases, display: { $0.displayName }, current: override.fontScale) { [weak self] in self?.override.fontScale = $0; self?.persist() }
+        addEnumRow(to: appearance, title: String(localized: "Font"), options: SwitcherFontFace.allCases, display: { $0.displayName }, current: override.fontFace) { [weak self] in self?.override.fontFace = $0; self?.persist() }
         addIntRow(to: appearance, title: String(localized: "Grid columns"),
                   subtitle: String(localized: "Applies to the Grid and Previews layouts."),
                   values: [0, 2, 3, 4, 5, 6], display: { $0 == 0 ? String(localized: "Automatic") : "\($0)" }, current: override.gridMaxColumns) { [weak self] in self?.override.gridMaxColumns = $0; self?.persist() }

--- a/BetterCmdTab/Switcher/EffectiveSettings.swift
+++ b/BetterCmdTab/Switcher/EffectiveSettings.swift
@@ -15,6 +15,8 @@ struct EffectiveSettings {
     let resolvedAccent: NSColor
     let layoutMode: SwitcherLayoutMode
     let panelSize: PanelSize
+    let fontScale: SwitcherFontScale
+    let fontFace: SwitcherFontFace
     let gridMaxColumns: Int
     let panelOpacity: Int
     let panelCornerRadius: Int
@@ -59,6 +61,8 @@ extension Preferences {
             resolvedAccent: accent,
             layoutMode: override.layoutMode ?? switcherLayoutMode,
             panelSize: override.panelSize ?? panelSize,
+            fontScale: override.fontScale ?? fontScale,
+            fontFace: override.fontFace ?? fontFace,
             gridMaxColumns: override.gridMaxColumns ?? gridMaxColumns,
             panelOpacity: override.panelOpacity ?? panelOpacity,
             panelCornerRadius: override.panelCornerRadius ?? panelCornerRadius,

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -2438,7 +2438,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// in `handleScreenParametersChange()`; `refreshDisplay()` re-presents.
     private func applySessionScreen(_ screen: NSScreen) {
         panel.targetScreen = screen
-        currentMetrics = SwitcherMetrics.forScreen(screen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+        currentMetrics = SwitcherMetrics.forScreen(screen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, fontScale: effective.fontScale.multiplier, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
         refreshDisplay()
     }
 
@@ -2749,7 +2749,7 @@ final class SwitcherController: SwitcherViewDelegate {
 
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
-        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, fontScale: effective.fontScale.multiplier, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, effective: effective, highlightPrefix: letterBuffer)
         panel.present(opacity: effective.panelOpacity)
         phase = .visible
@@ -2857,7 +2857,7 @@ final class SwitcherController: SwitcherViewDelegate {
 
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
-        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+        currentMetrics = SwitcherMetrics.forScreen(sessionScreen, layoutMode: effective.layoutMode, userScale: effective.panelSize.scale, fontScale: effective.fontScale.multiplier, letterHints: effective.letterHintsEnabled, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, effective: effective, highlightPrefix: letterBuffer)
         panel.present(opacity: effective.panelOpacity)
         phase = .visible

--- a/BetterCmdTab/Switcher/SwitcherFont.swift
+++ b/BetterCmdTab/Switcher/SwitcherFont.swift
@@ -1,0 +1,32 @@
+import AppKit
+
+/// Resolves the switcher's name/title font for the user's chosen face (#62).
+/// Non-system designs go through an `NSFontDescriptor.withDesign` resolve,
+/// which is memoized so it runs once per (size, weight, face) — never per row
+/// apply on the reveal path. Jump letters and count badges keep their
+/// dedicated system/monospaced fonts and never come through here.
+@MainActor
+enum SwitcherFont {
+    private struct Key: Hashable {
+        let size: CGFloat
+        let weight: NSFont.Weight
+        let design: SwitcherFontFace
+    }
+
+    private static var cache: [Key: NSFont] = [:]
+    /// Small hard cap: a session touches a handful of (size, weight) pairs per
+    /// face; overflow just clears (next lookups re-resolve and re-fill).
+    private static let cacheLimit = 64
+
+    static func font(ofSize size: CGFloat, weight: NSFont.Weight, design: SwitcherFontFace) -> NSFont {
+        guard design != .system else { return .systemFont(ofSize: size, weight: weight) }
+        let key = Key(size: size, weight: weight, design: design)
+        if let cached = cache[key] { return cached }
+        let system = NSFont.systemFont(ofSize: size, weight: weight)
+        let resolved = system.fontDescriptor.withDesign(design.systemDesign)
+            .flatMap { NSFont(descriptor: $0, size: size) } ?? system
+        if cache.count >= cacheLimit { cache.removeAll(keepingCapacity: true) }
+        cache[key] = resolved
+        return resolved
+    }
+}

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -191,6 +191,10 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         imageView.image = nil
     }
 
+    /// Last face the font pass ran with — pooled views must re-apply fonts when
+    /// the user changes the face pref even though `metrics` is unchanged (#62).
+    private var appliedFace: SwitcherFontFace = .system
+
     func configure(with row: SwitcherRow, label: String, prefixLength: Int, selected: Bool, metrics: SwitcherMetrics, accent: NSColor, effective: EffectiveSettings) {
         self.effective = effective
         // Ellipsis position for long titles (#90). Guarded set — one enum read,
@@ -201,7 +205,11 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         if titleLabel.lineBreakMode != truncation {
             titleLabel.lineBreakMode = truncation
         }
-        if metrics != self.metrics {
+        // Font face (#62) is not part of `metrics` and views are pooled across
+        // reveals, so track the applied face and re-run the font pass on change.
+        let faceChanged = appliedFace != effective.fontFace
+        if faceChanged { appliedFace = effective.fontFace }
+        if faceChanged || metrics != self.metrics {
             applyMetrics(metrics)
         }
         if self.accent != accent {
@@ -339,7 +347,8 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
             text: text,
             fontSize: metrics.tileTitleFontSize,
             accentKey: accentKey,
-            truncation: effective.titleTruncationMode
+            truncation: effective.titleTruncationMode,
+            face: effective.fontFace
         )
         return Self.titleCache.value(for: key) {
             self.buildTitle(indicators: indicators, text: text)
@@ -347,7 +356,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     }
 
     private func buildTitle(indicators: [SwitcherIndicator], text: String) -> NSAttributedString {
-        let font = NSFont.systemFont(ofSize: metrics.tileTitleFontSize, weight: .regular)
+        let font = SwitcherFont.font(ofSize: metrics.tileTitleFontSize, weight: .regular, design: effective.fontFace)
         let para = NSMutableParagraphStyle()
         para.alignment = .center
         para.lineBreakMode = effective.titleTruncationMode.lineBreakMode
@@ -382,8 +391,8 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         self.metrics = metrics
         letterLabel.font = NSFont.monospacedSystemFont(ofSize: metrics.tileLetterFontSize, weight: .bold)
         badgeLabel.font = NSFont.systemFont(ofSize: metrics.tileLetterFontSize, weight: .bold)
-        nameLabel.font = NSFont.systemFont(ofSize: metrics.tileNameFontSize, weight: .medium)
-        titleLabel.font = NSFont.systemFont(ofSize: metrics.tileTitleFontSize, weight: .regular)
+        nameLabel.font = SwitcherFont.font(ofSize: metrics.tileNameFontSize, weight: .medium, design: effective.fontFace)
+        titleLabel.font = SwitcherFont.font(ofSize: metrics.tileTitleFontSize, weight: .regular, design: effective.fontFace)
         selectionBackdrop.layer?.cornerRadius = metrics.tileSelectionCornerRadius
         needsLayout = true
     }
@@ -394,9 +403,10 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         // Bolding the selected name is optional (#72) — off keeps a steady weight
         // so the label doesn't grow/shrink as selection moves; it still brightens.
         let bold = isSelected && effective.boldSelectedLabel
-        nameLabel.font = NSFont.systemFont(
+        nameLabel.font = SwitcherFont.font(
             ofSize: metrics.tileNameFontSize,
-            weight: bold ? .semibold : .medium
+            weight: bold ? .semibold : .medium,
+            design: effective.fontFace
         )
         // The jump letter doesn't depend on selection, so it is rendered once in
         // `configure` rather than re-built on every selection move.
@@ -425,6 +435,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         let fontSize: CGFloat
         let accentKey: String
         let truncation: TitleTruncationMode
+        let face: SwitcherFontFace
     }
     /// The fully assembled secondary line (tinted glyph attachments + text) is
     /// the same immutable string for any tile with the same inputs, so memoize

--- a/BetterCmdTab/Switcher/SwitcherItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherItemView.swift
@@ -171,6 +171,10 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         imageView.image = nil
     }
 
+    /// Last face the font pass ran with — pooled views must re-apply fonts when
+    /// the user changes the face pref even though `metrics` is unchanged (#62).
+    private var appliedFace: SwitcherFontFace = .system
+
     func configure(with row: SwitcherRow, label: String, prefixLength: Int, selected: Bool, metrics: SwitcherMetrics, accent: NSColor, effective: EffectiveSettings) {
         self.effective = effective
         // Ellipsis position for long titles (#90). Guarded set — one enum read,
@@ -179,7 +183,11 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         if titleLabel.lineBreakMode != truncation {
             titleLabel.lineBreakMode = truncation
         }
-        if metrics != self.metrics {
+        // Font face (#62) is not part of `metrics` and views are pooled across
+        // reveals, so track the applied face and re-run the font pass on change.
+        let faceChanged = appliedFace != effective.fontFace
+        if faceChanged { appliedFace = effective.fontFace }
+        if faceChanged || metrics != self.metrics {
             applyMetrics(metrics)
         }
         if self.accent != accent {
@@ -259,7 +267,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
 
     private func applyMetrics(_ metrics: SwitcherMetrics) {
         self.metrics = metrics
-        let font = NSFont.systemFont(ofSize: metrics.fontSize)
+        let font = SwitcherFont.font(ofSize: metrics.fontSize, weight: .regular, design: effective.fontFace)
         appNameLabel.font = font
         titleLabel.font = font
         badgeLabel.font = NSFont.systemFont(ofSize: max(9, metrics.fontSize - 2), weight: .bold)

--- a/BetterCmdTab/Switcher/SwitcherMetrics.swift
+++ b/BetterCmdTab/Switcher/SwitcherMetrics.swift
@@ -3,6 +3,9 @@ import AppKit
 struct SwitcherMetrics: Equatable {
     let layoutMode: SwitcherLayoutMode
     let scale: CGFloat
+    /// Extra multiplier applied to text sizes (and the areas that hold text)
+    /// only (#62) — icons, tiles, and spacing keep following `scale`.
+    let fontScale: CGFloat
     let rowHeight: CGFloat
     let rowWidth: CGFloat
     let iconSize: CGFloat
@@ -98,20 +101,26 @@ struct SwitcherMetrics: Equatable {
 
     static let baseline = SwitcherMetrics.forScale(1.0, layoutMode: .list)
 
-    static func forScreen(_ screen: NSScreen?, layoutMode: SwitcherLayoutMode = .list, userScale: CGFloat = 1.0, letterHints: Bool = true, showAppNames: Bool = true, showWindowTitles: Bool = true, hoverActionCount: Int = 0, browserTabsExpanded: Bool = false) -> SwitcherMetrics {
+    static func forScreen(_ screen: NSScreen?, layoutMode: SwitcherLayoutMode = .list, userScale: CGFloat = 1.0, fontScale: CGFloat = 1.0, letterHints: Bool = true, showAppNames: Bool = true, showWindowTitles: Bool = true, hoverActionCount: Int = 0, browserTabsExpanded: Bool = false) -> SwitcherMetrics {
         let width = screen?.frame.width ?? referenceWidth
         let raw = width / referenceWidth
         // Screen-adaptive clamp first (keep base size on small displays, cap on
         // huge ones), then fold in the user's size preference as a free multiplier
         // so "Small" can shrink below the 1.0 floor.
         let clamped = max(1.0, min(1.8, raw)) * userScale
-        return forScale(clamped, layoutMode: layoutMode, letterHints: letterHints, showAppNames: showAppNames, showWindowTitles: showWindowTitles, hoverActionCount: hoverActionCount, browserTabsExpanded: browserTabsExpanded)
+        return forScale(clamped, layoutMode: layoutMode, fontScale: fontScale, letterHints: letterHints, showAppNames: showAppNames, showWindowTitles: showWindowTitles, hoverActionCount: hoverActionCount, browserTabsExpanded: browserTabsExpanded)
     }
 
     /// `letterHints == false` collapses the space the jump-letter occupies — the
     /// top strip on tiles and the left column in the list — so the panel reflows
     /// tighter when the user turned letter hints off.
-    static func forScale(_ scale: CGFloat, layoutMode: SwitcherLayoutMode = .list, letterHints: Bool = true, showAppNames: Bool = true, showWindowTitles: Bool = true, hoverActionCount: Int = 0, browserTabsExpanded: Bool = false) -> SwitcherMetrics {
+    static func forScale(_ scale: CGFloat, layoutMode: SwitcherLayoutMode = .list, fontScale: CGFloat = 1.0, letterHints: Bool = true, showAppNames: Bool = true, showWindowTitles: Bool = true, hoverActionCount: Int = 0, browserTabsExpanded: Bool = false) -> SwitcherMetrics {
+        // Text-only multiplier (#62): every *font* size scales by `f`, and every
+        // container whose height/width exists to hold that text scales by
+        // `scale * f` so text never clips. Icon sizes, tile geometry, paddings,
+        // and gaps stay on `scale` alone. Row height floors at `f == 1` so
+        // shrinking text never squeezes the icon-driven row.
+        let f = fontScale
         let outerPadding: CGFloat
         let cornerRadius: CGFloat
         switch layoutMode {
@@ -123,7 +132,7 @@ struct SwitcherMetrics: Equatable {
             cornerRadius = round(baseTileCornerRadius * scale)
         }
 
-        let letterColumnW = letterHints ? round(baseLetterColumnWidth * scale) : 0
+        let letterColumnW = letterHints ? round(baseLetterColumnWidth * scale * f) : 0
 
         // Hiding app names removes the List layout's dedicated name column so the
         // panel narrows. But the hover action bar floats over that column; with no
@@ -157,9 +166,9 @@ struct SwitcherMetrics: Equatable {
         if layoutMode == .gridView, !showAppNames, !showWindowTitles {
             tileLabelAreaH = 0
         } else if layoutMode == .gridView, !(showAppNames && showWindowTitles) {
-            tileLabelAreaH = round(baseTileCompactLabelArea * scale)
+            tileLabelAreaH = round(baseTileCompactLabelArea * scale * f)
         } else {
-            tileLabelAreaH = round(baseTileLabelArea * scale)
+            tileLabelAreaH = round(baseTileLabelArea * scale * f)
         }
 
         // Preview tiles carry a single label row: small app icon + window title.
@@ -173,34 +182,35 @@ struct SwitcherMetrics: Equatable {
         // heights stay aligned) even with the title otherwise hidden.
         let previewLabelAreaH = (layoutMode == .windowPreview && !showWindowTitles && !browserTabsExpanded)
             ? 0
-            : round(basePreviewLabelArea * scale)
+            : round(basePreviewLabelArea * scale * f)
 
         return SwitcherMetrics(
             layoutMode: layoutMode,
             scale: scale,
-            rowHeight: round(baseRowHeight * scale),
+            fontScale: f,
+            rowHeight: round(baseRowHeight * scale * max(1.0, f)),
             rowWidth: rowW,
             iconSize: round(baseIconSize * scale),
             appNameWidth: appNameW,
             interGap: round(baseInterGap * scale),
             horizontalInset: round(baseHorizontalInset * scale),
-            fontSize: baseFontSize * scale,
+            fontSize: baseFontSize * scale * f,
             outerPadding: outerPadding,
             cornerRadius: cornerRadius,
             highlightCornerRadius: round(baseHighlightCornerRadius * scale),
             highlightInset: round(baseHighlightInset * scale),
-            labelHeight: round(baseLabelHeight * scale),
+            labelHeight: round(baseLabelHeight * scale * f),
             letterColumnWidth: letterColumnW,
-            letterFontSize: baseLetterFontSize * scale,
+            letterFontSize: baseLetterFontSize * scale * f,
             tileSize: round(baseTileSize * scale),
             tileIconSize: round(baseTileIconSize * scale),
             tileGap: round(baseTileGap * scale),
             tileLabelArea: tileLabelAreaH,
-            tileLetterArea: letterHints ? round(baseTileLetterArea * scale) : 0,
-            tileNameFontSize: baseTileNameFontSize * scale,
-            tileTitleFontSize: baseTileTitleFontSize * scale,
-            tileLetterFontSize: baseTileLetterFontSize * scale,
-            tileLetterBadgeSize: round(baseTileLetterBadgeSize * scale),
+            tileLetterArea: letterHints ? round(baseTileLetterArea * scale * f) : 0,
+            tileNameFontSize: baseTileNameFontSize * scale * f,
+            tileTitleFontSize: baseTileTitleFontSize * scale * f,
+            tileLetterFontSize: baseTileLetterFontSize * scale * f,
+            tileLetterBadgeSize: round(baseTileLetterBadgeSize * scale * f),
             tileStatusIconSize: round(baseTileStatusIconSize * scale),
             tileSelectionInset: round(baseTileSelectionInset * scale),
             tileSelectionCornerRadius: round(baseTileSelectionCornerRadius * scale),
@@ -208,9 +218,9 @@ struct SwitcherMetrics: Equatable {
             previewThumbHeight: round(basePreviewThumbHeight * scale),
             previewGap: round(basePreviewGap * scale),
             previewLabelArea: previewLabelAreaH,
-            previewLetterArea: letterHints ? round(baseTileLetterArea * scale) : 0,
+            previewLetterArea: letterHints ? round(baseTileLetterArea * scale * f) : 0,
             previewIconSize: round(basePreviewIconSize * scale),
-            previewNameFontSize: basePreviewNameFontSize * scale,
+            previewNameFontSize: basePreviewNameFontSize * scale * f,
             previewThumbCornerRadius: round(basePreviewThumbCornerRadius * scale),
             previewSelectionInset: round(basePreviewSelectionInset * scale),
             previewSelectionCornerRadius: round(basePreviewSelectionCornerRadius * scale)

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -189,6 +189,10 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         windowID = 0
     }
 
+    /// Last face the font pass ran with — pooled views must re-apply fonts when
+    /// the user changes the face pref even though `metrics` is unchanged (#62).
+    private var appliedFace: SwitcherFontFace = .system
+
     func configure(with row: SwitcherRow, label: String, prefixLength: Int, selected: Bool, metrics: SwitcherMetrics, accent: NSColor, effective: EffectiveSettings) {
         self.effective = effective
         // Ellipsis position for long titles (#90). Guarded set — one enum read,
@@ -197,7 +201,11 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         if nameLabel.lineBreakMode != truncation {
             nameLabel.lineBreakMode = truncation
         }
-        if metrics != self.metrics {
+        // Font face (#62) is not part of `metrics` and views are pooled across
+        // reveals, so track the applied face and re-run the font pass on change.
+        let faceChanged = appliedFace != effective.fontFace
+        if faceChanged { appliedFace = effective.fontFace }
+        if faceChanged || metrics != self.metrics {
             applyMetrics(metrics)
         }
         if self.accent != accent {
@@ -294,7 +302,7 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     private func applyMetrics(_ metrics: SwitcherMetrics) {
         self.metrics = metrics
         letterLabel.font = NSFont.monospacedSystemFont(ofSize: metrics.tileLetterFontSize, weight: .bold)
-        nameLabel.font = NSFont.systemFont(ofSize: metrics.previewNameFontSize, weight: .medium)
+        nameLabel.font = SwitcherFont.font(ofSize: metrics.previewNameFontSize, weight: .medium, design: effective.fontFace)
         thumbContainer.layer?.cornerRadius = metrics.previewThumbCornerRadius
         selectionBackdrop.layer?.cornerRadius = metrics.previewSelectionCornerRadius
         needsLayout = true
@@ -306,9 +314,10 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         // The selected title brightens to `labelColor`; bolding it is optional so
         // users who dislike the on-select width wobble keep a steady weight (#72).
         let bold = isSelected && effective.boldSelectedLabel
-        nameLabel.font = NSFont.systemFont(
+        nameLabel.font = SwitcherFont.font(
             ofSize: metrics.previewNameFontSize,
-            weight: bold ? .semibold : .medium
+            weight: bold ? .semibold : .medium,
+            design: effective.fontFace
         )
     }
 
@@ -420,7 +429,9 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
             // sized for .medium clipping a later semibold render. The bold width fits
             // the medium render too (~1pt slack); the outer `min` still clamps to the
             // tile's free width. Constant weight also keeps this off the pref read path.
-            let measureFont = NSFont.systemFont(ofSize: m.previewNameFontSize, weight: .semibold)
+            // Same face as the render (#62) or the ellipsis math breaks —
+            // monospaced faces are wider than the system face at equal size.
+            let measureFont = SwitcherFont.font(ofSize: m.previewNameFontSize, weight: .semibold, design: effective.fontFace)
             let textW = (nameLabel.stringValue as NSString).size(withAttributes: [.font: measureFont]).width
             let nameW = min(ceil(textW) + Self.labelCellInset, w - iconSize - 6 - badgeSlot)
             let groupW = iconSize + 4 + nameW + badgeSlot

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -150,6 +150,7 @@ final class SwitcherView: NSView, TabStripDelegate {
         self.accent = effective.resolvedAccent
         self.selectedIndex = selectedIndex
         searchBar.update(query: searchQuery)
+        searchBar.applyFont(fontScale: metrics.fontScale, face: effective.fontFace)
         searchBar.isHidden = !searchActive
         if let titles = tabStripTitles, !titles.isEmpty {
             tabStrip.configure(titles: titles, selectedIndex: tabStripSelectedIndex, accent: accent)
@@ -169,7 +170,7 @@ final class SwitcherView: NSView, TabStripDelegate {
             emptyTitle.stringValue = searchActive
                 ? String(localized: "No matches")
                 : String(localized: "No open windows")
-            emptyTitle.font = .systemFont(ofSize: round(14 * metrics.scale), weight: .semibold)
+            emptyTitle.font = SwitcherFont.font(ofSize: round(14 * metrics.scale * metrics.fontScale), weight: .semibold, design: effective.fontFace)
         }
         emptyIcon.isHidden = !rows.isEmpty
         emptyTitle.isHidden = !rows.isEmpty
@@ -655,7 +656,7 @@ final class SwitcherView: NSView, TabStripDelegate {
         var candidate = base
         while scale > minScale + 0.001 {
             scale = max(minScale, scale - 0.05)
-            candidate = SwitcherMetrics.forScale(scale, layoutMode: base.layoutMode, letterHints: letterHints, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
+            candidate = SwitcherMetrics.forScale(scale, layoutMode: base.layoutMode, fontScale: effective.fontScale.multiplier, letterHints: letterHints, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: effective.expandBrowserTabsAsWindows && !effective.applicationsOnly)
             if fits(candidate) { return candidate }
         }
         return candidate
@@ -958,6 +959,8 @@ private final class SwitcherSearchBarView: NSView {
         field.font = .systemFont(ofSize: 14, weight: .medium)
         field.lineBreakMode = .byTruncatingTail
         field.translatesAutoresizingMaskIntoConstraints = false
+        // Text size/face applied per reveal via `applyFont` (#62) — the bar is
+        // created once, so the init font is only the pre-first-reveal default.
 
         addSubview(icon)
         addSubview(field)
@@ -999,6 +1002,15 @@ private final class SwitcherSearchBarView: NSView {
             field.stringValue = query
             field.textColor = .labelColor
         }
+    }
+
+    /// Text size/face for the query text (#62), applied per reveal — the bar is
+    /// created once and pooled, so a pref change must reach the live field.
+    /// Guarded: `SwitcherFont` memoizes, so the common no-change path is one
+    /// dictionary hit + pointer compare.
+    func applyFont(fontScale: CGFloat, face: SwitcherFontFace) {
+        let font = SwitcherFont.font(ofSize: round(14 * fontScale), weight: .medium, design: face)
+        if field.font != font { field.font = font }
     }
 
     private func updateAppearance() {

--- a/BetterCmdTab/Switcher/TabStripView.swift
+++ b/BetterCmdTab/Switcher/TabStripView.swift
@@ -88,16 +88,22 @@ final class TabStripView: NSView {
             stack.removeArrangedSubview(cell)
             cell.removeFromSuperview()
         }
-        // Ellipsis position for long titles (#90): global preference only (the
-        // per-shortcut override deliberately does not reach the strip). Cells
-        // are pooled across configures, so apply it here — one enum read per
-        // drill-in — rather than once in `TabStripCell.init`.
-        let truncation = Preferences.shared.titleTruncationMode.lineBreakMode
+        // Ellipsis position (#90) and text size/face (#62): global preferences
+        // only (the per-shortcut override deliberately does not reach the
+        // strip). Cells are pooled across configures, so apply both here — one
+        // pref read + one memoized font resolve per drill-in — rather than once
+        // in `TabStripCell.init`.
+        let prefs = Preferences.shared
+        let truncation = prefs.titleTruncationMode.lineBreakMode
+        let font = SwitcherFont.font(ofSize: round(12 * prefs.fontScale.multiplier),
+                                     weight: .medium,
+                                     design: prefs.fontFace)
         for (i, title) in titles.enumerated() {
             cells[i].configure(title: title.isEmpty ? String(localized: "Untitled") : title,
                                selected: i == selectedIndex,
                                accent: accent,
-                               truncation: truncation)
+                               truncation: truncation,
+                               font: font)
         }
         scrollSelectedIntoView()
     }
@@ -172,9 +178,12 @@ private final class TabStripCell: NSView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
 
-    func configure(title: String, selected: Bool, accent: NSColor, truncation: NSLineBreakMode) {
+    func configure(title: String, selected: Bool, accent: NSColor, truncation: NSLineBreakMode, font: NSFont) {
         if label.lineBreakMode != truncation {
             label.lineBreakMode = truncation
+        }
+        if label.font != font {
+            label.font = font
         }
         label.stringValue = title
         isSelected = selected

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -121,6 +121,35 @@ struct PreferencesEnumTests {
         #expect(fresh == .tail)
     }
 
+    @Test("SwitcherFontScale raw values round-trip and multipliers strictly increase")
+    func fontScaleRoundTrip() {
+        for scale in SwitcherFontScale.allCases {
+            #expect(SwitcherFontScale(rawValue: scale.rawValue) == scale)
+            #expect(!scale.displayName.isEmpty)
+        }
+        // allCases is ordered smallest → largest; the multipliers must agree so
+        // the settings popup reads as a monotonic size ramp.
+        let multipliers = SwitcherFontScale.allCases.map(\.multiplier)
+        #expect(multipliers == multipliers.sorted())
+        #expect(Set(multipliers).count == multipliers.count)
+        #expect(SwitcherFontScale.standard.multiplier == 1.0)
+        // Unknown raw value → nil, so the init read falls back to .standard.
+        #expect(SwitcherFontScale(rawValue: "huge") == nil)
+    }
+
+    @Test("SwitcherFontFace raw values round-trip and map to SystemDesign")
+    func fontFaceRoundTrip() {
+        for face in SwitcherFontFace.allCases {
+            #expect(SwitcherFontFace(rawValue: face.rawValue) == face)
+            #expect(!face.displayName.isEmpty)
+        }
+        #expect(SwitcherFontFace.system.systemDesign == .default)
+        #expect(SwitcherFontFace.rounded.systemDesign == .rounded)
+        #expect(SwitcherFontFace.serif.systemDesign == .serif)
+        #expect(SwitcherFontFace.monospaced.systemDesign == .monospaced)
+        #expect(SwitcherFontFace(rawValue: "papyrus") == nil)
+    }
+
     @MainActor
     @Test("titleGroupOriginX places the preview title at the chosen edge")
     func titleGroupOriginX() {

--- a/BetterCmdTabTests/ShortcutOverrideTests.swift
+++ b/BetterCmdTabTests/ShortcutOverrideTests.swift
@@ -97,6 +97,8 @@ struct ShortcutOverrideTests {
         ov.stayOpenOnQuickTap = false
         ov.layoutMode = .list
         ov.panelSize = .large
+        ov.fontScale = .small
+        ov.fontFace = .monospaced
         ov.gridMaxColumns = 7
         ov.accentChoice = .custom
         ov.customAccentHex = "#1A2B3C"
@@ -294,6 +296,24 @@ struct ShortcutOverrideTests {
         #expect(prefs.effectiveSettings(for: ov).stayOpenOnQuickTap == target)
         // Unset inherits the global.
         #expect(prefs.effectiveSettings(for: ShortcutOverride()).stayOpenOnQuickTap == prefs.stayOpenOnQuickTap)
+    }
+
+    @Test("text size and font face resolve the override over the global (#62)")
+    func effectiveFontOverride() {
+        let prefs = Preferences.shared
+        var ov = ShortcutOverride()
+        // Force values that differ from the current globals so the assertions are real.
+        let scaleTarget: SwitcherFontScale = prefs.fontScale == .large ? .small : .large
+        let faceTarget: SwitcherFontFace = prefs.fontFace == .monospaced ? .rounded : .monospaced
+        ov.fontScale = scaleTarget
+        ov.fontFace = faceTarget
+        let eff = prefs.effectiveSettings(for: ov)
+        #expect(eff.fontScale == scaleTarget)
+        #expect(eff.fontFace == faceTarget)
+        // Unset inherits the globals.
+        let inherited = prefs.effectiveSettings(for: ShortcutOverride())
+        #expect(inherited.fontScale == prefs.fontScale)
+        #expect(inherited.fontFace == prefs.fontFace)
     }
 
     @Test("title truncation resolves the override over the global (#90)")

--- a/BetterCmdTabTests/SwitcherFontTests.swift
+++ b/BetterCmdTabTests/SwitcherFontTests.swift
@@ -1,0 +1,33 @@
+import AppKit
+import Testing
+@testable import BetterCmdTab
+
+/// Coverage for the memoized font factory (#62). NSFont resolution works
+/// headless, so these run in the plain unit suite — no WindowServer needed.
+@Suite("SwitcherFont")
+@MainActor
+struct SwitcherFontTests {
+    @Test("monospaced design yields a fixed-pitch font (the issue's ask)")
+    func monospacedIsFixedPitch() {
+        let font = SwitcherFont.font(ofSize: 13, weight: .regular, design: .monospaced)
+        #expect(font.isFixedPitch)
+    }
+
+    @Test("every design preserves the requested point size; .system is the system font")
+    func designPreservesPointSizeAndWeight() {
+        for face in SwitcherFontFace.allCases {
+            let font = SwitcherFont.font(ofSize: 13, weight: .medium, design: face)
+            #expect(font.pointSize == 13)
+        }
+        #expect(SwitcherFont.font(ofSize: 14, weight: .medium, design: .system)
+            == NSFont.systemFont(ofSize: 14, weight: .medium))
+    }
+
+    @Test("repeat lookups return the same instance (resolve once, not per row)")
+    func cacheReturnsIdenticalInstance() {
+        // Pinned to a memoized design — .system is the unmemoized fast path.
+        let a = SwitcherFont.font(ofSize: 13, weight: .semibold, design: .monospaced)
+        let b = SwitcherFont.font(ofSize: 13, weight: .semibold, design: .monospaced)
+        #expect(a === b)
+    }
+}

--- a/BetterCmdTabTests/SwitcherMetricsTests.swift
+++ b/BetterCmdTabTests/SwitcherMetricsTests.swift
@@ -157,6 +157,54 @@ struct SwitcherMetricsTests {
     func userScaleDefault() {
         #expect(SwitcherMetrics.forScreen(nil) == SwitcherMetrics.forScreen(nil, userScale: 1.0))
     }
+
+    @Test("fontScale defaults to 1.0 (no behavior change)")
+    func fontScaleDefaultIdentity() {
+        #expect(SwitcherMetrics.forScale(1.2) == SwitcherMetrics.forScale(1.2, fontScale: 1.0))
+        #expect(SwitcherMetrics.forScreen(nil) == SwitcherMetrics.forScreen(nil, fontScale: 1.0))
+    }
+
+    @Test("fontScale multiplies every font size (#62)")
+    func fontScaleScalesAllFonts() {
+        let m = SwitcherMetrics.forScale(1.0, fontScale: 1.3)
+        #expect(m.fontSize == SwitcherMetrics.baseFontSize * 1.3)
+        #expect(m.letterFontSize == SwitcherMetrics.baseLetterFontSize * 1.3)
+        #expect(m.tileNameFontSize == SwitcherMetrics.baseTileNameFontSize * 1.3)
+        #expect(m.tileTitleFontSize == SwitcherMetrics.baseTileTitleFontSize * 1.3)
+        #expect(m.tileLetterFontSize == SwitcherMetrics.baseTileLetterFontSize * 1.3)
+        #expect(m.previewNameFontSize == SwitcherMetrics.basePreviewNameFontSize * 1.3)
+    }
+
+    @Test("fontScale grows the areas that hold text, not the tile geometry")
+    func fontScaleGrowsTextAreas() {
+        let m = SwitcherMetrics.forScale(1.0, fontScale: 1.3)
+        #expect(m.labelHeight == round(SwitcherMetrics.baseLabelHeight * 1.3))
+        #expect(m.letterColumnWidth == round(SwitcherMetrics.baseLetterColumnWidth * 1.3))
+        #expect(m.previewLabelArea == round(SwitcherMetrics.basePreviewLabelArea * 1.3))
+        let grid = SwitcherMetrics.forScale(1.0, layoutMode: .gridView, fontScale: 1.3)
+        #expect(grid.tileLabelArea == round(SwitcherMetrics.baseTileLabelArea * 1.3))
+        #expect(grid.tileLetterArea == round(SwitcherMetrics.baseTileLetterArea * 1.3))
+        // Icon/tile geometry stays on the panel scale alone.
+        #expect(grid.tileSize == SwitcherMetrics.baseTileSize)
+        #expect(grid.tileIconSize == SwitcherMetrics.baseTileIconSize)
+        #expect(m.iconSize == SwitcherMetrics.baseIconSize)
+    }
+
+    @Test("shrinking text keeps the icon-driven row height, growing raises it")
+    func fontScaleShrinkKeepsRowHeight() {
+        let small = SwitcherMetrics.forScale(1.0, fontScale: 0.85)
+        #expect(small.fontSize == SwitcherMetrics.baseFontSize * 0.85)
+        #expect(small.rowHeight == SwitcherMetrics.baseRowHeight)
+        let big = SwitcherMetrics.forScale(1.0, fontScale: 1.3)
+        #expect(big.rowHeight == round(SwitcherMetrics.baseRowHeight * 1.3))
+    }
+
+    @Test("forScreen passes fontScale through to the fonts")
+    func forScreenPassesFontScale() {
+        let m = SwitcherMetrics.forScreen(nil, userScale: 1.0, fontScale: 0.85)
+        #expect(m.fontSize == SwitcherMetrics.baseFontSize * 0.85)
+        #expect(m.fontScale == 0.85)
+    }
 }
 
 @Suite("Switcher grid/preview column fitting")


### PR DESCRIPTION
On large/ultrawide displays the screen-adaptive scale renders switcher text at up to 1.8× base even at panel size Small. Adds two Appearance ▸ Labels options:

- **Text size** — five steps (0.7×–1.3×) applied to names and titles only; icons, tiles and spacing keep following the panel size, and rows never shrink below their icon-driven height.
- **Font** — System / Rounded / Serif / Monospaced (system font designs, so nothing is bundled and every weight stays available). Monospaced answers the fixed-width request directly.

Faces resolve through a memoized factory once per preference change — never per row on the ⌘Tab path. Defaults are bit-identical to the previous rendering. Includes per-shortcut overrides, settings search, pl/de/fr/es strings, and 11 new tests.

Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)