### PR TITLE
fix: minimize fullscreen windows from switcher

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1892,7 +1892,7 @@ final class SwitcherController: SwitcherViewDelegate {
         case .close:
             performCloseAction()
         case .minimize:
-            performOnVisibleTarget { Activator.minimizeWindow($0) }
+            performMinimizeAction()
         case .maximize:
             performOnVisibleTarget { Activator.zoomWindow($0) }
         case .hide:
@@ -1997,7 +1997,7 @@ final class SwitcherController: SwitcherViewDelegate {
         case .closeWindow:
             performCloseAction()
         case .minimizeWindow:
-            performOnVisibleTarget { Activator.minimizeWindow($0) }
+            performMinimizeAction()
         case .fullscreen:
             performOnVisibleTarget { Activator.toggleFullscreen($0) }
         case .hideApp:
@@ -3673,13 +3673,31 @@ final class SwitcherController: SwitcherViewDelegate {
         }
     }
 
-    private func performOnVisibleTarget(_ action: (SwitcherRow) -> Void) {
-        guard phase == .visible, rows.indices.contains(index) else { return }
+    private var visibleActionTarget: SwitcherRow? {
+        guard phase == .visible, rows.indices.contains(index) else { return nil }
         // System permission/consent windows can't be acted on from the switcher
         // (close/quit/minimize/hide) — the user must enter them and click
         // Deny / Open Settings themselves.
-        guard !rows[index].isSystemDialog else { return }
-        action(rows[index])
+        guard !rows[index].isSystemDialog else { return nil }
+        return rows[index]
+    }
+
+    /// Full-screen minimization is a multi-stage AX operation. Refresh only
+    /// after Activator reports that the final mutation ran; scheduling the usual
+    /// 250 ms refresh when the key is pressed would race the Space transition
+    /// and leave `isMinimized` stale in the still-visible switcher.
+    private func performMinimizeAction() {
+        guard let row = visibleActionTarget else { return }
+        let gen = revealGeneration
+        Activator.minimizeWindow(row) { [weak self] in
+            guard let self, gen == self.revealGeneration, self.phase == .visible else { return }
+            self.scheduleVisibleRefresh(after: 0.25)
+        }
+    }
+
+    private func performOnVisibleTarget(_ action: (SwitcherRow) -> Void) {
+        guard let row = visibleActionTarget else { return }
+        action(row)
         scheduleVisibleRefresh(after: 0.25)
     }
 

--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -613,56 +613,159 @@ enum Activator {
         return AXUIElementPerformAction(buttonValue as! AXUIElement, kAXPressAction as CFString) == .success
     }
 
-    static func minimizeWindow(_ row: SwitcherRow) {
-        guard let window = row.window, let app = row.app else { return }
+    enum FullscreenMinimizeDecision: Equatable {
+        case waitForExit
+        case requestMinimize
+        case complete
+        case finalAttempt
+    }
+
+    /// Pure decision core for the asynchronous full-screen -> minimized
+    /// transition. `AXFullScreen = false` only requests a Space transition; it
+    /// does not guarantee that the window is ready to accept `AXMinimized` when
+    /// the setter returns. Keep polling until full screen is observably off,
+    /// then retry minimization until AX confirms it. A bounded final attempt
+    /// prevents a broken target app from keeping the action alive forever.
+    static func fullscreenMinimizeDecision(
+        fullscreen: Bool?,
+        minimized: Bool?,
+        timedOut: Bool
+    ) -> FullscreenMinimizeDecision {
+        if minimized == true { return .complete }
+        if timedOut { return .finalAttempt }
+        if fullscreen == false { return .requestMinimize }
+        return .waitForExit
+    }
+
+    private static let fullscreenMinimizePollInterval: TimeInterval = 0.05
+    private static let fullscreenMinimizeTimeout: TimeInterval = 2.0
+
+    /// Toggle a window's minimized state. `completion` always runs on the main
+    /// actor after the final AX mutation (and, for a full-screen window, after
+    /// AX confirms minimization or the bounded fallback fires). This lets the
+    /// switcher refresh from completed state instead of racing a fixed timer.
+    static func minimizeWindow(
+        _ row: SwitcherRow,
+        completion: @escaping @MainActor () -> Void = {}
+    ) {
+        guard let window = row.window, let app = row.app else {
+            finishMinimize(completion)
+            return
+        }
         let wasMinimized = row.isMinimized
         let wasFullscreen = row.isFullscreen
 
-        let apply = {
+        // In-process AX writes drive AppKit window-management code and must run
+        // on the main thread. Cross-process AX stays off-main so a slow target
+        // never stalls our UI. GCD is used for both paths so every poll remains
+        // on the executor appropriate for that window.
+        let queue = app.processIdentifier == getpid()
+            ? DispatchQueue.main
+            : DispatchQueue.global(qos: .userInitiated)
+        queue.async {
             if wasMinimized {
                 AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
-                DispatchQueue.main.async {
-                    if #available(macOS 14.0, *) {
-                        _ = app.activate(from: NSRunningApplication.current, options: [])
-                    } else {
-                        app.activate(options: [.activateIgnoringOtherApps])
-                    }
-                }
+                activateAndFinish(app, completion: completion)
                 return
             }
-            if wasFullscreen {
-                _ = AXUIElementSetAttributeValue(window, "AXFullScreen" as CFString, kCFBooleanFalse)
-                try? await Task.sleep(nanoseconds: 450_000_000)
-            }
-            AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-        }
-        let applyOnMain = {
-            if wasMinimized {
-                AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
-                if #available(macOS 14.0, *) {
-                    _ = app.activate(from: NSRunningApplication.current, options: [])
-                } else {
-                    app.activate(options: [.activateIgnoringOtherApps])
-                }
-                return
-            }
-            if wasFullscreen {
-                _ = AXUIElementSetAttributeValue(window, "AXFullScreen" as CFString, kCFBooleanFalse)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-                }
-                return
-            }
-            AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-        }
 
-        // Mutating AX state on our own window must happen on the main thread
-        // (same window-management constraint as closeWindow). Other apps stay
-        // off-main so a slow cross-process AX call never blocks ours.
-        if app.processIdentifier == getpid() {
-            DispatchQueue.main.async(execute: applyOnMain)
-        } else {
-            Task.detached(priority: .userInitiated, operation: apply)
+            guard wasFullscreen else {
+                AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+                finishMinimize(completion)
+                return
+            }
+
+            let retryFullscreenExit = AXUIElementSetAttributeValue(
+                window,
+                "AXFullScreen" as CFString,
+                kCFBooleanFalse
+            ) != .success
+            let deadline = DispatchTime.now() + fullscreenMinimizeTimeout
+            scheduleFullscreenMinimizePoll(
+                window: window,
+                on: queue,
+                deadline: deadline,
+                retryFullscreenExit: retryFullscreenExit,
+                completion: completion
+            )
+        }
+    }
+
+    private static func scheduleFullscreenMinimizePoll(
+        window: AXUIElement,
+        on queue: DispatchQueue,
+        deadline: DispatchTime,
+        retryFullscreenExit: Bool,
+        completion: @escaping @MainActor () -> Void
+    ) {
+        queue.asyncAfter(deadline: .now() + fullscreenMinimizePollInterval) {
+            let fullscreen = booleanAttribute("AXFullScreen" as CFString, of: window)
+            let minimized = fullscreen == true
+                ? nil
+                : booleanAttribute(kAXMinimizedAttribute as CFString, of: window)
+            let timedOut = DispatchTime.now().uptimeNanoseconds >= deadline.uptimeNanoseconds
+
+            switch fullscreenMinimizeDecision(
+                fullscreen: fullscreen,
+                minimized: minimized,
+                timedOut: timedOut
+            ) {
+            case .waitForExit:
+                // Retry only when the initial setter was rejected. Once AX
+                // accepts the request, polling observes the asynchronous Space
+                // transition without repeatedly restarting the same mutation.
+                let stillNeedsExitRetry = retryFullscreenExit
+                    && AXUIElementSetAttributeValue(
+                        window,
+                        "AXFullScreen" as CFString,
+                        kCFBooleanFalse
+                    ) != .success
+                scheduleFullscreenMinimizePoll(
+                    window: window,
+                    on: queue,
+                    deadline: deadline,
+                    retryFullscreenExit: stillNeedsExitRetry,
+                    completion: completion
+                )
+            case .requestMinimize:
+                _ = AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+                scheduleFullscreenMinimizePoll(
+                    window: window,
+                    on: queue,
+                    deadline: deadline,
+                    retryFullscreenExit: false,
+                    completion: completion
+                )
+            case .complete:
+                finishMinimize(completion)
+            case .finalAttempt:
+                Log.activator.warning("Timed out confirming full-screen minimization; applying one final AXMinimized request")
+                if fullscreen != false {
+                    _ = AXUIElementSetAttributeValue(window, "AXFullScreen" as CFString, kCFBooleanFalse)
+                }
+                _ = AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+                finishMinimize(completion)
+            }
+        }
+    }
+
+    private static func activateAndFinish(
+        _ app: NSRunningApplication,
+        completion: @escaping @MainActor () -> Void
+    ) {
+        DispatchQueue.main.async {
+            if #available(macOS 14.0, *) {
+                _ = app.activate(from: NSRunningApplication.current, options: [])
+            } else {
+                app.activate(options: [.activateIgnoringOtherApps])
+            }
+            completion()
+        }
+    }
+
+    private static func finishMinimize(_ completion: @escaping @MainActor () -> Void) {
+        DispatchQueue.main.async {
+            completion()
         }
     }
 
@@ -1094,13 +1197,16 @@ enum Activator {
         AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, value)
     }
 
+    private static func booleanAttribute(_ attribute: CFString, of window: AXUIElement) -> Bool? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, attribute, &ref) == .success else { return nil }
+        return ref as? Bool
+    }
+
     /// Read a window's native full-screen state. Best-effort: any AX failure or a
     /// window that doesn't expose `AXFullScreen` reads as not-full-screen.
     private static func isFullscreen(window: AXUIElement) -> Bool {
-        var ref: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(window, "AXFullScreen" as CFString, &ref) == .success,
-              let flag = ref as? Bool else { return false }
-        return flag
+        booleanAttribute("AXFullScreen" as CFString, of: window) ?? false
     }
 
     /// Put `window` back to its `PreviousFrameStore` snapshot. Re-enters full

--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -616,6 +616,7 @@ enum Activator {
     static func minimizeWindow(_ row: SwitcherRow) {
         guard let window = row.window, let app = row.app else { return }
         let wasMinimized = row.isMinimized
+        let wasFullscreen = row.isFullscreen
 
         let apply = {
             if wasMinimized {
@@ -629,6 +630,29 @@ enum Activator {
                 }
                 return
             }
+            if wasFullscreen {
+                _ = AXUIElementSetAttributeValue(window, "AXFullScreen" as CFString, kCFBooleanFalse)
+                try? await Task.sleep(nanoseconds: 450_000_000)
+            }
+            AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+        }
+        let applyOnMain = {
+            if wasMinimized {
+                AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
+                if #available(macOS 14.0, *) {
+                    _ = app.activate(from: NSRunningApplication.current, options: [])
+                } else {
+                    app.activate(options: [.activateIgnoringOtherApps])
+                }
+                return
+            }
+            if wasFullscreen {
+                _ = AXUIElementSetAttributeValue(window, "AXFullScreen" as CFString, kCFBooleanFalse)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+                }
+                return
+            }
             AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
         }
 
@@ -636,9 +660,9 @@ enum Activator {
         // (same window-management constraint as closeWindow). Other apps stay
         // off-main so a slow cross-process AX call never blocks ours.
         if app.processIdentifier == getpid() {
-            DispatchQueue.main.async(execute: apply)
+            DispatchQueue.main.async(execute: applyOnMain)
         } else {
-            DispatchQueue.global(qos: .userInitiated).async(execute: apply)
+            Task.detached(priority: .userInitiated, operation: apply)
         }
     }
 

--- a/BetterCmdTabTests/ActivatorFullscreenMinimizeTests.swift
+++ b/BetterCmdTabTests/ActivatorFullscreenMinimizeTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import BetterCmdTab
+
+/// Covers the pure state machine that coordinates native full-screen exit with
+/// minimization. Live AX/WindowServer behavior remains an integration concern,
+/// but the ordering and timeout policy are deterministic here.
+@Suite("Activator full-screen minimization")
+struct ActivatorFullscreenMinimizeTests {
+
+    @Test("waits while the window is still full screen")
+    func waitsForFullscreenExit() {
+        #expect(Activator.fullscreenMinimizeDecision(
+            fullscreen: true,
+            minimized: false,
+            timedOut: false
+        ) == .waitForExit)
+    }
+
+    @Test("an unavailable full-screen state is retried")
+    func retriesUnavailableState() {
+        #expect(Activator.fullscreenMinimizeDecision(
+            fullscreen: nil,
+            minimized: nil,
+            timedOut: false
+        ) == .waitForExit)
+    }
+
+    @Test("requests minimization only after full screen is observably off")
+    func minimizesAfterFullscreenExit() {
+        #expect(Activator.fullscreenMinimizeDecision(
+            fullscreen: false,
+            minimized: false,
+            timedOut: false
+        ) == .requestMinimize)
+    }
+
+    @Test("completes only after AX confirms the minimized state")
+    func completesWhenMinimized() {
+        #expect(Activator.fullscreenMinimizeDecision(
+            fullscreen: false,
+            minimized: true,
+            timedOut: false
+        ) == .complete)
+    }
+
+    @Test("a confirmed result wins at the timeout boundary")
+    func confirmedResultWinsAtTimeout() {
+        #expect(Activator.fullscreenMinimizeDecision(
+            fullscreen: false,
+            minimized: true,
+            timedOut: true
+        ) == .complete)
+    }
+
+    @Test("timeout performs one bounded final attempt")
+    func timesOutWithFinalAttempt() {
+        #expect(Activator.fullscreenMinimizeDecision(
+            fullscreen: true,
+            minimized: false,
+            timedOut: true
+        ) == .finalAttempt)
+    }
+}


### PR DESCRIPTION
## Summary

- Make the switcher minimize action handle native full-screen windows.
- Replace the fixed transition delay with AX state polling: wait for `AXFullScreen == false`, then retry `AXMinimized` until confirmed.
- Bound the transition with a timeout and a final best-effort request so an unresponsive target cannot keep the action alive forever.
- Refresh the visible switcher only after the AX operation completes, preventing stale minimized state.
- Keep in-process window mutation on the main thread and cross-process AX work off-main.
- Add pure state-machine coverage for the transition ordering and timeout behavior.

Fixes #108.

## Why

Native macOS full-screen transitions are asynchronous. A fixed delay can fire `AXMinimized` before the Space transition finishes, and the switcher's earlier 250 ms refresh could read stale state before minimization occurred. The new flow advances from observed AX state and reports completion before scheduling the UI refresh.

## Testing

- `xcodebuild -project BetterCmdTab.xcodeproj -scheme "BetterCmdTab Debug" -configuration Debug -destination "platform=macOS,arch=arm64" ARCHS=arm64 ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64 CODE_SIGNING_ALLOWED=NO test`
  - 411 tests in 48 suites passed.
- `xcodebuild -project BetterCmdTab.xcodeproj -scheme BetterCmdTab -configuration Release -destination "generic/platform=macOS" "ARCHS=arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO build`
  - Universal Release build succeeded.