### PR TITLE
feat: drill into an app's windows in applications-only mode

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -807,6 +807,7 @@ final class Preferences: ObservableObject {
         /// and is deliberately not migrated: everyone, including users who never
         /// touched the old toggle, gets the peek on by default now.
         static let tabDrillEnabled = "Switcher.tabDrillEnabled"
+        static let windowDrillEnabled = "Switcher.windowDrillEnabled"
         /// Expand native-system-tab windows (Finder, Terminal, TextEdit, …) into
         /// one switcher row per tab instead of a single collapsed window row.
         /// Default off — the collapsed row + `\` peek is the default.
@@ -1314,6 +1315,16 @@ final class Preferences: ObservableObject {
         didSet {
             guard oldValue != tabDrillEnabled else { return }
             UserDefaults.standard.set(tabDrillEnabled, forKey: Keys.tabDrillEnabled)
+        }
+    }
+
+    /// Window drill-down (#80): in applications-only mode, `↓` or `\` on an app
+    /// with several windows opens the strip UI listing that app's windows —
+    /// native ⌘Tab parity. Cache-sourced and keypress-driven. Default on.
+    @Published var windowDrillEnabled: Bool {
+        didSet {
+            guard oldValue != windowDrillEnabled else { return }
+            UserDefaults.standard.set(windowDrillEnabled, forKey: Keys.windowDrillEnabled)
         }
     }
 
@@ -1831,6 +1842,7 @@ final class Preferences: ObservableObject {
         self.cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false
         self.experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
         self.tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
+        self.windowDrillEnabled = defaults.object(forKey: Keys.windowDrillEnabled) as? Bool ?? true
         self.expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         self.expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
         self.experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
@@ -1960,6 +1972,7 @@ final class Preferences: ObservableObject {
         cycleTileWidths = defaults.object(forKey: Keys.cycleTileWidths) as? Bool ?? false
         experimentalInstantSpaceSwitch = defaults.object(forKey: Keys.experimentalInstantSpaceSwitch) as? Bool ?? false
         tabDrillEnabled = defaults.object(forKey: Keys.tabDrillEnabled) as? Bool ?? true
+        windowDrillEnabled = defaults.object(forKey: Keys.windowDrillEnabled) as? Bool ?? true
         expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
         experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -113,6 +113,34 @@
         }
       }
     },
+    "In applications-only mode, press ↓ or \\ on an app with several windows to show its windows in a strip below the switcher and pick one." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Nur-Apps-Modus ↓ oder \\ auf einer App mit mehreren Fenstern drücken, um ihre Fenster in einer Leiste unter dem Umschalter anzuzeigen und eines auszuwählen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En el modo de solo aplicaciones, pulsa ↓ o \\ en una app con varias ventanas para mostrar sus ventanas en una franja bajo el selector y elegir una."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En mode applications uniquement, appuyez sur ↓ ou \\ sur une app ayant plusieurs fenêtres pour afficher ses fenêtres dans une bande sous le sélecteur et en choisir une."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W trybie tylko aplikacje naciśnij ↓ lub \\ na aplikacji z kilkoma oknami, aby pokazać jej okna na pasku pod przełącznikiem i wybrać jedno."
+          }
+        }
+      }
+    },
     "Monospaced" : {
       "localizations" : {
         "de" : {
@@ -137,6 +165,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "O stałej szerokości"
+          }
+        }
+      }
+    },
+    "Peek windows with ↓" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster mit ↓ einblenden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver ventanas con ↓"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les fenêtres avec ↓"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podejrzyj okna klawiszem ↓"
           }
         }
       }

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -31,6 +31,8 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
     private let sortOrderPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let sortOrders: [SwitcherSortOrder] = SwitcherSortOrder.allCases
 
+    private let windowDrillSwitch = NSSwitch()
+
     // Tabs
     private let tabDrillSwitch = NSSwitch()
     private let expandTabsSwitch = NSSwitch()
@@ -126,6 +128,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         addRow(to: contents, title: String(localized: "Applications only"),
                subtitle: String(localized: "Show one row per app instead of one per window — classic ⌘Tab."),
                accessory: applicationsOnlySwitch, searchItemID: SearchID.applicationsOnly)
+        configureSwitch(windowDrillSwitch, action: #selector(toggleWindowDrill(_:)))
+        addRow(to: contents, title: String(localized: "Peek windows with ↓"),
+               subtitle: String(localized: "In applications-only mode, press ↓ or \\ on an app with several windows to show its windows in a strip below the switcher and pick one."),
+               accessory: windowDrillSwitch, searchItemID: SearchID.windowDrill)
         configureSwitch(badgesSwitch, action: #selector(toggleBadges(_:)))
         addRow(to: contents, title: String(localized: "Show unread badges"),
                subtitle: String(localized: "Show each app's Dock badge count (e.g. Mail's unread mail) on its row."),
@@ -322,6 +328,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         selectRecentlyClosedLimit(prefs.recentlyClosedLimit)
         recentlyClosedLimitPopup.isEnabled = prefs.showRecentlyClosed
         tabDrillSwitch.state = prefs.tabDrillEnabled ? .on : .off
+        windowDrillSwitch.state = prefs.windowDrillEnabled ? .on : .off
         expandTabsSwitch.state = prefs.expandTabsAsWindows ? .on : .off
         expandBrowserTabsSwitch.state = prefs.expandBrowserTabsAsWindows ? .on : .off
         letterHintsSwitch.state = prefs.letterHintsEnabled ? .on : .off
@@ -545,6 +552,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleApplicationsOnly(_ sender: NSSwitch) {
         Preferences.shared.applicationsOnly = (sender.state == .on)
+    }
+
+    @objc private func toggleWindowDrill(_ sender: NSSwitch) {
+        Preferences.shared.windowDrillEnabled = (sender.state == .on)
     }
 
     @objc private func toggleBadges(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -94,6 +94,7 @@ enum SearchID {
     static let showRecentlyClosed = "switcher.showRecentlyClosed"
     static let recentlyClosedLimit = "switcher.recentlyClosedLimit"
     static let tabDrill = "switcher.tabDrill"
+    static let windowDrill = "switcher.windowDrill"
     static let expandTabs = "switcher.expandTabs"
     static let expandBrowserTabs = "switcher.expandBrowserTabs"
     static let tabPermissions = "switcher.tabPermissions"
@@ -372,6 +373,9 @@ enum SettingsCatalog {
         item(SearchID.applicationsOnly, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
              String(localized: "Applications only"),
              ["applications only", "apps only", "one per app", "per app", "command tab", "classic", "group windows"]),
+        item(SearchID.windowDrill, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
+             String(localized: "Peek windows with ↓"),
+             ["windows", "window", "drill", "peek", "down arrow", "applications only", "app windows", "expose"]),
         item(SearchID.showBadges, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),
              String(localized: "Show unread badges"), ["badge", "unread", "dock badge", "count"]),
         item(SearchID.spaceScope, .switcher, SettingsAnchor.contents, String(localized: "Behavior"), String(localized: "Contents"),

--- a/BetterCmdTab/Switcher/DrillRouting.swift
+++ b/BetterCmdTab/Switcher/DrillRouting.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Pure routing decisions for the window drill-down (#80), split from
+/// `SwitcherController` so the unit suite can pin them without a live panel.
+enum DrillRouting {
+    /// Whether a `↓` keypress should open the window drill instead of
+    /// navigating. Down stays navigation wherever it already moves the
+    /// selection somewhere new: the list layout (column wrap,
+    /// `wrapWithinColumn`) and multi-row grids (2-D neighbor moves). Only
+    /// where it was a redundant linear wrap — a single-row grid or previews
+    /// strip — does it drill, matching the native ⌘Tab `↓` gesture. Search
+    /// owns the arrows while active, and a strip that is already up keeps
+    /// them for its own navigation.
+    static func downArrowOpensWindowDrill(layoutMode: SwitcherLayoutMode, rowsPerColumn: Int, searchActive: Bool, tabDrillActive: Bool) -> Bool {
+        guard !searchActive, !tabDrillActive else { return false }
+        guard layoutMode != .list else { return false }
+        return rowsPerColumn <= 1
+    }
+
+    /// Strip cell title for a window row — the window title, or the app name
+    /// when the window is untitled (an empty strip cell would be unclickable).
+    static func stripTitle(windowTitle: String, appName: String) -> String {
+        windowTitle.isEmpty ? appName : windowTitle
+    }
+}

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -257,9 +257,16 @@ final class SwitcherController: SwitcherViewDelegate {
     /// `BrowserTabs.activateTab`. `accessibility` → AX press on
     /// `liveTabElements[tabIndex]`. `windows` → native window tabs: each
     /// `liveTabElements[i]` is a real NSWindow; raising it selects that tab.
-    /// Picked once per drill, never crossed.
-    private enum TabDrillBackend { case appleScript, accessibility, windows }
+    /// `appWindows` → applications-only window drill (#80): the strip lists the
+    /// selected app's catalogued windows; committing activates
+    /// `drillWindowRows[tabIndex]`. Picked once per drill, never crossed.
+    private enum TabDrillBackend { case appleScript, accessibility, windows, appWindows }
     private var tabDrillBackend: TabDrillBackend = .accessibility
+    /// The pid-filtered, window-MRU-sorted rows the `.appWindows` strip was
+    /// built from, index-aligned with `tabTitles`. Non-empty only while an
+    /// `.appWindows` strip is up; each row carries its enumeration-time
+    /// CGWindowID so the SLPS raise fallback survives a stale AX element.
+    private var drillWindowRows: [SwitcherRow] = []
     /// The window `applyDrill` built the current tab strip against. `commitTab`
     /// re-validates that the selected row still points at this window before
     /// pairing it with the captured tab elements — a background refresh can move
@@ -1807,6 +1814,17 @@ final class SwitcherController: SwitcherViewDelegate {
         }
     }
 
+    /// True when the visible list is collapsed to one row per app — the exact
+    /// gate `applyApplicationsOnly` applies. The window drill (#80) only makes
+    /// sense then: everywhere else each window already has its own row.
+    private var applicationsCollapseActive: Bool {
+        guard effective.applicationsOnly, !windowsOnlyMode else { return false }
+        switch activeScope {
+        case .currentAppWindows, .minimizedOnly: return false
+        case .allAppsAllSpaces, .allAppsCurrentSpace, .none: return true
+        }
+    }
+
     private func prewarmPanel() {
         let placeholder = SwitcherRow(
             app: NSRunningApplication.current,
@@ -1920,6 +1938,13 @@ final class SwitcherController: SwitcherViewDelegate {
         case .prevWindow:
             if tabDrillActive { advanceTab(by: -1) } else { advanceWindowsOnly(by: -1) }
         case .nextRow:
+            // Native ⌘Tab parity (#80): ↓ peeks the selected app's windows, but
+            // only where it was a redundant linear wrap — list and multi-row
+            // grids keep their vertical navigation.
+            if DrillRouting.downArrowOpensWindowDrill(layoutMode: currentMetrics.layoutMode, rowsPerColumn: view.rowsPerColumn, searchActive: searchActive, tabDrillActive: tabDrillActive),
+               enterWindowDrillIfEligible() {
+                break
+            }
             advanceVerticalOrLinear(by: 1)
         case .prevRow:
             advanceVerticalOrLinear(by: -1)
@@ -1982,7 +2007,10 @@ final class SwitcherController: SwitcherViewDelegate {
         case .forceQuitApp:
             performForceQuitAction()
         case .enterTabDrill:
-            enterTabDrill()
+            // On a collapsed multi-window row the window strip wins `\` (#80):
+            // each window may itself own a tab set, so windows are the outer
+            // level. Single-window rows keep the existing tab drill.
+            if !enterWindowDrillIfEligible() { enterTabDrill() }
         case .exitTabDrill:
             exitTabDrill()
         case .tabPrev:
@@ -3608,6 +3636,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabDrillHint = nil
         tabTitles = []
         liveTabElements = []
+        drillWindowRows = []
         tabIndex = 0
         drillWindow = nil
         hotkey.setTabDrillActive(false)
@@ -3762,6 +3791,39 @@ final class SwitcherController: SwitcherViewDelegate {
     ///   group.
     /// Both run off-main; the strip appears once titles land. Silently
     /// no-ops if no tabs are found.
+    /// Window drill-down (#80): in applications-only mode, open the strip UI
+    /// with the selected app's catalogued windows. Everything is sourced from
+    /// the warm cache and window-MRU order (exactly like `pickWindowsOnlyTarget`)
+    /// on the keypress — no AX walk, nothing added to the reveal path. Returns
+    /// false when ineligible so the caller can fall through to its old action.
+    @discardableResult
+    private func enterWindowDrillIfEligible() -> Bool {
+        // Cheap gates first — the candidate build below is the only real work,
+        // and this runs on every ↓ / `\` keypress.
+        guard Preferences.shared.windowDrillEnabled,
+              applicationsCollapseActive,
+              phase == .visible, rows.indices.contains(index) else { return false }
+        let row = rows[index]
+        // An inline browser-tab row is already a leaf (mirrors enterTabDrill),
+        // and a windowless app has nothing to list.
+        guard row.browserTab == nil, let pid = row.pid, let anchor = row.window else { return false }
+        // Warm cache ONLY, same filter config as the visible list so the strip
+        // agrees with the panel on minimized/Space-scope windows.
+        var candidates = cache.rows(orderedBy: mru.order, filter: activeFilterConfig)
+            .filter { $0.pid == pid && $0.window != nil }
+        // A 1-window strip is useless: committing it equals committing the row.
+        guard candidates.count >= 2 else { return false }
+        candidates = windowMRU.sortRows(candidates, forPid: pid)
+        drillWindowRows = candidates
+        applyDrill(
+            titles: candidates.map { DrillRouting.stripTitle(windowTitle: $0.windowTitle, appName: $0.appName) },
+            liveTabs: candidates.compactMap(\.window),
+            backend: .appWindows,
+            window: anchor
+        )
+        return true
+    }
+
     private func enterTabDrill() {
         guard Preferences.shared.tabDrillEnabled else { return }
         guard phase == .visible, rows.indices.contains(index) else { return }
@@ -3802,6 +3864,10 @@ final class SwitcherController: SwitcherViewDelegate {
             let result = Self.fetchTabsBlocking(app: app, window: window, title: title, isBrowser: isBrowser, prefetchedTabs: prefetchedTabs)
             DispatchQueue.main.async {
                 guard let self, gen == self.revealGeneration, self.phase == .visible else { return }
+                // A window drill (#80) opened while this fetch was in flight owns
+                // the strip — a late tab result must not overwrite it (the strip
+                // would show tabs while `drillWindowRows` stays populated).
+                guard !(self.tabDrillActive && self.tabDrillBackend == .appWindows) else { return }
                 guard self.rows.indices.contains(self.index),
                       let currentWindow = self.rows[self.index].window,
                       CFEqual(currentWindow, window) else { return }
@@ -3851,7 +3917,12 @@ final class SwitcherController: SwitcherViewDelegate {
         hotkey.setTabDrillActive(true)
         refreshDisplay()
         resyncSecureInputChords()
-        tabPrefetchCache[AXRef(element: window)] = TabPrefetch(titles: titles, liveTabs: liveTabs, backend: backend)
+        // `.appWindows` strips must never enter the TAB prefetch cache: a later
+        // `\` tab drill on the same window would replay window rows as tabs
+        // against stale `drillWindowRows` (#80).
+        if backend != .appWindows {
+            tabPrefetchCache[AXRef(element: window)] = TabPrefetch(titles: titles, liveTabs: liveTabs, backend: backend)
+        }
     }
 
     /// Blocking tab fetch suitable for a background queue. Returns nil for a
@@ -3967,6 +4038,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabDrillHint = nil
         tabTitles = []
         liveTabElements = []
+        drillWindowRows = []
         tabIndex = 0
         drillWindow = nil
         // Restore the pre-drill detach state so a `\`-toggle exit while ⌘ is held
@@ -4013,9 +4085,18 @@ final class SwitcherController: SwitcherViewDelegate {
             commit()
             return
         }
+        // `.appWindows` (#80) activates `drillWindowRows[chosen]` — same bail
+        // shape as the missing target element above.
+        if backend == .appWindows, !drillWindowRows.indices.contains(chosen) {
+            exitTabDrill()
+            commit()
+            return
+        }
         let instantSpace = Preferences.shared.experimentalInstantSpaceSwitch
         if let pid = row.pid { mru.bump(pid) }
-        bumpWindowMRUIfPossible(for: row)
+        // Window MRU follows the window the user actually lands on: for the
+        // window drill that's the chosen strip entry, not the collapsed row.
+        bumpWindowMRUIfPossible(for: backend == .appWindows ? drillWindowRows[chosen] : row)
 
         revealGeneration &+= 1
         phase = .idle
@@ -4045,6 +4126,13 @@ final class SwitcherController: SwitcherViewDelegate {
                 let tabRow = SwitcherRow(app: app, window: tabWindow, windowTitle: row.windowTitle, isMinimized: false, cgWindowID: cachedWid)
                 Activator.activate(tabRow, instantSpace: instantSpace)
             }
+        case .appWindows:
+            // The strip lists the app's own windows (#80). The chosen row was
+            // captured from the warm cache with its enumeration-time
+            // CGWindowID, so activating it keeps the SLPS raise fallback for
+            // stale AX elements (Electron) — never rebuild it from
+            // `liveTabElements`, which would drop that id.
+            Activator.activate(drillWindowRows[chosen], instantSpace: instantSpace)
         }
         panel.dismiss()
         // Activating the chosen tab's app above; nothing to restore.
@@ -4052,6 +4140,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabDrillActive = false
         tabTitles = []
         liveTabElements = []
+        drillWindowRows = []
         tabIndex = 0
         drillWindow = nil
         hotkey.setTabDrillActive(false)

--- a/BetterCmdTabTests/DrillRoutingTests.swift
+++ b/BetterCmdTabTests/DrillRoutingTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import BetterCmdTab
+
+/// Pure-logic coverage for the window drill-down routing (#80): which `↓`
+/// presses open the strip instead of navigating, and how strip titles fall
+/// back for untitled windows. The eligibility checks that need live state
+/// (visible panel, warm catalog cache) are manual-checklist territory.
+@Suite("Window drill routing")
+struct DrillRoutingTests {
+    @Test("down never hijacks the list layout — column wrap stays navigation")
+    func downNeverHijacksListLayout() {
+        for rpc in [1, 2, 8] {
+            #expect(!DrillRouting.downArrowOpensWindowDrill(
+                layoutMode: .list, rowsPerColumn: rpc, searchActive: false, tabDrillActive: false))
+        }
+    }
+
+    @Test("down never hijacks multi-row grids — 2-D neighbor moves stay navigation")
+    func downNeverHijacksMultiRowGrid() {
+        for mode in [SwitcherLayoutMode.gridView, .windowPreview] {
+            #expect(!DrillRouting.downArrowOpensWindowDrill(
+                layoutMode: mode, rowsPerColumn: 2, searchActive: false, tabDrillActive: false))
+            #expect(!DrillRouting.downArrowOpensWindowDrill(
+                layoutMode: mode, rowsPerColumn: 5, searchActive: false, tabDrillActive: false))
+        }
+    }
+
+    @Test("down drills only where it was a redundant linear wrap (single-row grid/previews)")
+    func downFiresOnlyOnSingleRowGridLikeLayouts() {
+        for mode in [SwitcherLayoutMode.gridView, .windowPreview] {
+            #expect(DrillRouting.downArrowOpensWindowDrill(
+                layoutMode: mode, rowsPerColumn: 1, searchActive: false, tabDrillActive: false))
+        }
+    }
+
+    @Test("search owns the arrows; an open strip keeps them for itself")
+    func downSuppressedInSearchAndWhileDrilled() {
+        #expect(!DrillRouting.downArrowOpensWindowDrill(
+            layoutMode: .windowPreview, rowsPerColumn: 1, searchActive: true, tabDrillActive: false))
+        #expect(!DrillRouting.downArrowOpensWindowDrill(
+            layoutMode: .windowPreview, rowsPerColumn: 1, searchActive: false, tabDrillActive: true))
+    }
+
+    @Test("strip titles pass through, untitled windows fall back to the app name")
+    func stripTitleFallsBackToAppName() {
+        #expect(DrillRouting.stripTitle(windowTitle: "Report.pdf", appName: "Preview") == "Report.pdf")
+        #expect(DrillRouting.stripTitle(windowTitle: "", appName: "Preview") == "Preview")
+    }
+}


### PR DESCRIPTION
Native ⌘Tab shows an app's windows when you press ↓; the applications-only mode had no equivalent, so reaching a specific window meant leaving the mode.

Pressing **↓** or **\** on an app with several windows now opens a strip below the switcher listing that app's windows (most-recent first) — pick one with the arrows and Return, or the mouse. ↓ drills only where it didn't already navigate (single-row grid/previews; the list and multi-row grids keep vertical navigation), and \ prefers windows over tabs on multi-window apps since each window may itself have tabs. Everything is served from the warm catalog cache on the keypress — nothing is added to the ⌘Tab open path — and it works under Secure Event Input like the tab drill. Toggle: Behavior ▸ Contents ▸ **Peek windows with ↓** (default on).

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)