### PR TITLE
fix: run full sort pipeline in post-action refresh

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -4537,7 +4537,11 @@ final class SwitcherController: SwitcherViewDelegate {
                 // Collapse to one row per app when "Applications only" is on — the
                 // reveal paths do this; without it the first in-panel window action's
                 // refresh would re-expand the panel to one row per window.
-                self.baseRows = self.expandBrowserTabs(self.applyApplicationsOnly(self.applyPerAppWindowMRU(fresh)))
+                // Sort through the same pipeline as `applyFullSnapshot`
+                // (`applyWindowMRUSort` + `applyBrowserTabMRU`) so a refresh in
+                // the window-recency sort doesn't fall back to app-grouped cache
+                // order and expanded browser tabs keep their sink/MRU order (#110).
+                self.baseRows = self.applyBrowserTabMRU(self.expandBrowserTabs(self.applyApplicationsOnly(self.applyPerAppWindowMRU(self.applyWindowMRUSort(fresh)))))
                 self.baseLabels = RowLabels.labels(for: self.baseRows)
                 self.refreshDisplay()
                 self.scheduleBrowserTabExpansion()

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -4522,6 +4522,15 @@ final class SwitcherController: SwitcherViewDelegate {
                     }
                     return
                 }
+                // Scoped open: narrow the refreshed snapshot the same way the
+                // reveal did — mirroring `applyFullSnapshot`. If the scope
+                // empties it, keep the current rows rather than cancelling —
+                // a transient empty refresh shouldn't tear the panel down.
+                var next = fresh
+                if let scope = self.activeScope {
+                    next = self.scopeFiltered(next, scope: scope)
+                    if next.isEmpty { return }
+                }
                 // `refreshDisplay` preserves selection by row identity (pid +
                 // title + hasWindow). Plain index clamping silently shifts the
                 // highlight onto a different window when the fresh snapshot
@@ -4541,7 +4550,7 @@ final class SwitcherController: SwitcherViewDelegate {
                 // (`applyWindowMRUSort` + `applyBrowserTabMRU`) so a refresh in
                 // the window-recency sort doesn't fall back to app-grouped cache
                 // order and expanded browser tabs keep their sink/MRU order (#110).
-                self.baseRows = self.applyBrowserTabMRU(self.expandBrowserTabs(self.applyApplicationsOnly(self.applyPerAppWindowMRU(self.applyWindowMRUSort(fresh)))))
+                self.baseRows = self.applyBrowserTabMRU(self.expandBrowserTabs(self.applyApplicationsOnly(self.applyPerAppWindowMRU(self.applyWindowMRUSort(next)))))
                 self.baseLabels = RowLabels.labels(for: self.baseRows)
                 self.refreshDisplay()
                 self.scheduleBrowserTabExpansion()


### PR DESCRIPTION
Fixes #110.

`scheduleVisibleRefresh` (the refresh after an in-panel window action like close/minimize/hide) rebuilt rows with `expandBrowserTabs(applyApplicationsOnly(applyPerAppWindowMRU(fresh)))`, skipping steps that `reveal()` and `applyFullSnapshot` run. Two gaps, both fixed by mirroring the `applyFullSnapshot` path exactly:

- **Window-recency sort + browser-tab ordering** (`b25773b`, the #110 report): under the **Most recent (windows)** sort the panel momentarily fell back to app-grouped cache order after a window action, and with browser tabs expanded the active-tab sink (#97) / experimental tab MRU were not applied until the next full snapshot. The refresh now runs `applyBrowserTabMRU(expandBrowserTabs(applyApplicationsOnly(applyPerAppWindowMRU(applyWindowMRUSort(…)))))`.
- **Scope filter** (`bd5f63c`, found while auditing the same pipeline): the refresh also skipped the `scopeFiltered` pass, so a scoped panel (current-app windows, minimized-only, …) rebuilt from the full catalog and suddenly showed every app's rows after a window action. Like `applyFullSnapshot`, a scope that empties the snapshot keeps the current rows instead of tearing the panel down.

No new logic — this wires the existing (tested) passes into the one call site that missed them. Full suite: 421/421 green; Release configuration builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)