### PR TITLE
fix: use ascii-capable layout for IME key translation

### DIFF
--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -796,16 +796,10 @@ final class HotkeyTap {
     }
 
     private func loadKeyboardLayout() {
-        guard let sourceRef = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
-            Log.hotkey.warning("TISCopyCurrentKeyboardInputSource returned nil")
+        guard let data = KeyboardLayout.currentOrFallbackLayoutData() else {
+            Log.hotkey.warning("No keyboard layout data available")
             return
         }
-        guard let prop = TISGetInputSourceProperty(sourceRef, kTISPropertyUnicodeKeyLayoutData) else {
-            Log.hotkey.warning("TISGetInputSourceProperty kTISPropertyUnicodeKeyLayoutData nil")
-            return
-        }
-        let cfData = Unmanaged<CFData>.fromOpaque(prop).takeUnretainedValue()
-        let data = cfData as Data
         layoutData.withLock { $0 = data }
         // Reserved letters are layout-dependent (a bound keycode maps to a
         // different letter per layout) — re-derive them on every layout change.

--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -796,10 +796,9 @@ final class HotkeyTap {
     }
 
     private func loadKeyboardLayout() {
-        guard let data = KeyboardLayout.currentOrFallbackLayoutData() else {
-            Log.hotkey.warning("No keyboard layout data available")
-            return
-        }
+        // Failure branches are logged inside currentOrFallbackLayoutData();
+        // keep the previous cache (possibly nil) rather than clearing it.
+        guard let data = KeyboardLayout.currentOrFallbackLayoutData() else { return }
         layoutData.withLock { $0 = data }
         // Reserved letters are layout-dependent (a bound keycode maps to a
         // different letter per layout) — re-derive them on every layout change.

--- a/BetterCmdTab/Input/KeyboardLayout.swift
+++ b/BetterCmdTab/Input/KeyboardLayout.swift
@@ -49,12 +49,26 @@ enum KeyboardLayout {
 
     /// Re-read the current keyboard layout. Safe to call from any thread.
     static func reload() {
-        guard let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
-              let prop = TISGetInputSourceProperty(src, kTISPropertyUnicodeKeyLayoutData) else {
-            return
+        guard let data = currentOrFallbackLayoutData() else { return }
+        layoutData.withLock { $0 = data }
+    }
+
+    static func currentOrFallbackLayoutData() -> Data? {
+        if let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+           let data = layoutData(from: src) {
+            return data
         }
-        let cfData = Unmanaged<CFData>.fromOpaque(prop).takeUnretainedValue()
-        layoutData.withLock { $0 = cfData as Data }
+        if let src = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue() {
+            return layoutData(from: src)
+        }
+        return nil
+    }
+
+    private static func layoutData(from source: TISInputSource) -> Data? {
+        guard let prop = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+        return Unmanaged<CFData>.fromOpaque(prop).takeUnretainedValue() as Data
     }
 
     private static func ensureLoaded() {

--- a/BetterCmdTab/Input/KeyboardLayout.swift
+++ b/BetterCmdTab/Input/KeyboardLayout.swift
@@ -10,7 +10,9 @@ import os
 /// fired chord's keycode into the same letter/search character the tap would
 /// have produced. The ~15 lines of `UCKeyTranslate` glue are intentionally
 /// duplicated rather than shared out of `HotkeyTap`, to keep the hot-path tap
-/// untouched (its cache is read on its own thread under its own lock).
+/// untouched (its cache is read on its own thread under its own lock); only
+/// the cold-path layout *loading* is shared via
+/// `currentOrFallbackLayoutData()`.
 ///
 /// The layout snapshot is loaded lazily and refreshed on the system
 /// input-source-changed notification, so a mid-session layout switch stays
@@ -58,9 +60,14 @@ enum KeyboardLayout {
            let data = layoutData(from: src) {
             return data
         }
-        if let src = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue() {
-            return layoutData(from: src)
+        // Typical for IMEs without kTISPropertyUnicodeKeyLayoutData — fall back
+        // to the most recently used ASCII-capable keyboard layout.
+        if let src = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue(),
+           let data = layoutData(from: src) {
+            Log.hotkey.info("Current input source has no Unicode layout data — using ASCII-capable fallback")
+            return data
         }
+        Log.hotkey.warning("No Unicode layout data on current or ASCII-capable input source")
         return nil
     }
 


### PR DESCRIPTION
## Summary

- Share the keyboard layout fallback used by switcher character lookup with `HotkeyTap`.
- Fall back to macOS’ current ASCII-capable keyboard layout when the selected input source is an IME without Unicode layout data.

Fixes #106.

## Why

Some IME input sources do not expose `kTISPropertyUnicodeKeyLayoutData`. In that state BetterCmdTab could not translate keycodes for `/` search or letter shortcuts even though macOS still has an ASCII-capable keyboard layout available for shortcut-style input.

## Testing

- `xcodebuild -project BetterCmdTab.xcodeproj -scheme "BetterCmdTab Debug" -configuration Debug -destination "platform=macOS,arch=arm64" ARCHS=arm64 ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64 CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project BetterCmdTab.xcodeproj -scheme "BetterCmdTab Debug" -configuration Debug -destination "platform=macOS,arch=arm64" ARCHS=arm64 ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64 CODE_SIGNING_ALLOWED=NO test`

No new pure-logic test was added because this path depends on the active macOS Text Input Source APIs.