### PR TITLE
feat: add browser tab favicons and previews

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -737,6 +737,7 @@ final class Preferences: ObservableObject {
         static let cycleTileWidths = "Switcher.cycleTileWidths"
         static let experimentalInstantSpaceSwitch = "Switcher.experimentalInstantSpaceSwitch"
         static let experimentalBrowserTabMRU = "Switcher.experimentalBrowserTabMRU"
+        static let experimentalBrowserTabPreviews = "Switcher.experimentalBrowserTabPreviews"
         /// Continuously refresh window-preview thumbnails while the panel is
         /// open, so tiles show live window contents instead of a frame captured
         /// on reveal. Default off — recurring captures cost CPU/GPU on an
@@ -1289,6 +1290,15 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Capture the active browser tab once per switcher trigger for the
+    /// Previews layout. Off by default because it requires screen capture work.
+    @Published var experimentalBrowserTabPreviews: Bool {
+        didSet {
+            guard oldValue != experimentalBrowserTabPreviews else { return }
+            UserDefaults.standard.set(experimentalBrowserTabPreviews, forKey: Keys.experimentalBrowserTabPreviews)
+        }
+    }
+
     /// When true, preview tiles take short, tile-sized ScreenCaptureKit snapshots
     /// at roughly 10 fps while the switcher is open. This is smoother than a
     /// reveal-time still without using persistent streams, whose system sharing
@@ -1837,6 +1847,7 @@ final class Preferences: ObservableObject {
         self.expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         self.expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
         self.experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
+        self.experimentalBrowserTabPreviews = defaults.object(forKey: Keys.experimentalBrowserTabPreviews) as? Bool ?? false
         self.experimentalLivePreviews = defaults.object(forKey: Keys.experimentalLivePreviews) as? Bool ?? false
         // Badges graduated out of the Experimental tab and now default on. Honor
         // the new key if present, otherwise carry over a choice made under the
@@ -1970,6 +1981,7 @@ final class Preferences: ObservableObject {
         expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
         experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
+        experimentalBrowserTabPreviews = defaults.object(forKey: Keys.experimentalBrowserTabPreviews) as? Bool ?? false
         experimentalLivePreviews = defaults.object(forKey: Keys.experimentalLivePreviews) as? Bool ?? false
         showUnreadBadges = defaults.object(forKey: Keys.showUnreadBadges) as? Bool ?? true
 

--- a/BetterCmdTab/Catalog/BrowserFaviconCache.swift
+++ b/BetterCmdTab/Catalog/BrowserFaviconCache.swift
@@ -1,0 +1,294 @@
+import AppKit
+import CryptoKit
+import Foundation
+import ImageIO
+import SQLite3
+
+enum BrowserFaviconCache {
+    struct Request: Hashable, Sendable {
+        let bundleID: String
+        let url: String
+    }
+
+    private struct LoadResult {
+        let images: [String: NSImage]
+        let complete: Bool
+    }
+
+    private static let edge = 128
+    private static let cost = edge * edge * 4
+    private static let images: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 128
+        cache.totalCostLimit = 128 * cost
+        return cache
+    }()
+    private static let misses: NSCache<NSString, NSNumber> = {
+        let cache = NSCache<NSString, NSNumber>()
+        cache.countLimit = 512
+        return cache
+    }()
+
+    static func normalizedURL(_ raw: String) -> String? {
+        guard !raw.isEmpty else { return nil }
+        if var components = URLComponents(string: raw) {
+            components.fragment = nil
+            if let value = components.string, !value.isEmpty { return value }
+        }
+        let value = raw.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? raw
+        return value.isEmpty ? nil : value
+    }
+
+    static func key(bundleID: String?, url: String) -> String? {
+        guard let bundleID, let url = normalizedURL(url) else { return nil }
+        return bundleID.lowercased() + "\u{1F}" + url
+    }
+
+    static func image(forKey key: String?) -> NSImage? {
+        key.flatMap { images.object(forKey: $0 as NSString) }
+    }
+
+    /// Runs on the caller's background queue. All SQLite reads and image
+    /// decoding finish before the caller performs its single UI refresh.
+    static func load(_ requests: [Request], home: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        let unique = Array(Set(requests)).filter {
+            guard let key = key(bundleID: $0.bundleID, url: $0.url) else { return false }
+            return images.object(forKey: key as NSString) == nil && misses.object(forKey: key as NSString) == nil
+        }
+        guard !unique.isEmpty else { return }
+
+        for group in Dictionary(grouping: unique, by: { $0.bundleID.lowercased() }) {
+            let bundleID = group.key
+            let requests = group.value
+            let loaded: LoadResult
+            switch BrowserTabs.Family.from(bundleID: bundleID) {
+            case .safari:
+                let root = safariDirectory(bundleID: bundleID, home: home)
+                loaded = loadSafariResult(urls: requests.map(\.url), databaseURL: root.appendingPathComponent("favicons.db"), iconsURL: root.appendingPathComponent("favicons"))
+            case .chromium:
+                guard let root = chromiumDirectory(bundleID: bundleID, home: home) else { continue }
+                loaded = loadChromiumResult(urls: requests.map(\.url), dataDirectory: root)
+            case nil:
+                continue
+            }
+            for request in requests {
+                guard let normalized = normalizedURL(request.url),
+                      let cacheKey = key(bundleID: bundleID, url: normalized) else { continue }
+                if let image = loaded.images[normalized] {
+                    images.setObject(image, forKey: cacheKey as NSString, cost: cost)
+                } else if loaded.complete {
+                    misses.setObject(1, forKey: cacheKey as NSString)
+                }
+            }
+        }
+    }
+
+    static func loadSafari(urls: [String], databaseURL: URL, iconsURL: URL) -> [String: NSImage] {
+        loadSafariResult(urls: urls, databaseURL: databaseURL, iconsURL: iconsURL).images
+    }
+
+    private static func loadSafariResult(urls: [String], databaseURL: URL, iconsURL: URL) -> LoadResult {
+        let normalized = Array(Set(urls.compactMap(normalizedURL)))
+        guard !normalized.isEmpty else { return LoadResult(images: [:], complete: true) }
+        return withDatabase(at: databaseURL) { db in
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "SELECT uuid FROM page_url WHERE url = ? LIMIT 1", -1, &statement, nil) == SQLITE_OK,
+                  let statement else { return LoadResult(images: [:], complete: false) }
+            defer { sqlite3_finalize(statement) }
+            var result: [String: NSImage] = [:]
+            var complete = true
+            for url in normalized {
+                sqlite3_reset(statement)
+                sqlite3_clear_bindings(statement)
+                sqlite3_bind_text(statement, 1, url, -1, SQLITE_TRANSIENT)
+                let status = sqlite3_step(statement)
+                guard status == SQLITE_ROW else {
+                    if status != SQLITE_DONE { complete = false }
+                    continue
+                }
+                guard let text = sqlite3_column_text(statement, 0) else { continue }
+                let uuid = String(cString: text)
+                let digest = Insecure.MD5.hash(data: Data(uuid.utf8)).map { String(format: "%02X", $0) }.joined()
+                if let image = decode(iconsURL.appendingPathComponent(digest)) { result[url] = image }
+            }
+            return LoadResult(images: result, complete: complete)
+        } ?? LoadResult(images: [:], complete: false)
+    }
+
+    static func loadChromium(urls: [String], dataDirectory: URL) -> [String: NSImage] {
+        loadChromiumResult(urls: urls, dataDirectory: dataDirectory).images
+    }
+
+    private static func loadChromiumResult(urls: [String], dataDirectory: URL) -> LoadResult {
+        var unresolved = Set(urls.compactMap(normalizedURL))
+        var result: [String: NSImage] = [:]
+        var readDatabase = false
+        var complete = true
+        for profile in chromiumProfileDirectories(in: dataDirectory) where !unresolved.isEmpty {
+            let databaseURL = profile.appendingPathComponent("Favicons")
+            guard FileManager.default.fileExists(atPath: databaseURL.path) else { continue }
+            let found = loadChromiumDatabase(urls: Array(unresolved), databaseURL: databaseURL)
+            readDatabase = readDatabase || found.complete
+            complete = complete && found.complete
+            result.merge(found.images) { current, _ in current }
+            unresolved.subtract(found.images.keys)
+        }
+        return LoadResult(images: result, complete: readDatabase && complete)
+    }
+
+    static func chromiumProfileDirectories(in root: URL) -> [URL] {
+        let localState = root.appendingPathComponent("Local State")
+        guard let data = try? Data(contentsOf: localState),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let profile = json["profile"] as? [String: Any] else {
+            return [root, root.appendingPathComponent("Default")]
+        }
+        let lastUsed = profile["last_used"] as? String
+        let active = profile["last_active_profiles"] as? [String] ?? []
+        let known = (profile["info_cache"] as? [String: Any])?.keys.sorted() ?? []
+        var names: [String] = []
+        for name in [lastUsed].compactMap({ $0 }) + active + known where !names.contains(name) {
+            names.append(name)
+        }
+        return names.map { root.appendingPathComponent($0) } + [root]
+    }
+
+    private static func loadChromiumDatabase(urls: [String], databaseURL: URL) -> LoadResult {
+        return withDatabase(at: databaseURL) { db in
+            let sql = """
+            SELECT fb.image_data
+            FROM icon_mapping im
+            JOIN favicons f ON f.id = im.icon_id
+            JOIN favicon_bitmaps fb ON fb.icon_id = f.id
+            WHERE im.page_url = ?
+            ORDER BY fb.width DESC
+            LIMIT 1
+            """
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK,
+                  let statement else { return LoadResult(images: [:], complete: false) }
+            defer { sqlite3_finalize(statement) }
+            var result: [String: NSImage] = [:]
+            var complete = true
+            for url in urls {
+                sqlite3_reset(statement)
+                sqlite3_clear_bindings(statement)
+                sqlite3_bind_text(statement, 1, url, -1, SQLITE_TRANSIENT)
+                let status = sqlite3_step(statement)
+                guard status == SQLITE_ROW else {
+                    if status != SQLITE_DONE { complete = false }
+                    continue
+                }
+                guard let bytes = sqlite3_column_blob(statement, 0) else { continue }
+                let data = Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, 0)))
+                if let image = decode(data) { result[url] = image }
+            }
+            return LoadResult(images: result, complete: complete)
+        } ?? LoadResult(images: [:], complete: false)
+    }
+
+    private static func withDatabase<T>(at url: URL, _ body: (OpaquePointer) -> T) -> T? {
+        guard FileManager.default.isReadableFile(atPath: url.path) else { return nil }
+
+        func read(_ path: String, flags: Int32) -> (value: T?, status: Int32) {
+            var db: OpaquePointer?
+            let opened = sqlite3_open_v2(path, &db, flags, nil)
+            guard opened == SQLITE_OK, let db else {
+                if db != nil { sqlite3_close(db) }
+                return (nil, opened)
+            }
+            defer { sqlite3_close(db) }
+            sqlite3_busy_timeout(db, 20)
+            let status = sqlite3_exec(db, "PRAGMA schema_version", nil, nil, nil)
+            guard status == SQLITE_OK else { return (nil, status) }
+            return (body(db), SQLITE_OK)
+        }
+
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX
+        let first = read(url.path, flags: flags)
+        if let value = first.value { return value }
+
+        // Chromium forks such as Helium keep an exclusive connection even
+        // between writes. Reading the stable main file is safe only when no
+        // rollback/WAL payload exists; otherwise keep the normal silent fallback.
+        let primaryStatus = first.status & 0xFF
+        guard primaryStatus == SQLITE_BUSY || primaryStatus == SQLITE_LOCKED,
+              !hasData(atPath: url.path + "-wal"),
+              !hasData(atPath: url.path + "-journal") else { return nil }
+        return read(url.absoluteString + "?immutable=1", flags: flags | SQLITE_OPEN_URI).value
+    }
+
+    private static func hasData(atPath path: String) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? NSNumber else { return false }
+        return size.int64Value > 0
+    }
+
+    private static func decode(_ url: URL) -> NSImage? {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return nil }
+        return decode(data)
+    }
+
+    private static func decode(_ data: Data) -> NSImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let image = CGImageSourceCreateThumbnailAtIndex(source, 0, [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: edge,
+              ] as CFDictionary)
+            ?? CGImageSourceCreateImageAtIndex(source, 0, nil).flatMap(downscaled)
+        guard let image else { return nil }
+        return NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+    }
+
+    private static func downscaled(_ image: CGImage) -> CGImage? {
+        guard image.width > edge || image.height > edge else { return image }
+        let scale = min(CGFloat(edge) / CGFloat(image.width), CGFloat(edge) / CGFloat(image.height))
+        let width = max(1, Int((CGFloat(image.width) * scale).rounded()))
+        let height = max(1, Int((CGFloat(image.height) * scale).rounded()))
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()
+    }
+
+    private static func safariDirectory(bundleID: String, home: URL) -> URL {
+        let name = bundleID == "com.apple.safaritechnologypreview" ? "SafariTechnologyPreview" : "Safari"
+        return home.appendingPathComponent("Library/\(name)/Favicon Cache")
+    }
+
+    static func chromiumDirectory(bundleID: String, home: URL) -> URL? {
+        let relative: [String: String] = [
+            "com.google.chrome": "Google/Chrome",
+            "com.google.chrome.canary": "Google/Chrome Canary",
+            "com.google.chrome.beta": "Google/Chrome Beta",
+            "com.google.chrome.dev": "Google/Chrome Dev",
+            "com.brave.browser": "BraveSoftware/Brave-Browser",
+            "com.brave.browser.beta": "BraveSoftware/Brave-Browser-Beta",
+            "com.brave.browser.nightly": "BraveSoftware/Brave-Browser-Nightly",
+            "com.brave.browser.dev": "BraveSoftware/Brave-Browser-Dev",
+            "com.microsoft.edgemac": "Microsoft Edge",
+            "com.microsoft.edgemac.beta": "Microsoft Edge Beta",
+            "com.microsoft.edgemac.dev": "Microsoft Edge Dev",
+            "com.microsoft.edgemac.canary": "Microsoft Edge Canary",
+            "com.vivaldi.vivaldi": "Vivaldi",
+            "com.operasoftware.opera": "com.operasoftware.Opera",
+            "com.operasoftware.operadeveloper": "com.operasoftware.OperaDeveloper",
+            "company.thebrowser.browser": "Arc/User Data",
+            "company.thebrowser.dia": "Dia/User Data",
+            "net.imput.helium": "net.imput.helium",
+        ]
+        guard let path = relative[bundleID.lowercased()] else { return nil }
+        return home.appendingPathComponent("Library/Application Support/\(path)")
+    }
+}
+
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/BetterCmdTab/Catalog/IconCache.swift
+++ b/BetterCmdTab/Catalog/IconCache.swift
@@ -45,6 +45,11 @@ enum IconCache {
     }()
 
     static func icon(for row: SwitcherRow) -> NSImage? {
+        if let tab = row.browserTab,
+           let key = BrowserFaviconCache.key(bundleID: row.bundleIdentifier, url: tab.url),
+           let favicon = BrowserFaviconCache.image(forKey: key) {
+            return favicon
+        }
         if let pid = row.pid {
             let key = NSNumber(value: pid)
             if let cached = cache.object(forKey: key) { return cached }

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -12282,6 +12282,74 @@
           }
         }
       }
+    },
+    "Browser tab previews" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Tab-Vorschauen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vistas previas de pestañas del navegador"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçus des onglets du navigateur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podglądy kart przeglądarki"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览器标签页预览"
+          }
+        }
+      }
+    },
+    "Capture the active browser tab for the Previews layout. Background tabs use an earlier cached image or their favicon." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erfasst den aktiven Browser-Tab für das Vorschau-Layout. Hintergrund-Tabs verwenden ein früher zwischengespeichertes Bild oder ihr Favicon."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Captura la pestaña activa del navegador para la disposición Vistas previas. Las pestañas en segundo plano usan una imagen almacenada anteriormente o su favicon."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capture l’onglet actif du navigateur pour la disposition Aperçus. Les onglets en arrière-plan utilisent une image mise en cache auparavant ou leur favicon."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przechwytuje aktywną kartę przeglądarki dla układu Podglądy. Karty w tle używają wcześniejszego obrazu z pamięci podręcznej lub swojej favicony."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为预览布局捕获当前浏览器标签页。后台标签页使用先前缓存的图像或其网站图标。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
+++ b/BetterCmdTab/Settings/ExperimentalSettingsViewController.swift
@@ -16,6 +16,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
     private let sensitivityValueLabel = NSTextField(labelWithString: "")
     private let instantSpaceSwitch = NSSwitch()
     private let browserTabMRUSwitch = NSSwitch()
+    private let browserTabPreviewSwitch = NSSwitch()
     private let livePreviewSwitch = NSSwitch()
     private let rankResultsSwitch = NSSwitch()
     private let searchTabsSwitch = NSSwitch()
@@ -86,6 +87,10 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
         // Previews section (the window-preview layout).
         let previews = addSection(title: String(localized: "Previews"), anchor: SettingsAnchor.experimentalPreviews)
+        configureSwitch(browserTabPreviewSwitch, action: #selector(toggleBrowserTabPreviews(_:)))
+        addRow(to: previews, title: String(localized: "Browser tab previews"),
+               subtitle: String(localized: "Capture the active browser tab for the Previews layout. Background tabs use an earlier cached image or their favicon."),
+               accessory: browserTabPreviewSwitch, searchItemID: SearchID.browserTabPreviews)
         configureSwitch(livePreviewSwitch, action: #selector(toggleLivePreviews(_:)))
         addRow(to: previews, title: String(localized: "Live window previews"),
                subtitle: String(localized: "In the Previews layout, thumbnails keep refreshing while the switcher is open, so they show what is happening in each window right now. Uses extra CPU and GPU while the panel is up."),
@@ -140,6 +145,7 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
         applySensitivity(prefs.swipeSensitivity)
         instantSpaceSwitch.state = prefs.experimentalInstantSpaceSwitch ? .on : .off
         browserTabMRUSwitch.state = prefs.experimentalBrowserTabMRU ? .on : .off
+        browserTabPreviewSwitch.state = prefs.experimentalBrowserTabPreviews ? .on : .off
         livePreviewSwitch.state = prefs.experimentalLivePreviews ? .on : .off
         rankResultsSwitch.state = prefs.fuzzySearchRankBestMatchFirst ? .on : .off
         searchTabsSwitch.state = prefs.searchExpandsBrowserTabs ? .on : .off
@@ -183,6 +189,10 @@ final class ExperimentalSettingsViewController: SettingsTabViewController {
 
     @objc private func toggleBrowserTabMRU(_ sender: NSSwitch) {
         Preferences.shared.experimentalBrowserTabMRU = (sender.state == .on)
+    }
+
+    @objc private func toggleBrowserTabPreviews(_ sender: NSSwitch) {
+        Preferences.shared.experimentalBrowserTabPreviews = (sender.state == .on)
     }
 
     @objc private func toggleLivePreviews(_ sender: NSSwitch) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -140,6 +140,7 @@ enum SearchID {
     static let sensitivity = "experimental.sensitivity"
     static let instantSpace = "experimental.instantSpace"
     static let browserTabMRU = "experimental.browserTabMRU"
+    static let browserTabPreviews = "experimental.browserTabPreviews"
     static let livePreviews = "experimental.livePreviews"
     static let rankResults = "experimental.rankResults"
     static let searchExpandsBrowserTabs = "experimental.searchExpandsBrowserTabs"
@@ -418,6 +419,8 @@ enum SettingsCatalog {
         item(SearchID.browserTabMRU, .experimental, SettingsAnchor.experimentalTabs, String(localized: "Experimental"), String(localized: "Browser tabs"),
              String(localized: "Track browser tabs in recency"), ["browser", "tab", "tabs", "recent", "mru", "safari", "chrome"]),
         // Experimental · Previews
+        item(SearchID.browserTabPreviews, .experimental, SettingsAnchor.experimentalPreviews, String(localized: "Experimental"), String(localized: "Previews"),
+             String(localized: "Browser tab previews"), ["browser", "tab", "preview", "previews", "thumbnail", "safari", "chrome"]),
         item(SearchID.livePreviews, .experimental, SettingsAnchor.experimentalPreviews, String(localized: "Experimental"), String(localized: "Previews"),
              String(localized: "Live window previews"), ["live", "preview", "previews", "thumbnail", "thumbnails", "refresh", "video"]),
     ]

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -148,6 +148,9 @@ final class SwitcherController: SwitcherViewDelegate {
     /// highlighted row and not a live `frontmostApplication` read (which returns
     /// BetterCmdTab once our key panel is on screen). Cleared on teardown.
     private var openFocusedWindow: AXUIElement?
+    /// AX title captured with `openFocusedWindow`; for browsers this identifies
+    /// the active tab without another AppleScript scan.
+    private var openFocusedWindowTitle = ""
     /// Target screen for `.activeWindow` ("active Space") display mode (#22),
     /// resolved off-main: the active monitor (the bright-menu-bar / focused
     /// display, which does not follow the mouse), or — when that can't be
@@ -271,6 +274,7 @@ final class SwitcherController: SwitcherViewDelegate {
     }
     private var tabIndex: Int = 0
     private var tabTitles: [String] = []
+    private var tabStripItems: [TabStripItem] = []
     /// Transient, non-interactive message shown in the tab-strip region (e.g.
     /// "grant Automation access") when a browser drill can't read tabs. Distinct
     /// from `tabDrillActive`: presenting it never enables tab navigation.
@@ -308,6 +312,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// dismisses or the base row set changes.
     private struct TabPrefetch {
         let titles: [String]
+        let faviconKeys: [String?]
         let liveTabs: [AXUIElement]
         let backend: TabDrillBackend
     }
@@ -336,17 +341,20 @@ final class SwitcherController: SwitcherViewDelegate {
     /// let a rapid reopen spawn a duplicate osascript scan, and the older result
     /// could then overwrite the newer one. `browserTabsCacheStamp` throttles the
     /// background re-scan that keeps the cache fresh.
-    private var browserTabsCache: [AXRef: [String]] = [:]
+    private struct CachedBrowserTabs {
+        var tabs: [BrowserTabInfo]
+        var activeIndex: Int
+        var fetchedAt: TimeInterval
+    }
+    private var browserTabsCache: [AXRef: CachedBrowserTabs] = [:]
     private var browserTabsFetchInFlight: Set<AXRef> = []
     /// Monotonic timestamp (systemUptime) of the last successful tab fetch per
     /// window. A window is re-scanned only when its entry is older than
     /// `browserTabsCacheTTL`, bounding osascript spawns across rapid re-opens.
-    private var browserTabsCacheStamp: [AXRef: TimeInterval] = [:]
     private static let browserTabsCacheTTL: TimeInterval = 3.0
     /// Active-tab index per cached browser window, parallel to `browserTabsCache`.
     /// Lets a window-MRU fast tap into a browser land on the tab the user left on
     /// instead of snapping to tab 1 when post-expansion title matching misses (#39).
-    private var browserTabsActiveIndex: [AXRef: Int] = [:]
     /// Monotonic time of the last *forced* (event-driven) browser-tab scan. A
     /// forced scan (a browser-window title change while the panel is open, which
     /// fires when a tab is opened/closed/switched) bypasses the per-window TTL so
@@ -355,6 +363,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// keep osascript spawns (and CPU) bounded.
     private var lastForcedBrowserScanAt: TimeInterval = 0
     private static let forcedBrowserScanMinInterval: TimeInterval = 0.4
+    private var browserTabPreviewRequested = false
     private var windowsOnlyMode: Bool = false
     private var windowsOnlyPid: pid_t? = nil
     private var windowsOnlyPrimedDelta: Int = 0
@@ -439,6 +448,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// (overlapping the reveal delay) so `reveal()` doesn't block its critical
     /// path on the synchronous AX read. Consumed and cleared by `reveal()`.
     private var prefetchedFocusedWindow: AXUIElement?
+    private var prefetchedFocusedWindowTitle = ""
     /// `.activeWindow` target screen resolved during the primed prefetch, copied
     /// into `openTargetScreen` by `reveal()` (mirrors `prefetchedFocusedWindow`).
     private var prefetchedTargetScreen: NSScreen?
@@ -1690,7 +1700,9 @@ final class SwitcherController: SwitcherViewDelegate {
         focusSync = FocusSyncCoalescer()
         focusSyncTokens.removeAll()
         openFocusedWindow = nil
+        openFocusedWindowTitle = ""
         prefetchedFocusedWindow = nil
+        prefetchedFocusedWindowTitle = ""
         openTargetScreen = nil
         prefetchedTargetScreen = nil
         previousFrontmostApp = nil
@@ -1848,6 +1860,7 @@ final class SwitcherController: SwitcherViewDelegate {
             // commit/cancel → `.idle` both pass through here, so the normal fast
             // path disarms it well before it could fire.
             if newValue.isPrimed {
+                browserTabPreviewRequested = false
                 armPrimedWatchdog()
             } else {
                 primedWatchdog?.invalidate()
@@ -2720,6 +2733,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// skips the primed timer).
     private func prefetchOpenFocusedWindow() {
         prefetchedFocusedWindow = nil
+        prefetchedFocusedWindowTitle = ""
         prefetchedTargetScreen = nil
         let selfPid = getpid()
         guard let front = NSWorkspace.shared.frontmostApplication,
@@ -2730,6 +2744,11 @@ final class SwitcherController: SwitcherViewDelegate {
         let gen = focusedWindowCaptureGen
         DispatchQueue.global(qos: .userInteractive).async {
             let window = Activator.focusedWindow(pid: pid)
+            var titleValue: AnyObject?
+            let title = window.flatMap {
+                AXUIElementCopyAttributeValue($0, kAXTitleAttribute as CFString, &titleValue) == .success
+                    ? titleValue as? String : nil
+            } ?? ""
             // Prefer the active monitor (the one with the bright menu bar — the
             // focused display, which does NOT follow the mouse; correct even with
             // no focused window, e.g. a bare desktop). Only pay for the
@@ -2755,6 +2774,7 @@ final class SwitcherController: SwitcherViewDelegate {
                 // skip the primed prefetch) would adopt.
                 guard self.phase == .primed else { return }
                 self.prefetchedFocusedWindow = window
+                self.prefetchedFocusedWindowTitle = title
                 if let activeDisplayID, let s = self.screen(forDisplayID: activeDisplayID) {
                     self.prefetchedTargetScreen = s
                 } else if let axBounds {
@@ -2800,9 +2820,12 @@ final class SwitcherController: SwitcherViewDelegate {
         // they no-op gracefully if not). `front` is the real frontmost captured
         // above, before `panel.present()` makes our key panel frontmost.
         openFocusedWindow = prefetchedFocusedWindow
+        openFocusedWindowTitle = prefetchedFocusedWindowTitle
         prefetchedFocusedWindow = nil
+        prefetchedFocusedWindowTitle = ""
         openTargetScreen = prefetchedTargetScreen
         prefetchedTargetScreen = nil
+        _ = syncFocusedBrowserTabIndex()
         // Mode may have flipped to .activeWindow after the primed prefetch (which
         // captured the window but not the screen). Resolve the screen now —
         // active monitor (bright menu bar) first, the captured window as
@@ -2832,6 +2855,11 @@ final class SwitcherController: SwitcherViewDelegate {
             let gen = focusedWindowCaptureGen
             DispatchQueue.global(qos: .userInteractive).async {
                 let window = Activator.focusedWindow(pid: pid)
+                var titleValue: AnyObject?
+                let title = window.flatMap {
+                    AXUIElementCopyAttributeValue($0, kAXTitleAttribute as CFString, &titleValue) == .success
+                        ? titleValue as? String : nil
+                } ?? ""
                 let activeDisplayID = wantScreen ? PrivateAPI.activeMenuBarDisplayID() : nil
                 let axBounds = (wantScreen && activeDisplayID == nil && window != nil) ? Activator.axBounds(of: window!) : nil
                 let wid = window.map { PrivateAPI.cgWindowId(of: $0) } ?? 0
@@ -2842,6 +2870,11 @@ final class SwitcherController: SwitcherViewDelegate {
                     if wid != 0, self.phase != .idle { self.windowMRU.bump(pid: pid, wid: wid) }
                     guard self.phase == .visible, self.openFocusedWindow == nil else { return }
                     self.openFocusedWindow = window
+                    self.openFocusedWindowTitle = title
+                    if self.syncFocusedBrowserTabIndex() != nil {
+                        self.reExpandBrowserTabs(force: true)
+                    }
+                    self.prewarmActiveBrowserTabPreview()
                     if let activeDisplayID, let resolved = self.screen(forDisplayID: activeDisplayID) {
                         self.openTargetScreen = resolved
                         self.reapplySessionScreenIfChanged()
@@ -2965,7 +2998,7 @@ final class SwitcherController: SwitcherViewDelegate {
             if let windowKey, let match = rows.firstIndex(where: { keyMatches($0, windowKey) }) {
                 index = match
             } else if let win = selectedWindow,
-                      let active = browserTabsActiveIndex[AXRef(element: win)],
+                      let active = browserTabsCache[AXRef(element: win)]?.activeIndex,
                       let match = Self.activeBrowserTabIndex(in: rows, window: AXRef(element: win), activeTabIndex: active) {
                 index = match
             } else if let pid = selectedPid, let match = rows.firstIndex(where: { $0.pid == pid }) {
@@ -2981,9 +3014,13 @@ final class SwitcherController: SwitcherViewDelegate {
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
         currentMetrics = makeMetrics(for: sessionScreen)
+        syncActiveBrowserTabPreviewKeys()
+        prewarmActiveBrowserTabPreview()
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, effective: effective, highlightPrefix: letterBuffer)
         panel.present(opacity: effective.panelOpacity)
         phase = .visible
+        syncActiveBrowserTabPreviewKeys()
+        prewarmActiveBrowserTabPreview()
         cache.setPanelVisible(true)
         dockBadgeObserver.start(enabled: effective.showUnreadBadges)
         // Inline browser-tab mode: start scanning the visible browser windows'
@@ -3072,9 +3109,13 @@ final class SwitcherController: SwitcherViewDelegate {
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
         currentMetrics = makeMetrics(for: sessionScreen)
+        syncActiveBrowserTabPreviewKeys()
+        prewarmActiveBrowserTabPreview()
         view.configure(rows: rows, labels: displayLabels, selectedIndex: index, metrics: currentMetrics, effective: effective, highlightPrefix: letterBuffer)
         panel.present(opacity: effective.panelOpacity)
         phase = .visible
+        syncActiveBrowserTabPreviewKeys()
+        prewarmActiveBrowserTabPreview()
         cache.setPanelVisible(true)
         dockBadgeObserver.start(enabled: effective.showUnreadBadges)
     }
@@ -3220,7 +3261,7 @@ final class SwitcherController: SwitcherViewDelegate {
               !effective.applicationsOnly else { return rows }
         return Self.sinkInactiveBrowserTabs(
             rows,
-            activeIndex: browserTabsActiveIndex,
+            activeIndexFor: { [browserTabsCache] in browserTabsCache[$0]?.activeIndex },
             pinnedIDs: Preferences.shared.pinnedBundleIDs
         )
     }
@@ -3236,12 +3277,20 @@ final class SwitcherController: SwitcherViewDelegate {
         activeIndex: [AXRef: Int],
         pinnedIDs: [String]
     ) -> [SwitcherRow] {
+        sinkInactiveBrowserTabs(rows, activeIndexFor: { activeIndex[$0] }, pinnedIDs: pinnedIDs)
+    }
+
+    private static func sinkInactiveBrowserTabs(
+        _ rows: [SwitcherRow],
+        activeIndexFor: (AXRef) -> Int?,
+        pinnedIDs: [String]
+    ) -> [SwitcherRow] {
         var active: [SwitcherRow] = []
         var inactive: [SwitcherRow] = []
         active.reserveCapacity(rows.count)
         for row in rows {
             if let bt = row.browserTab, let win = row.window,
-               let activeIdx = activeIndex[AXRef(element: win)],
+               let activeIdx = activeIndexFor(AXRef(element: win)),
                bt.index != activeIdx {
                 inactive.append(row)
             } else {
@@ -3475,9 +3524,9 @@ final class SwitcherController: SwitcherViewDelegate {
             guard row.browserTab == nil,
                   let window = row.window,
                   BrowserTabs.Family.from(bundleID: row.bundleIdentifier) != nil,
-                  let titles = browserTabsCache[AXRef(element: window)],
-                  titles.count > 1 else { out.append(row); continue }
-            out.append(contentsOf: row.browserTabRows(tabTitles: titles))
+                  let cached = browserTabsCache[AXRef(element: window)],
+                  cached.tabs.count > 1 else { out.append(row); continue }
+            out.append(contentsOf: row.browserTabRows(tabs: cached.tabs, activeIndex: cached.activeIndex))
         }
         return out
     }
@@ -3571,7 +3620,7 @@ final class SwitcherController: SwitcherViewDelegate {
             if browserTabsFetchInFlight.contains(key) { continue }
             // Skip a window whose cache entry is still fresh (unless forced); fall
             // through when it's missing or older than the TTL so tab add/close shows.
-            if !force, let stamp = browserTabsCacheStamp[key], now - stamp < Self.browserTabsCacheTTL { continue }
+            if !force, let cached = browserTabsCache[key], now - cached.fetchedAt < Self.browserTabsCacheTTL { continue }
             byApp[app.processIdentifier, default: (app, [])].wins.append(
                 Target(window: window, title: row.windowTitle, key: key)
             )
@@ -3583,22 +3632,20 @@ final class SwitcherController: SwitcherViewDelegate {
         // pruning against it would evict every out-of-scope browser window.
         if activeScope == nil, browserTabsCache.contains(where: { !liveKeys.contains($0.key) }) {
             browserTabsCache = browserTabsCache.filter { liveKeys.contains($0.key) }
-            browserTabsCacheStamp = browserTabsCacheStamp.filter { liveKeys.contains($0.key) }
-            browserTabsActiveIndex = browserTabsActiveIndex.filter { liveKeys.contains($0.key) }
         }
         guard !byApp.isEmpty else { return }
         if force { lastForcedBrowserScanAt = now }
         for (_, entry) in byApp { for t in entry.wins { browserTabsFetchInFlight.insert(t.key) } }
         let apps = Array(byApp.values)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            var fetched: [AXRef: [String]] = [:]
+            var fetched: [AXRef: (tabs: [BrowserTabInfo], active: Int)] = [:]
+            var faviconRequests: [BrowserFaviconCache.Request] = []
             // Browsers whose scan hit a script error (Automation denied / timeout)
             // rather than genuinely having no tabs — surface the permission hint and
             // skip negative-caching so a grant + re-open retries at once (#39).
             var failedApps: [NSRunningApplication] = []
             // Active-tab index per resolved window, so the panel can land a
             // window-MRU step on the tab the user left on rather than tab 1 (#39).
-            var fetchedActive: [AXRef: Int] = [:]
             for entry in apps {
                 // A browser window's AX kAXTitleAttribute reflects its ACTIVE TAB,
                 // not the AppleScript window title (e.g. Arc reports "Arc" as the
@@ -3609,13 +3656,20 @@ final class SwitcherController: SwitcherViewDelegate {
                 let result = BrowserTabs.allWindowTabs(for: entry.app)
                 if result.failed { failedApps.append(entry.app); continue }
                 let perWindow = result.windows
+                if let bundleID = entry.app.bundleIdentifier {
+                    faviconRequests.append(contentsOf: perWindow.flatMap(\.tabs).map {
+                        .init(bundleID: bundleID, url: $0.url)
+                    })
+                }
                 var activeCounts: [String: Int] = [:]
-                var byActive: [String: (tabs: [String], active: Int)] = [:]
+                var byActive: [String: (tabs: [BrowserTabInfo], active: Int)] = [:]
                 var titleCounts: [String: Int] = [:]
-                var byTitle: [String: (tabs: [String], active: Int)] = [:]
+                var byTitle: [String: (tabs: [BrowserTabInfo], active: Int)] = [:]
                 for w in perWindow {
-                    let activeIdx = w.tabs.firstIndex(of: w.activeTab) ?? 0
-                    let a = w.activeTab.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let activeIdx = w.activeIndex
+                    let a = w.tabs.indices.contains(activeIdx)
+                        ? w.tabs[activeIdx].title.trimmingCharacters(in: .whitespacesAndNewlines)
+                        : ""
                     if !a.isEmpty { activeCounts[a, default: 0] += 1; byActive[a] = (w.tabs, activeIdx) }
                     let t = w.title.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !t.isEmpty { titleCounts[t, default: 0] += 1; byTitle[t] = (w.tabs, activeIdx) }
@@ -3623,20 +3677,20 @@ final class SwitcherController: SwitcherViewDelegate {
                 for t in entry.wins {
                     let k = t.title.trimmingCharacters(in: .whitespacesAndNewlines)
                     if activeCounts[k] == 1, let hit = byActive[k] {
-                        fetched[t.key] = hit.tabs; fetchedActive[t.key] = hit.active
+                        fetched[t.key] = hit
                     } else if titleCounts[k] == 1, let hit = byTitle[k] {
-                        fetched[t.key] = hit.tabs; fetchedActive[t.key] = hit.active
+                        fetched[t.key] = hit
                     } else if perWindow.count == 1 && entry.wins.count == 1 {
                         let only = perWindow[0]
-                        fetched[t.key] = only.tabs
-                        fetchedActive[t.key] = only.tabs.firstIndex(of: only.activeTab) ?? 0
+                        fetched[t.key] = (only.tabs, only.activeIndex)
                     } else {
                         // Negative-cache (empty) a missing/ambiguous window so we
                         // don't re-spawn osascript for it every tick this session.
-                        fetched[t.key] = []
+                        fetched[t.key] = ([], 0)
                     }
                 }
             }
+            BrowserFaviconCache.load(faviconRequests)
             DispatchQueue.main.async {
                 guard let self else { return }
                 let stamp = ProcessInfo.processInfo.systemUptime
@@ -3644,14 +3698,87 @@ final class SwitcherController: SwitcherViewDelegate {
                 // resolved, so a failed app's windows re-scan on the next open.
                 for entry in apps { for t in entry.wins { self.browserTabsFetchInFlight.remove(t.key) } }
                 for (k, v) in fetched {
-                    self.browserTabsCache[k] = v
-                    self.browserTabsCacheStamp[k] = stamp
-                    self.browserTabsActiveIndex[k] = fetchedActive[k]
+                    self.browserTabsCache[k] = CachedBrowserTabs(
+                        tabs: v.tabs,
+                        activeIndex: v.active,
+                        fetchedAt: stamp
+                    )
                 }
+                self.syncActiveBrowserTabPreviewKeys()
                 if let failed = failedApps.first { self.showTabDrillHint(forApp: failed) }
                 onDone?()
+                self.prewarmActiveBrowserTabPreview()
             }
         }
+    }
+
+    private func syncActiveBrowserTabPreviewKeys() {
+        guard let focused = openFocusedWindow,
+              let row = collapsedBrowserSource().first(where: {
+                  $0.window.map { CFEqual($0, focused) } == true
+              }),
+              let pid = row.pid,
+              row.cgWindowID != 0,
+              let activeIndex = syncFocusedBrowserTabIndex(),
+              let cached = browserTabsCache[AXRef(element: focused)],
+              cached.tabs.indices.contains(activeIndex) else {
+            WindowThumbnailCache.shared.setActiveBrowserTab(nil)
+            return
+        }
+        let tab = cached.tabs[activeIndex]
+        WindowThumbnailCache.shared.setActiveBrowserTab(BrowserTabPreviewKey(
+            pid: pid,
+            windowID: row.cgWindowID,
+            index: activeIndex,
+            pageIdentity: BrowserFaviconCache.normalizedURL(tab.url) ?? tab.title
+        ))
+    }
+
+    @discardableResult
+    private func syncFocusedBrowserTabIndex() -> Int? {
+        guard let focused = openFocusedWindow,
+              var cached = browserTabsCache[AXRef(element: focused)],
+              let index = Self.activeBrowserTabIndex(
+                  tabs: cached.tabs,
+                  windowTitle: openFocusedWindowTitle
+              ) else { return nil }
+        if cached.activeIndex != index {
+            cached.activeIndex = index
+            browserTabsCache[AXRef(element: focused)] = cached
+        }
+        return index
+    }
+
+    /// At most one non-blocking browser-tab capture per switcher trigger.
+    private func prewarmActiveBrowserTabPreview() {
+        guard !browserTabPreviewRequested,
+              Preferences.shared.experimentalBrowserTabPreviews,
+              effective.layoutMode == .windowPreview,
+              phase == .primed || phase == .visible,
+              let app = previousFrontmostApp,
+              BrowserTabs.Family.from(bundleID: app.bundleIdentifier) != nil,
+              let focused = openFocusedWindow,
+              let row = collapsedBrowserSource().first(where: {
+                  $0.pid == app.processIdentifier && $0.window.map { CFEqual($0, focused) } == true
+              }),
+              row.cgWindowID != 0,
+              let activeIndex = syncFocusedBrowserTabIndex(),
+              let cached = browserTabsCache[AXRef(element: focused)],
+              cached.tabs.indices.contains(activeIndex) else { return }
+        let tab = cached.tabs[activeIndex]
+        let key = BrowserTabPreviewKey(
+            pid: app.processIdentifier,
+            windowID: row.cgWindowID,
+            index: activeIndex,
+            pageIdentity: BrowserFaviconCache.normalizedURL(tab.url) ?? tab.title
+        )
+        browserTabPreviewRequested = true
+        let scale = panel.backingScaleFactor
+        WindowThumbnailCache.shared.setActiveBrowserTab(key)
+        WindowThumbnailCache.shared.requestBrowserTab(
+            key,
+            pixelHeight: currentMetrics.previewThumbHeight * scale
+        )
     }
 
     /// Reveal-time / post-action browser-tab scan over the currently displayed
@@ -3700,7 +3827,9 @@ final class SwitcherController: SwitcherViewDelegate {
     /// re-scan that loaded new titles (same tab count) still re-renders.
     private static func rowsDifferVisibly(_ a: [SwitcherRow], _ b: [SwitcherRow]) -> Bool {
         guard a.count == b.count else { return true }
-        for (x, y) in zip(a, b) where x.windowTitle != y.windowTitle { return true }
+        for (x, y) in zip(a, b) where x.windowTitle != y.windowTitle
+            || x.browserTab?.url != y.browserTab?.url
+            || x.browserTab?.isActive != y.browserTab?.isActive { return true }
         return false
     }
 
@@ -3915,6 +4044,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // session and be adopted by a gesture/scoped open that skips the primed
         // prefetch (those call reveal() directly).
         prefetchedFocusedWindow = nil
+        prefetchedFocusedWindowTitle = ""
         prefetchedTargetScreen = nil
         // We picked a target — `pendingActivation` activates it, so there's
         // nothing to restore. Without a pick (committing out of the empty
@@ -3948,6 +4078,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabDrillActive = false
         tabDrillHint = nil
         tabTitles = []
+        tabStripItems = []
         liveTabElements = []
         drillWindowRows = []
         tabIndex = 0
@@ -3960,7 +4091,9 @@ final class SwitcherController: SwitcherViewDelegate {
         resetLetterBuffer()
         resetSearch()
         openFocusedWindow = nil
+        openFocusedWindowTitle = ""
         prefetchedFocusedWindow = nil
+        prefetchedFocusedWindowTitle = ""
         openTargetScreen = nil
         prefetchedTargetScreen = nil
         view.releaseIdleResources()
@@ -4180,7 +4313,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // Cache hit: drill-in is instant — strip appears on the same run
         // loop tick.
         if let cached = tabPrefetchCache[AXRef(element: window)], !cached.titles.isEmpty {
-            applyDrill(titles: cached.titles, liveTabs: cached.liveTabs, backend: cached.backend, window: window)
+            applyDrill(titles: cached.titles, faviconKeys: cached.faviconKeys, liveTabs: cached.liveTabs, backend: cached.backend, window: window)
             return
         }
         let isBrowser = (BrowserTabs.Family.from(bundleID: app.bundleIdentifier) != nil)
@@ -4207,8 +4340,8 @@ final class SwitcherController: SwitcherViewDelegate {
                       let currentWindow = self.rows[self.index].window,
                       CFEqual(currentWindow, window) else { return }
                 switch result {
-                case .tabs(let titles, let liveTabs, let backend):
-                    self.applyDrill(titles: titles, liveTabs: liveTabs, backend: backend, window: window)
+                case .tabs(let titles, let faviconKeys, let liveTabs, let backend):
+                    self.applyDrill(titles: titles, faviconKeys: faviconKeys, liveTabs: liveTabs, backend: backend, window: window)
                 case .failed:
                     self.showTabDrillHint(forApp: app)
                 case .none:
@@ -4237,11 +4370,14 @@ final class SwitcherController: SwitcherViewDelegate {
 
     /// Apply a fetched/cached tab set to the panel — single sink used by
     /// both the cache-hit and async paths so they can't drift.
-    private func applyDrill(titles: [String], liveTabs: [AXUIElement], backend: TabDrillBackend, window: AXUIElement) {
+    private func applyDrill(titles: [String], faviconKeys: [String?] = [], liveTabs: [AXUIElement], backend: TabDrillBackend, window: AXUIElement) {
         // Snapshot the detach state on first entry only (a re-drill onto another
         // row must keep the original pre-drill value, not the forced `true`).
         if !tabDrillActive { stickyOpenBeforeDrill = stickyOpen }
         tabTitles = titles
+        tabStripItems = titles.enumerated().map { index, title in
+            TabStripItem(title: title, faviconKey: faviconKeys.indices.contains(index) ? faviconKeys[index] : nil)
+        }
         liveTabElements = liveTabs
         tabDrillBackend = backend
         tabIndex = 0
@@ -4256,7 +4392,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // `\` tab drill on the same window would replay window rows as tabs
         // against stale `drillWindowRows` (#80).
         if backend != .appWindows {
-            tabPrefetchCache[AXRef(element: window)] = TabPrefetch(titles: titles, liveTabs: liveTabs, backend: backend)
+            tabPrefetchCache[AXRef(element: window)] = TabPrefetch(titles: titles, faviconKeys: faviconKeys, liveTabs: liveTabs, backend: backend)
         }
     }
 
@@ -4271,7 +4407,7 @@ final class SwitcherController: SwitcherViewDelegate {
     private enum DrillFetch: @unchecked Sendable {
         case none
         case failed
-        case tabs(titles: [String], liveTabs: [AXUIElement], backend: TabDrillBackend)
+        case tabs(titles: [String], faviconKeys: [String?], liveTabs: [AXUIElement], backend: TabDrillBackend)
     }
 
     /// AX tab enumeration must never target our own process. Accessibility
@@ -4294,8 +4430,16 @@ final class SwitcherController: SwitcherViewDelegate {
             switch BrowserTabs.tabTitles(for: app, window: window, title: title) {
             case .failed:
                 return .failed
-            case .tabs(let titles):
-                return titles.count > 1 ? .tabs(titles: titles, liveTabs: [], backend: .appleScript) : .none
+            case .tabs(let tabs):
+                guard tabs.count > 1 else { return .none }
+                let requests = tabs.map { BrowserFaviconCache.Request(bundleID: app.bundleIdentifier ?? "", url: $0.url) }
+                BrowserFaviconCache.load(requests)
+                return .tabs(
+                    titles: tabs.map(\.title),
+                    faviconKeys: tabs.map { BrowserFaviconCache.key(bundleID: app.bundleIdentifier, url: $0.url) },
+                    liveTabs: [],
+                    backend: .appleScript
+                )
             case .notSupported:
                 return .none
             }
@@ -4308,7 +4452,7 @@ final class SwitcherController: SwitcherViewDelegate {
         }
         guard axTabs.count > 1 else { return .none }
         let titles = WindowEnumerator.tabTitles(for: axTabs)
-        return .tabs(titles: titles, liveTabs: axTabs, backend: .accessibility)
+        return .tabs(titles: titles, faviconKeys: [], liveTabs: axTabs, backend: .accessibility)
     }
 
     /// Kick a background prefetch for the highlighted row after a short
@@ -4366,8 +4510,8 @@ final class SwitcherController: SwitcherViewDelegate {
                         guard let self, gen == self.revealGeneration,
                               prefetchGeneration == self.tabPrefetchGeneration else { return }
                         self.tabPrefetchInFlight.remove(key)
-                        guard case .tabs(let titles, let liveTabs, let backend) = result, !titles.isEmpty else { return }
-                        self.tabPrefetchCache[key] = TabPrefetch(titles: titles, liveTabs: liveTabs, backend: backend)
+                        guard case .tabs(let titles, let faviconKeys, let liveTabs, let backend) = result, !titles.isEmpty else { return }
+                        self.tabPrefetchCache[key] = TabPrefetch(titles: titles, faviconKeys: faviconKeys, liveTabs: liveTabs, backend: backend)
                     }
                 }
             }
@@ -4381,6 +4525,7 @@ final class SwitcherController: SwitcherViewDelegate {
         tabDrillActive = false
         tabDrillHint = nil
         tabTitles = []
+        tabStripItems = []
         liveTabElements = []
         drillWindowRows = []
         tabIndex = 0
@@ -4499,6 +4644,7 @@ final class SwitcherController: SwitcherViewDelegate {
         previousFrontmostApp = nil
         tabDrillActive = false
         tabTitles = []
+        tabStripItems = []
         liveTabElements = []
         drillWindowRows = []
         tabIndex = 0
@@ -4558,10 +4704,11 @@ final class SwitcherController: SwitcherViewDelegate {
             // down naturally because `browserTabRows` re-enumerates the array. The
             // throttled background re-scan reconciles if the close didn't take.
             let key = AXRef(element: window)
-            if var titles = browserTabsCache[key], titles.indices.contains(tabIndex) {
-                titles.remove(at: tabIndex)
-                browserTabsCache[key] = titles
-                browserTabsCacheStamp[key] = nil   // force a refresh on next scan
+            if var cached = browserTabsCache[key], cached.tabs.indices.contains(tabIndex) {
+                cached.tabs.remove(at: tabIndex)
+                cached.activeIndex = min(cached.activeIndex, max(0, cached.tabs.count - 1))
+                cached.fetchedAt = 0
+                browserTabsCache[key] = cached
             }
             reExpandBrowserTabs(force: true)
             if baseRows.isEmpty { cancel(); return }
@@ -4958,6 +5105,26 @@ final class SwitcherController: SwitcherViewDelegate {
         }
     }
 
+    /// Resolve the active tab from the focused browser window's current AX
+    /// title. Duplicate titles are intentionally ambiguous: skipping one frame
+    /// is better than caching the current page under another tab's URL.
+    nonisolated static func activeBrowserTabIndex(tabs: [BrowserTabInfo], windowTitle: String) -> Int? {
+        let title = windowTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return nil }
+        var match: Int?
+        for index in tabs.indices {
+            let tabTitle = tabs[index].title.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !tabTitle.isEmpty,
+                  title == tabTitle
+                || title.hasPrefix(tabTitle + " — ")
+                || title.hasPrefix(tabTitle + " – ")
+                || title.hasPrefix(tabTitle + " - ") else { continue }
+            guard match == nil else { return nil }
+            match = index
+        }
+        return match
+    }
+
     /// Recently closed windows/apps to surface for reopening. `forSearchQuery`
     /// non-nil filters by fuzzy match; nil yields the newest entries. Returns
     /// nothing when the feature is off or in window-only mode. App-only entries
@@ -5159,7 +5326,7 @@ final class SwitcherController: SwitcherViewDelegate {
             highlightPrefix: searchActive ? "" : letterBuffer,
             searchActive: searchActive,
             searchQuery: searchQuery,
-            tabStripTitles: tabDrillActive ? tabTitles : tabDrillHint.map { [$0] },
+            tabStripItems: tabDrillActive ? tabStripItems : tabDrillHint.map { [TabStripItem(title: $0, faviconKey: nil)] },
             tabStripSelectedIndex: tabIndex
         )
         panel.present(opacity: effective.panelOpacity)

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -32,6 +32,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     private let titleLabel = NSTextField(labelWithString: "")
 
     private var metrics: SwitcherMetrics = .baseline
+    private var usesCompactTabIcon = false
     private var accent: NSColor = .controlAccentColor
     /// Resolved appearance for the current reveal (#74); set in `configure`, read
     /// by render helpers (`applySelection`) that run outside it.
@@ -193,6 +194,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         badgeLabel.stringValue = ""
         nameLabel.stringValue = ""
         titleLabel.stringValue = ""
+        usesCompactTabIcon = false
         currentLabel = ""
         currentPrefixLength = 0
     }
@@ -291,6 +293,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         }
 
         imageView.image = isDialog ? SystemSettingsIcon.image : IconCache.icon(for: row)
+        usesCompactTabIcon = row.browserTab != nil
 
         // Dock badge. Empty map when the feature is off.
         let badge = (row.isPlaceholder || isDialog) ? nil : DockBadgeReader.shared.badge(forBundleID: row.bundleIdentifier)
@@ -504,11 +507,12 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         let iconArea = NSRect(x: (w - tile) / 2, y: bounds.height - letterArea - tile, width: tile, height: tile)
         selectionBackdrop.frame = iconArea.insetBy(dx: m.tileSelectionInset, dy: m.tileSelectionInset)
 
+        let iconSize = usesCompactTabIcon ? floor(m.tileIconSize * 0.9) : m.tileIconSize
         let iconRect = NSRect(
-            x: iconArea.midX - m.tileIconSize / 2,
-            y: iconArea.midY - m.tileIconSize / 2,
-            width: m.tileIconSize,
-            height: m.tileIconSize
+            x: iconArea.midX - iconSize / 2,
+            y: iconArea.midY - iconSize / 2,
+            width: iconSize,
+            height: iconSize
         )
         imageView.frame = iconRect
 

--- a/BetterCmdTab/Switcher/SwitcherItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherItemView.swift
@@ -18,6 +18,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
     private let badgeLabel = NSTextField(labelWithString: "")
 
     private var metrics: SwitcherMetrics = .baseline
+    private var usesCompactTabIcon = false
     /// Resolved appearance for the current reveal (#74); set in `configure`.
     private var effective: EffectiveSettings = .defaults
     private static let statusIconGap: CGFloat = 4
@@ -173,6 +174,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         appNameLabel.stringValue = ""
         titleLabel.stringValue = ""
         badgeLabel.stringValue = ""
+        usesCompactTabIcon = false
         currentLabel = ""
         currentPrefixLength = 0
     }
@@ -222,6 +224,11 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
             }
         }
         imageView.image = isDialog ? SystemSettingsIcon.image : IconCache.icon(for: row)
+        let compactTabIcon = row.browserTab != nil
+        if usesCompactTabIcon != compactTabIcon {
+            usesCompactTabIcon = compactTabIcon
+            needsLayout = true
+        }
         let showHidden = !isDialog && !row.isPlaceholder && row.isHidden
         let showMinimized = !isDialog && !row.isPlaceholder && row.isMinimized && !showHidden
         // No-window applies only to running apps — launch/reopen rows have their
@@ -370,7 +377,9 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
 
         let labelH = m.labelHeight
         let labelY = (h - labelH) / 2
-        let iconY = (h - m.iconSize) / 2
+        let displayedIconSize = usesCompactTabIcon ? floor(m.iconSize * 0.9) : m.iconSize
+        let iconY = (h - displayedIconSize) / 2
+        let statusY = (h - m.iconSize) / 2
         let statusSize = m.iconSize
         let statusGap = Self.statusIconGap
 
@@ -391,14 +400,19 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         // between the letter column and the icon — drop its trailing gap so the
         // icon doesn't float on a double gap. Matches the rowWidth reduction.
         let iconX = appX + m.appNameWidth + (m.appNameWidth > 0 ? m.interGap : 0)
-        imageView.frame = NSRect(x: iconX, y: iconY, width: m.iconSize, height: m.iconSize)
+        imageView.frame = NSRect(
+            x: iconX + (m.iconSize - displayedIconSize) / 2,
+            y: iconY,
+            width: displayedIconSize,
+            height: displayedIconSize
+        )
 
         let visibleStatusIcons = indicatorViews.map { $0.1 }.filter { !$0.isHidden }
         var statusRightEdge = bounds.width - m.horizontalInset
         for iv in visibleStatusIcons.reversed() {
             let frame = NSRect(
                 x: statusRightEdge - statusSize,
-                y: iconY,
+                y: statusY,
                 width: statusSize,
                 height: statusSize
             )

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -25,6 +25,10 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     /// CGWindowID of the row this tile shows, so a late thumbnail capture can be
     /// matched back to the right tile. 0 for rows without a real window.
     private(set) var windowID: CGWindowID = 0
+    private(set) var thumbnailKey: ThumbnailKey?
+    private(set) var isActiveBrowserTab = false
+    private var browserTabPreviewEnabled = false
+    private var usesCompactTabIcon = false
     /// The app icon shown while no thumbnail is available — kept so a thumbnail
     /// arriving via `setThumbnail` can be applied without re-reading the row.
     private var placeholderIcon: NSImage?
@@ -190,6 +194,10 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         badgeLabel.stringValue = ""
         placeholderIcon = nil
         windowID = 0
+        thumbnailKey = nil
+        isActiveBrowserTab = false
+        browserTabPreviewEnabled = false
+        usesCompactTabIcon = false
         currentLabel = ""
         currentPrefixLength = 0
     }
@@ -225,6 +233,7 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         let icon = isDialog ? SystemSettingsIcon.image : IconCache.icon(for: row)
         placeholderIcon = icon
         iconView.image = icon
+        usesCompactTabIcon = row.browserTab != nil
         // "Window title under icon" preference: when off, keep the app icon but
         // drop the title text so the tile is just the thumbnail + icon. Browser
         // tabs always show their title — it's the only thing distinguishing one
@@ -261,14 +270,25 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         // the *active* tab — so requesting it would paint every tab tile with the
         // same, misleading thumbnail. Force the app-icon placeholder (id 0)
         // instead; the distinct tab title under the icon identifies each tab.
-        windowID = (row.browserTab == nil)
-            ? (row.cgWindowID != 0 ? row.cgWindowID : (row.window.map { PrivateAPI.cgWindowId(of: $0) } ?? 0))
-            : 0
-        if windowID != 0 {
+        windowID = row.cgWindowID != 0 ? row.cgWindowID : (row.window.map { PrivateAPI.cgWindowId(of: $0) } ?? 0)
+        if let browserKey = row.browserTabPreviewKey {
+            thumbnailKey = .browserTab(browserKey)
+            isActiveBrowserTab = row.browserTab?.isActive == true
+            browserTabPreviewEnabled = Preferences.shared.experimentalBrowserTabPreviews
+            imageView.image = browserTabPreviewEnabled
+                ? WindowThumbnailCache.shared.image(for: .browserTab(browserKey)) ?? icon
+                : icon
+        } else if windowID != 0 {
+            thumbnailKey = .window(windowID)
+            isActiveBrowserTab = false
+            browserTabPreviewEnabled = false
             let scale = window?.backingScaleFactor ?? 2
             WindowThumbnailCache.shared.request(wid: windowID, pixelHeight: metrics.previewThumbHeight * scale)
             imageView.image = WindowThumbnailCache.shared.image(for: windowID) ?? icon
         } else {
+            thumbnailKey = nil
+            isActiveBrowserTab = false
+            browserTabPreviewEnabled = false
             imageView.image = icon
         }
         applyImageScaling()
@@ -290,8 +310,9 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     /// Swap in a freshly captured thumbnail (called from the view's `onReady`
     /// hook). Ignores stale callbacks for a tile that has since been reused for
     /// a different window.
-    func setThumbnail(_ image: NSImage?, for wid: CGWindowID) {
-        guard wid == windowID, wid != 0 else { return }
+    func setThumbnail(_ image: NSImage?, for key: ThumbnailKey) {
+        guard key == thumbnailKey else { return }
+        if case .browserTab = key, !browserTabPreviewEnabled { return }
         imageView.image = image ?? placeholderIcon
         applyImageScaling()
     }
@@ -300,7 +321,16 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     /// placeholder stays small and centered so it doesn't look like a blurry
     /// full-bleed preview.
     private func applyImageScaling() {
-        let hasThumb = (windowID != 0) && (WindowThumbnailCache.shared.image(for: windowID) != nil)
+        let hasThumb: Bool
+        if let key = thumbnailKey {
+            if case .browserTab = key, !browserTabPreviewEnabled {
+                hasThumb = false
+            } else {
+                hasThumb = WindowThumbnailCache.shared.image(for: key) != nil
+            }
+        } else {
+            hasThumb = false
+        }
         imageView.imageScaling = hasThumb ? .scaleProportionallyUpOrDown : .scaleProportionallyDown
     }
 
@@ -403,7 +433,8 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
             badgePill.frame = .zero
             badgePill.isHidden = true
         } else {
-            let iconSize = min(m.previewIconSize, labelAreaH)
+            let baseIconSize = min(m.previewIconSize, labelAreaH)
+            let iconSize = usesCompactTabIcon ? floor(baseIconSize * 0.9) : baseIconSize
 
             // Count badge sits to the right of the title — a small circle, noticeably
             // smaller than the app icon (a notification badge, not an icon-sized

--- a/BetterCmdTab/Switcher/SwitcherRow.swift
+++ b/BetterCmdTab/Switcher/SwitcherRow.swift
@@ -5,9 +5,27 @@ import ApplicationServices
 /// `index` is the tab's 0-based position; `parentTitle` is the parent window's
 /// AX title, used to resolve the AppleScript `window N` on commit without a
 /// raise (matching `BrowserTabs.tabTitles`/`activateTab`'s name-match path).
+struct BrowserTabPreviewKey: Hashable, Sendable {
+    let pid: pid_t
+    let windowID: CGWindowID
+    let index: Int
+    let pageIdentity: String
+}
+
 struct BrowserTabRef {
     let index: Int
     let parentTitle: String
+    let url: String
+    let isActive: Bool
+
+    func previewKey(pid: pid_t, windowID: CGWindowID, title: String) -> BrowserTabPreviewKey {
+        BrowserTabPreviewKey(
+            pid: pid,
+            windowID: windowID,
+            index: index,
+            pageIdentity: BrowserFaviconCache.normalizedURL(url) ?? title
+        )
+    }
 }
 
 struct SwitcherRow {
@@ -164,20 +182,37 @@ struct SwitcherRow {
     /// title (`parentTitle`) so commit can resolve the AppleScript window without
     /// a raise. Fewer than 2 titles, a non-running subject, or no window → just
     /// this row (nothing to expand). Pure — no AX messaging.
-    func browserTabRows(tabTitles: [String]) -> [SwitcherRow] {
-        guard case .running(let app) = subject, window != nil, tabTitles.count > 1 else { return [self] }
+    func browserTabRows(tabs: [BrowserTabInfo], activeIndex: Int) -> [SwitcherRow] {
+        guard case .running(let app) = subject, window != nil, tabs.count > 1 else { return [self] }
         let parentTitle = windowTitle
-        return tabTitles.enumerated().map { i, title in
+        return tabs.enumerated().map { i, tab in
             SwitcherRow(
                 app: app,
                 window: window,
-                windowTitle: title,
+                windowTitle: tab.title,
                 isMinimized: isMinimized,
                 isFullscreen: isFullscreen,
                 cgWindowID: cgWindowID,
-                browserTab: BrowserTabRef(index: i, parentTitle: parentTitle)
+                browserTab: BrowserTabRef(
+                    index: i,
+                    parentTitle: parentTitle,
+                    url: tab.url,
+                    isActive: i == activeIndex
+                )
             )
         }
+    }
+
+    func browserTabRows(tabTitles: [String]) -> [SwitcherRow] {
+        browserTabRows(
+            tabs: tabTitles.map { BrowserTabInfo(title: $0, url: "") },
+            activeIndex: 0
+        )
+    }
+
+    var browserTabPreviewKey: BrowserTabPreviewKey? {
+        guard let browserTab, let pid else { return nil }
+        return browserTab.previewKey(pid: pid, windowID: cgWindowID, title: windowTitle)
     }
 
     /// Collapse a browser-tab row back to its parent-window row — the inverse of

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -129,7 +129,7 @@ final class SwitcherView: NSView, TabStripDelegate {
     /// the firing shortcut's overrides instead of the global preferences.
     private var effective: EffectiveSettings = .defaults
 
-    func configure(rows: [SwitcherRow], labels: [String], selectedIndex: Int, metrics: SwitcherMetrics, effective: EffectiveSettings, highlightPrefix: String = "", searchActive: Bool = false, searchQuery: String = "", tabStripTitles: [String]? = nil, tabStripSelectedIndex: Int = 0) {
+    func configure(rows: [SwitcherRow], labels: [String], selectedIndex: Int, metrics: SwitcherMetrics, effective: EffectiveSettings, highlightPrefix: String = "", searchActive: Bool = false, searchQuery: String = "", tabStripItems: [TabStripItem]? = nil, tabStripSelectedIndex: Int = 0) {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         // Set before `fittedMetrics`/layout below read it (see ivar note).
@@ -141,7 +141,7 @@ final class SwitcherView: NSView, TabStripDelegate {
         // valid, so skip invalidating it and forcing a full relayout + panel
         // resize. The item views still reconfigure below and relayout themselves
         // if their own content changed.
-        let stripActiveNew = (tabStripTitles?.isEmpty == false)
+        let stripActiveNew = (tabStripItems?.isEmpty == false)
         // Shrink grid/preview tiles to fit the screen for large app/window counts
         // so they stay fully visible instead of overflowing top/bottom. Shadows
         // the incoming `metrics` so every downstream sizing path (layout math and
@@ -164,8 +164,8 @@ final class SwitcherView: NSView, TabStripDelegate {
         searchBar.update(query: searchQuery)
         searchBar.applyFont(fontScale: metrics.fontScale, face: effective.fontFace)
         searchBar.isHidden = !searchActive
-        if let titles = tabStripTitles, !titles.isEmpty {
-            tabStrip.configure(titles: titles, selectedIndex: tabStripSelectedIndex, accent: accent)
+        if let items = tabStripItems, !items.isEmpty {
+            tabStrip.configure(items: items, selectedIndex: tabStripSelectedIndex, accent: accent)
             tabStrip.isHidden = false
         } else {
             tabStrip.isHidden = true
@@ -223,11 +223,11 @@ final class SwitcherView: NSView, TabStripDelegate {
             return
         }
         WindowThumbnailCache.shared.ensurePermission()
-        WindowThumbnailCache.shared.onReady = { [weak self] wid in
+        WindowThumbnailCache.shared.onReady = { [weak self] key in
             guard let self else { return }
             for view in self.itemViews {
-                guard let preview = view as? SwitcherPreviewItemView, preview.windowID == wid else { continue }
-                preview.setThumbnail(WindowThumbnailCache.shared.image(for: wid), for: wid)
+                guard let preview = view as? SwitcherPreviewItemView, preview.thumbnailKey == key else { continue }
+                preview.setThumbnail(WindowThumbnailCache.shared.image(for: key), for: key)
             }
         }
         syncLivePreviewTimer()
@@ -268,11 +268,16 @@ final class SwitcherView: NSView, TabStripDelegate {
         for view in itemViews {
             guard let preview = view as? SwitcherPreviewItemView,
                   !preview.isHidden,
-                  preview.windowID != 0 else { continue }
-            WindowThumbnailCache.shared.requestLiveFrame(
-                wid: preview.windowID,
-                pixelHeight: pixelHeight
-            )
+                  let key = preview.thumbnailKey else { continue }
+            switch key {
+            case .window(let wid):
+                WindowThumbnailCache.shared.requestLiveFrame(wid: wid, pixelHeight: pixelHeight)
+            case .browserTab(let tab) where preview.isActiveBrowserTab
+                && Preferences.shared.experimentalBrowserTabPreviews:
+                WindowThumbnailCache.shared.requestBrowserTab(tab, pixelHeight: pixelHeight, isLive: true)
+            case .browserTab:
+                break
+            }
         }
     }
 

--- a/BetterCmdTab/Switcher/TabStripView.swift
+++ b/BetterCmdTab/Switcher/TabStripView.swift
@@ -1,5 +1,10 @@
 import AppKit
 
+struct TabStripItem: Equatable, Sendable {
+    let title: String
+    let faviconKey: String?
+}
+
 /// Horizontal strip of tab titles shown below the switcher list while the user
 /// is drilled into a browser/Finder row. Cells are title-only — no icons or
 /// thumbnails — sized to ~22pt tall and laid out in a horizontal scroll view so
@@ -67,10 +72,10 @@ final class TabStripView: NSView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
 
-    func configure(titles: [String], selectedIndex: Int, accent: NSColor) {
+    func configure(items: [TabStripItem], selectedIndex: Int, accent: NSColor) {
         self.accent = accent
         self.selectedIndex = selectedIndex
-        while cells.count < titles.count {
+        while cells.count < items.count {
             let cell = TabStripCell()
             cell.onSelect = { [weak self] cell in
                 guard let self, let i = self.cells.firstIndex(where: { $0 === cell }) else { return }
@@ -83,7 +88,7 @@ final class TabStripView: NSView {
             stack.addArrangedSubview(cell)
             cells.append(cell)
         }
-        while cells.count > titles.count {
+        while cells.count > items.count {
             let cell = cells.removeLast()
             stack.removeArrangedSubview(cell)
             cell.removeFromSuperview()
@@ -98,8 +103,9 @@ final class TabStripView: NSView {
         let font = SwitcherFont.font(ofSize: round(12 * prefs.fontScale.multiplier),
                                      weight: .medium,
                                      design: prefs.fontFace)
-        for (i, title) in titles.enumerated() {
-            cells[i].configure(title: title.isEmpty ? String(localized: "Untitled") : title,
+        for (i, item) in items.enumerated() {
+            cells[i].configure(title: item.title.isEmpty ? String(localized: "Untitled") : item.title,
+                               favicon: BrowserFaviconCache.image(forKey: item.faviconKey),
                                selected: i == selectedIndex,
                                accent: accent,
                                truncation: truncation,
@@ -160,6 +166,7 @@ final class TabStripView: NSView {
 
 @MainActor
 private final class TabStripCell: NSView {
+    private let iconView = NSImageView()
     private let label = NSTextField(labelWithString: "")
     private var isSelected = false
     private var accentColor: NSColor = .controlAccentColor
@@ -178,10 +185,17 @@ private final class TabStripCell: NSView {
         label.font = .systemFont(ofSize: 12, weight: .medium)
         label.lineBreakMode = .byTruncatingTail
         label.maximumNumberOfLines = 1
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyDown
+        addSubview(iconView)
         addSubview(label)
 
         NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 16),
+            iconView.heightAnchor.constraint(equalToConstant: 16),
+            label.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 5),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
             label.centerYAnchor.constraint(equalTo: centerYAnchor),
             heightAnchor.constraint(equalToConstant: 22),
@@ -192,7 +206,7 @@ private final class TabStripCell: NSView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
 
-    func configure(title: String, selected: Bool, accent: NSColor, truncation: NSLineBreakMode, font: NSFont) {
+    func configure(title: String, favicon: NSImage?, selected: Bool, accent: NSColor, truncation: NSLineBreakMode, font: NSFont) {
         if label.lineBreakMode != truncation {
             label.lineBreakMode = truncation
         }
@@ -200,6 +214,10 @@ private final class TabStripCell: NSView {
             label.font = font
         }
         label.stringValue = title
+        iconView.image = favicon
+        iconView.isHidden = favicon == nil
+        // Reclaim the icon's slot for native (text-only) tab groups.
+        iconView.constraints.first { $0.firstAttribute == .width }?.constant = favicon == nil ? 0 : 16
         isSelected = selected
         accentColor = accent
         applyAppearance()
@@ -213,6 +231,7 @@ private final class TabStripCell: NSView {
 
     func prepareForIdle() {
         label.stringValue = ""
+        iconView.image = nil
         mouseInside = false
         isSelected = false
         applyAppearance()

--- a/BetterCmdTab/Switcher/WindowThumbnailCache.swift
+++ b/BetterCmdTab/Switcher/WindowThumbnailCache.swift
@@ -2,31 +2,46 @@ import AppKit
 import CoreGraphics
 @preconcurrency import ScreenCaptureKit
 
+enum ThumbnailKey: Hashable, Sendable {
+    case window(CGWindowID)
+    case browserTab(BrowserTabPreviewKey)
+
+    var windowID: CGWindowID {
+        switch self {
+        case .window(let id): id
+        case .browserTab(let key): key.windowID
+        }
+    }
+}
+
 /// Generation tokens for asynchronous thumbnail captures. Clearing the cache
 /// invalidates every outstanding token; an old completion then cannot repopulate
 /// a cache cleared for memory pressure or remove a newer request for the same wid.
 struct ThumbnailRequestGate {
-    private var active: [CGWindowID: UInt64] = [:]
+    private var active: [ThumbnailKey: UInt64] = [:]
     private var nextToken: UInt64 = 0
 
     var count: Int { active.count }
 
-    func contains(_ wid: CGWindowID) -> Bool { active[wid] != nil }
+    func contains(_ key: ThumbnailKey) -> Bool { active[key] != nil }
+    func contains(_ wid: CGWindowID) -> Bool { contains(.window(wid)) }
 
-    mutating func begin(_ wid: CGWindowID) -> UInt64? {
-        guard wid != 0, active[wid] == nil else { return nil }
+    mutating func begin(_ key: ThumbnailKey) -> UInt64? {
+        guard key.windowID != 0, active[key] == nil else { return nil }
         nextToken &+= 1
         if nextToken == 0 { nextToken = 1 }
-        active[wid] = nextToken
+        active[key] = nextToken
         return nextToken
     }
+    mutating func begin(_ wid: CGWindowID) -> UInt64? { begin(.window(wid)) }
 
     /// True only for the currently-active request; also consumes that request.
-    mutating func finish(_ wid: CGWindowID, token: UInt64) -> Bool {
-        guard active[wid] == token else { return false }
-        active.removeValue(forKey: wid)
+    mutating func finish(_ key: ThumbnailKey, token: UInt64) -> Bool {
+        guard active[key] == token else { return false }
+        active.removeValue(forKey: key)
         return true
     }
+    mutating func finish(_ wid: CGWindowID, token: UInt64) -> Bool { finish(.window(wid), token: token) }
 
     mutating func reset() { active.removeAll() }
 }
@@ -56,7 +71,7 @@ final class WindowThumbnailCache {
     /// Invoked on the main actor when a requested thumbnail finishes capturing,
     /// so the view can repaint just the matching tile. The argument is the
     /// `CGWindowID` whose image is now in the cache.
-    var onReady: ((CGWindowID) -> Void)?
+    var onReady: ((ThumbnailKey) -> Void)?
 
     // Preview mode rarely surfaces more than ~24 windows at once; cap at 32 so
     // the cache holds a generous working set without retaining stale captures
@@ -69,10 +84,11 @@ final class WindowThumbnailCache {
     /// Handles let a memory-pressure clear cancel capture work as well as
     /// invalidating its result token. The token prevents an old completion from
     /// removing a newer task for a reused window id.
-    private var captureTasks: [CGWindowID: (token: UInt64, task: Task<Void, Never>)] = [:]
+    private var captureTasks: [ThumbnailKey: (token: UInt64, task: Task<Void, Never>)] = [:]
     /// Pace windows that cannot currently be captured (closed/minimized or a
     /// denied permission) instead of retrying them ten times per second.
-    private var liveFailureAt: [CGWindowID: Date] = [:]
+    private var liveFailureAt: [ThumbnailKey: Date] = [:]
+    private var activeBrowserTabByWindow: [CGWindowID: BrowserTabPreviewKey] = [:]
     private let liveFailureBackoff: TimeInterval = 2.0
     private var didRequestPermission = false
     private let memoryPressure: DispatchSourceMemoryPressure
@@ -97,8 +113,12 @@ final class WindowThumbnailCache {
     /// Cached thumbnail for `wid`, or nil if not captured yet. Bumps the
     /// entry's recency: tiles that still ask for a frame are the working set.
     func image(for wid: CGWindowID) -> NSImage? {
-        guard wid != 0 else { return nil }
-        return cache.image(for: wid)
+        image(for: .window(wid))
+    }
+
+    func image(for key: ThumbnailKey) -> NSImage? {
+        guard key.windowID != 0 else { return nil }
+        return cache.image(for: key)
     }
 
     /// Ensure `wid` has a reasonably fresh thumbnail. Skips work when a frame
@@ -110,7 +130,26 @@ final class WindowThumbnailCache {
     /// `pixelHeight` is the target raster height so the capture stays crisp on
     /// Retina without over-allocating.
     func request(wid: CGWindowID, pixelHeight: CGFloat) {
-        beginRequest(wid: wid, pixelHeight: pixelHeight, maxAge: refreshTTL, isLive: false)
+        beginRequest(key: .window(wid), pixelHeight: pixelHeight, maxAge: refreshTTL, isLive: false)
+    }
+
+    func setActiveBrowserTab(_ key: BrowserTabPreviewKey?) {
+        activeBrowserTabByWindow.removeAll(keepingCapacity: true)
+        if let key { activeBrowserTabByWindow[key.windowID] = key }
+    }
+
+    func isActiveBrowserTab(_ key: BrowserTabPreviewKey) -> Bool {
+        activeBrowserTabByWindow[key.windowID] == key
+    }
+
+    func requestBrowserTab(_ key: BrowserTabPreviewKey, pixelHeight: CGFloat, isLive: Bool = false) {
+        guard isActiveBrowserTab(key) else { return }
+        beginRequest(
+            key: .browserTab(key),
+            pixelHeight: pixelHeight,
+            maxAge: isLive ? 0 : refreshTTL,
+            isLive: isLive
+        )
     }
 
     /// Request the next one-shot live frame. ScreenCaptureKit only; the legacy
@@ -118,21 +157,22 @@ final class WindowThumbnailCache {
     /// is acceptable once per reveal but not on a 10 Hz path.
     func requestLiveFrame(wid: CGWindowID, pixelHeight: CGFloat) {
         guard #available(macOS 14.0, *) else { return }
-        beginRequest(wid: wid, pixelHeight: pixelHeight, maxAge: 0, isLive: true)
+        beginRequest(key: .window(wid), pixelHeight: pixelHeight, maxAge: 0, isLive: true)
     }
 
     private func beginRequest(
-        wid: CGWindowID,
+        key: ThumbnailKey,
         pixelHeight: CGFloat,
         maxAge: TimeInterval,
         isLive: Bool
     ) {
-        guard wid != 0, !requests.contains(wid) else { return }
-        if isLive, let failed = liveFailureAt[wid],
+        let wid = key.windowID
+        guard wid != 0, !requests.contains(key) else { return }
+        if isLive, let failed = liveFailureAt[key],
            Date().timeIntervalSince(failed) < liveFailureBackoff { return }
-        if maxAge > 0, let ts = cache.capturedAt(for: wid),
+        if maxAge > 0, let ts = cache.capturedAt(for: key),
            Date().timeIntervalSince(ts) < maxAge { return }
-        guard let token = requests.begin(wid) else { return }
+        guard let token = requests.begin(key) else { return }
         let task = Task { [weak self] in
             let image = await Self.capture(
                 wid: wid,
@@ -140,27 +180,29 @@ final class WindowThumbnailCache {
                 allowCGFallback: !isLive
             )
             guard !Task.isCancelled else { return }
-            self?.store(image, for: wid, token: token, isLive: isLive)
+            self?.store(image, for: key, token: token, isLive: isLive)
         }
-        captureTasks[wid] = (token, task)
+        captureTasks[key] = (token, task)
     }
 
     private func store(
         _ image: NSImage?,
-        for wid: CGWindowID,
+        for key: ThumbnailKey,
         token: UInt64,
         isLive: Bool
     ) {
-        if captureTasks[wid]?.token == token {
-            captureTasks.removeValue(forKey: wid)
+        if captureTasks[key]?.token == token {
+            captureTasks.removeValue(forKey: key)
         }
         // A memory-pressure clear, or a newer request after that clear, makes an
         // old completion stale. Do not repopulate the cache and, critically, do
         // not clear the newer request's in-flight slot.
-        guard requests.finish(wid, token: token) else { return }
+        guard requests.finish(key, token: token) else { return }
+        if case .browserTab(let tabKey) = key,
+           activeBrowserTabByWindow[tabKey.windowID] != tabKey { return }
         guard let image else {
             if isLive {
-                liveFailureAt[wid] = Date()
+                liveFailureAt[key] = Date()
                 if liveFailureAt.count > 64 {
                     let now = Date()
                     liveFailureAt = liveFailureAt.filter {
@@ -170,10 +212,10 @@ final class WindowThumbnailCache {
             }
             return
         }
-        liveFailureAt.removeValue(forKey: wid)
+        liveFailureAt.removeValue(forKey: key)
         let cost = Int(image.size.width * image.size.height * 4)
-        cache.set(image, cost: cost, capturedAt: Date(), for: wid)
-        onReady?(wid)
+        cache.set(image, cost: cost, capturedAt: Date(), for: key)
+        onReady?(key)
     }
 
     /// Drop every cached thumbnail (memory-pressure handler). Not called on
@@ -185,6 +227,7 @@ final class WindowThumbnailCache {
         cache.removeAll()
         requests.reset()
         liveFailureAt.removeAll()
+        activeBrowserTabByWindow.removeAll()
         releaseCaptureMetadata()
     }
 
@@ -293,9 +336,9 @@ struct ThumbnailLRU {
         let capturedAt: Date
     }
 
-    private var entries: [CGWindowID: Entry] = [:]
+    private var entries: [ThumbnailKey: Entry] = [:]
     /// Recency order, index 0 = least recently used.
-    private var order: [CGWindowID] = []
+    private var order: [ThumbnailKey] = []
     private(set) var totalCost = 0
     let countLimit: Int
     let costLimit: Int
@@ -308,28 +351,30 @@ struct ThumbnailLRU {
     var count: Int { entries.count }
 
     /// Cached image for `wid`, bumping its recency on a hit.
-    mutating func image(for wid: CGWindowID) -> NSImage? {
-        guard let entry = entries[wid] else { return nil }
-        bump(wid)
+    mutating func image(for key: ThumbnailKey) -> NSImage? {
+        guard let entry = entries[key] else { return nil }
+        bump(key)
         return entry.image
     }
+    mutating func image(for wid: CGWindowID) -> NSImage? { image(for: .window(wid)) }
 
     /// Capture timestamp for `wid` without touching recency (freshness checks
     /// shouldn't keep an otherwise-unused entry alive).
-    func capturedAt(for wid: CGWindowID) -> Date? {
-        entries[wid]?.capturedAt
+    func capturedAt(for key: ThumbnailKey) -> Date? {
+        entries[key]?.capturedAt
     }
+    func capturedAt(for wid: CGWindowID) -> Date? { capturedAt(for: .window(wid)) }
 
     /// Insert or replace `wid`, then evict least-recently-used entries while
     /// over either limit. The just-inserted entry is never evicted: one
     /// oversized frame beats an empty cache.
-    mutating func set(_ image: NSImage, cost: Int, capturedAt: Date, for wid: CGWindowID) {
-        if let old = entries.removeValue(forKey: wid) {
+    mutating func set(_ image: NSImage, cost: Int, capturedAt: Date, for key: ThumbnailKey) {
+        if let old = entries.removeValue(forKey: key) {
             totalCost -= old.cost
-            order.removeAll { $0 == wid }
+            order.removeAll { $0 == key }
         }
-        entries[wid] = Entry(image: image, cost: cost, capturedAt: capturedAt)
-        order.append(wid)
+        entries[key] = Entry(image: image, cost: cost, capturedAt: capturedAt)
+        order.append(key)
         totalCost += cost
         while entries.count > 1, entries.count > countLimit || totalCost > costLimit {
             let lru = order.removeFirst()
@@ -338,6 +383,9 @@ struct ThumbnailLRU {
             }
         }
     }
+    mutating func set(_ image: NSImage, cost: Int, capturedAt: Date, for wid: CGWindowID) {
+        set(image, cost: cost, capturedAt: capturedAt, for: .window(wid))
+    }
 
     mutating func removeAll() {
         entries.removeAll()
@@ -345,10 +393,10 @@ struct ThumbnailLRU {
         totalCost = 0
     }
 
-    private mutating func bump(_ wid: CGWindowID) {
-        guard order.last != wid, let idx = order.firstIndex(of: wid) else { return }
+    private mutating func bump(_ key: ThumbnailKey) {
+        guard order.last != key, let idx = order.firstIndex(of: key) else { return }
         order.remove(at: idx)
-        order.append(wid)
+        order.append(key)
     }
 }
 

--- a/BetterCmdTab/Windows/BrowserTabs.swift
+++ b/BetterCmdTab/Windows/BrowserTabs.swift
@@ -4,6 +4,11 @@ import Darwin
 import Foundation
 import os
 
+struct BrowserTabInfo: Equatable, Sendable {
+    let title: String
+    let url: String
+}
+
 // Private SPI from libsystem: detaches the spawned child's TCC
 // "responsibility" so it acts as its own client (osascript) instead of
 // inheriting from us (BetterCmdTab). This is the documented escape hatch
@@ -61,7 +66,7 @@ enum BrowserTabs {
     enum TabsOutcome {
         case notSupported
         case failed
-        case tabs([String])
+        case tabs([BrowserTabInfo])
     }
 
     enum Family {
@@ -303,9 +308,13 @@ enum BrowserTabs {
     /// Split osascript's list output into items. AppleScript's default text
     /// representation of a list separates items with ", " — split there.
     /// Returns the raw items in declaration order.
-    private static func parseList(_ raw: String) -> [String] {
+    private static func parseTabs(_ raw: String) -> [BrowserTabInfo] {
         guard !raw.isEmpty else { return [] }
-        return raw.components(separatedBy: ", ")
+        return raw.components(separatedBy: "\u{1F}").compactMap { record in
+            let parts = record.components(separatedBy: "\u{1C}")
+            guard parts.count == 2 else { return nil }
+            return BrowserTabInfo(title: parts[0], url: parts[1])
+        }
     }
 
     /// Force the macOS TCC prompt for Apple Events to the target app. Returns
@@ -429,8 +438,18 @@ enum BrowserTabs {
                         end ignoring
                     end repeat
                     if matchCount is 1 then
-                        set AppleScript's text item delimiters to (ASCII character 10)
-                        return "MATCH" & (ASCII character 10) & ((\(attr) of every tab of window matchIdx) as text)
+                        set tabText to ""
+                        set tc to count of tabs of window matchIdx
+                        repeat with j from 1 to tc
+                            set tabTitle to (\(attr) of tab j of window matchIdx) as text
+                            set tabURL to ""
+                            try
+                                set tabURL to (URL of tab j of window matchIdx) as text
+                            end try
+                            set tabText to tabText & tabTitle & (ASCII character 28) & tabURL
+                            if j < tc then set tabText to tabText & (ASCII character 31)
+                        end repeat
+                        return "MATCH" & (ASCII character 29) & tabText
                     else
                         return "FALLBACK"
                     end if
@@ -440,9 +459,9 @@ enum BrowserTabs {
             if let raw = runScript(matchSource) {
                 if raw == "NOWINDOWS" { return .tabs([]) }
                 if raw != "FALLBACK" {
-                    let body = raw.hasPrefix("MATCH\n") ? String(raw.dropFirst("MATCH\n".count)) : raw
-                    let titles = body.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-                    return .tabs(titles)
+                    let prefix = "MATCH\u{1D}"
+                    let body = raw.hasPrefix(prefix) ? String(raw.dropFirst(prefix.count)) : raw
+                    return .tabs(parseTabs(body))
                 }
                 // "FALLBACK" → title didn't uniquely match; use the raise path.
             } else {
@@ -461,18 +480,26 @@ enum BrowserTabs {
         tell \(appLit)
             with timeout of 3 seconds
                 if (count of windows) = 0 then return ""
-                set theList to \(attr) of every tab of window 1
+                set tabText to ""
+                set tc to count of tabs of window 1
+                repeat with j from 1 to tc
+                    set tabTitle to (\(attr) of tab j of window 1) as text
+                    set tabURL to ""
+                    try
+                        set tabURL to (URL of tab j of window 1) as text
+                    end try
+                    set tabText to tabText & tabTitle & (ASCII character 28) & tabURL
+                    if j < tc then set tabText to tabText & (ASCII character 31)
+                end repeat
             end timeout
         end tell
-        set AppleScript's text item delimiters to (ASCII character 10)
-        return theList as text
+        return tabText
         """
         guard let raw = runScript(source) else {
             Log.activator.error("BrowserTabs: tabTitles \(bid) failed (permission/timeout?)")
             return .failed
         }
-        let titles = raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        return .tabs(titles)
+        return .tabs(parseTabs(raw))
     }
 
     /// List every window of `app` together with its tab titles in a **single**
@@ -487,7 +514,13 @@ enum BrowserTabs {
     /// the "grant Automation access" hint (#39) — an empty result alone can't tell
     /// "denied" from "nothing to show".
     struct AllWindowTabs {
-        let windows: [(title: String, activeTab: String, tabs: [String])]
+        struct Window: Equatable, Sendable {
+            let title: String
+            let activeIndex: Int
+            let tabs: [BrowserTabInfo]
+        }
+
+        let windows: [Window]
         /// True only when the osascript spawn itself failed (nil result) — a
         /// permission/timeout signal, not an empty browser.
         let failed: Bool
@@ -519,8 +552,8 @@ enum BrowserTabs {
         // A browser window's AX title reflects its active tab, so also capture the
         // active tab's title per window for the caller to match AX windows by.
         let activeExpr: String = (family == .safari)
-            ? "name of current tab of window i"
-            : "title of active tab of window i"
+            ? "index of current tab of window i"
+            : "active tab index of window i"
         let source = """
         tell \(appLit)
             with timeout of 5 seconds
@@ -529,15 +562,22 @@ enum BrowserTabs {
                 set outText to ""
                 repeat with i from 1 to wc
                     set wTitle to (\(attr) of window i) as text
-                    set att to ""
+                    set activeIndex to 1
                     try
-                        set att to (\(activeExpr)) as text
+                        set activeIndex to \(activeExpr)
                     end try
-                    set tabNames to (\(attr) of every tab of window i)
-                    set AppleScript's text item delimiters to (ASCII character 31)
-                    set tabText to tabNames as text
-                    set AppleScript's text item delimiters to ""
-                    set outText to outText & wTitle & (ASCII character 30) & att & (ASCII character 30) & tabText
+                    set tabText to ""
+                    set tc to count of tabs of window i
+                    repeat with j from 1 to tc
+                        set tabTitle to (\(attr) of tab j of window i) as text
+                        set tabURL to ""
+                        try
+                            set tabURL to (URL of tab j of window i) as text
+                        end try
+                        set tabText to tabText & tabTitle & (ASCII character 28) & tabURL
+                        if j < tc then set tabText to tabText & (ASCII character 31)
+                    end repeat
+                    set outText to outText & wTitle & (ASCII character 30) & (activeIndex as text) & (ASCII character 30) & tabText
                     if i < wc then set outText to outText & (ASCII character 29)
                 end repeat
                 return outText
@@ -549,14 +589,20 @@ enum BrowserTabs {
             return .failure
         }
         if raw == "NOWINDOWS" || raw.isEmpty { return .empty }
-        var out: [(title: String, activeTab: String, tabs: [String])] = []
+        return AllWindowTabs(windows: parseAllWindowTabs(raw), failed: false)
+    }
+
+    static func parseAllWindowTabs(_ raw: String) -> [AllWindowTabs.Window] {
+        guard raw != "NOWINDOWS", !raw.isEmpty else { return [] }
+        var out: [AllWindowTabs.Window] = []
         for block in raw.components(separatedBy: "\u{1D}") {
             let parts = block.components(separatedBy: "\u{1E}")
-            guard parts.count == 3 else { continue }
-            let tabs = parts[2].isEmpty ? [] : parts[2].components(separatedBy: "\u{1F}")
-            out.append((title: parts[0], activeTab: parts[1], tabs: tabs))
+            guard parts.count == 3, let oneBased = Int(parts[1]) else { continue }
+            let tabs = parseTabs(parts[2])
+            let activeIndex = tabs.isEmpty ? 0 : min(max(0, oneBased - 1), tabs.count - 1)
+            out.append(.init(title: parts[0], activeIndex: activeIndex, tabs: tabs))
         }
-        return AllWindowTabs(windows: out, failed: false)
+        return out
     }
 
     /// Switch the row window's browser tab to `tabIndex` (0-based here, 1-based

--- a/BetterCmdTabTests/BrowserFaviconCacheTests.swift
+++ b/BetterCmdTabTests/BrowserFaviconCacheTests.swift
@@ -1,0 +1,208 @@
+import AppKit
+import CryptoKit
+import Foundation
+import ImageIO
+import SQLite3
+import Testing
+@testable import BetterCmdTab
+
+@Suite("BrowserFaviconCache")
+struct BrowserFaviconCacheTests {
+    @Test("Safari reads PNG and ICO files and ignores URL fragments")
+    func safariPNGAndICO() throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let icons = root.appendingPathComponent("favicons")
+        try FileManager.default.createDirectory(at: icons, withIntermediateDirectories: true)
+        let database = root.appendingPathComponent("favicons.db")
+        let db = try open(database)
+        defer { sqlite3_close(db) }
+        try exec(db, "CREATE TABLE page_url (url TEXT UNIQUE, uuid TEXT NOT NULL)")
+
+        let pngUUID = "11111111-1111-1111-1111-111111111111"
+        let icoUUID = "22222222-2222-2222-2222-222222222222"
+        try exec(db, "INSERT INTO page_url VALUES ('https://example.test/page', '\(pngUUID)')")
+        try exec(db, "INSERT INTO page_url VALUES ('https://example.test/icon', '\(icoUUID)')")
+        try png(size: 2).write(to: icons.appendingPathComponent(md5(pngUUID)))
+        try ico(size: 16).write(to: icons.appendingPathComponent(md5(icoUUID)))
+
+        let found = BrowserFaviconCache.loadSafari(
+            urls: ["https://example.test/page#section", "https://example.test/icon"],
+            databaseURL: database,
+            iconsURL: icons
+        )
+        #expect(found["https://example.test/page"]?.size.width == 2)
+        #expect(found["https://example.test/icon"] != nil)
+    }
+
+    @Test("Chromium starts with last_used, decodes data, and falls back silently")
+    func chromiumProfilesAndFailures() throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let localState: [String: Any] = ["profile": [
+            "last_used": "Profile 2",
+            "info_cache": ["Default": [:], "Profile 2": [:]],
+        ]]
+        try JSONSerialization.data(withJSONObject: localState).write(to: root.appendingPathComponent("Local State"))
+        let profile2 = root.appendingPathComponent("Profile 2")
+        let defaultProfile = root.appendingPathComponent("Default")
+        try FileManager.default.createDirectory(at: profile2, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: defaultProfile, withIntermediateDirectories: true)
+        try makeChromiumDB(profile2.appendingPathComponent("Favicons"), url: "https://example.test/page", data: png(size: 4))
+        try makeChromiumDB(defaultProfile.appendingPathComponent("Favicons"), url: "https://example.test/page", data: png(size: 2))
+
+        let profiles = BrowserFaviconCache.chromiumProfileDirectories(in: root)
+        #expect(profiles.first?.path == profile2.path)
+        let found = BrowserFaviconCache.loadChromium(urls: ["https://example.test/page#fragment", "https://missing.test"], dataDirectory: root)
+        #expect(found["https://example.test/page"]?.size.width == 4)
+        #expect(found["https://missing.test"] == nil)
+
+        let broken = root.appendingPathComponent("Broken")
+        try FileManager.default.createDirectory(at: broken, withIntermediateDirectories: true)
+        let brokenDB = try open(broken.appendingPathComponent("Favicons"))
+        try exec(brokenDB, "CREATE TABLE unrelated (value TEXT)")
+        sqlite3_close(brokenDB)
+        #expect(BrowserFaviconCache.loadChromium(urls: ["https://example.test/page"], dataDirectory: broken).isEmpty)
+    }
+
+    @Test("missing Local State checks only root and Default")
+    func chromiumFallbackProfiles() {
+        let root = URL(fileURLWithPath: "/tmp/no-local-state")
+        #expect(BrowserFaviconCache.chromiumProfileDirectories(in: root) == [
+            root,
+            root.appendingPathComponent("Default"),
+        ])
+    }
+
+    @Test("Chromium exclusive idle lock still permits a stable read")
+    func chromiumExclusiveLock() throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let profile = root.appendingPathComponent("Default")
+        try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
+        let database = profile.appendingPathComponent("Favicons")
+        try makeChromiumDB(database, url: "https://example.test/page", data: png(size: 3))
+
+        let lock = try open(database)
+        defer { sqlite3_close(lock) }
+        try exec(lock, "PRAGMA locking_mode=EXCLUSIVE")
+        try exec(lock, "BEGIN EXCLUSIVE")
+
+        let found = BrowserFaviconCache.loadChromium(
+            urls: ["https://example.test/page"],
+            dataDirectory: root
+        )
+        #expect(found["https://example.test/page"]?.size.width == 3)
+    }
+
+    @Test("a transient database failure is retried instead of cached as a miss")
+    func transientDatabaseFailureIsRetried() throws {
+        let home = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let url = "https://\(UUID().uuidString).test/page"
+        let request = BrowserFaviconCache.Request(bundleID: "com.apple.Safari", url: url)
+        let key = BrowserFaviconCache.key(bundleID: request.bundleID, url: url)
+
+        BrowserFaviconCache.load([request], home: home)
+        #expect(BrowserFaviconCache.image(forKey: key) == nil)
+
+        let root = home.appendingPathComponent("Library/Safari/Favicon Cache")
+        let icons = root.appendingPathComponent("favicons")
+        try FileManager.default.createDirectory(at: icons, withIntermediateDirectories: true)
+        let database = root.appendingPathComponent("favicons.db")
+        let db = try open(database)
+        try exec(db, "CREATE TABLE page_url (url TEXT UNIQUE, uuid TEXT NOT NULL)")
+        let uuid = UUID().uuidString
+        try exec(db, "INSERT INTO page_url VALUES ('\(url)', '\(uuid)')")
+        sqlite3_close(db)
+        try png(size: 3).write(to: icons.appendingPathComponent(md5(uuid)))
+
+        BrowserFaviconCache.load([request], home: home)
+        #expect(BrowserFaviconCache.image(forKey: key)?.size.width == 3)
+    }
+
+    @Test("every supported Chromium bundle has a data directory")
+    func chromiumBundleDirectories() {
+        let ids = [
+            "com.google.chrome", "com.google.chrome.canary", "com.google.chrome.beta", "com.google.chrome.dev",
+            "com.brave.browser", "com.brave.browser.beta", "com.brave.browser.nightly", "com.brave.browser.dev",
+            "com.microsoft.edgemac", "com.microsoft.edgemac.beta", "com.microsoft.edgemac.dev", "com.microsoft.edgemac.canary",
+            "com.vivaldi.vivaldi", "com.operasoftware.opera", "com.operasoftware.operadeveloper",
+            "company.thebrowser.browser", "company.thebrowser.dia", "net.imput.helium",
+        ]
+        let home = URL(fileURLWithPath: "/Users/test")
+        #expect(ids.allSatisfy { BrowserFaviconCache.chromiumDirectory(bundleID: $0, home: home) != nil })
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    private func open(_ url: URL) throws -> OpaquePointer {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK, let db else { throw TestError.sqlite }
+        return db
+    }
+
+    private func exec(_ db: OpaquePointer, _ sql: String) throws {
+        guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else { throw TestError.sqlite }
+    }
+
+    private func makeChromiumDB(_ url: URL, url pageURL: String, data: Data) throws {
+        let db = try open(url)
+        defer { sqlite3_close(db) }
+        try exec(db, "CREATE TABLE icon_mapping (id INTEGER PRIMARY KEY, page_url TEXT, icon_id INTEGER)")
+        try exec(db, "CREATE TABLE favicons (id INTEGER PRIMARY KEY, url TEXT)")
+        try exec(db, "CREATE TABLE favicon_bitmaps (id INTEGER PRIMARY KEY, icon_id INTEGER, image_data BLOB, width INTEGER)")
+        try exec(db, "INSERT INTO icon_mapping VALUES (1, '\(pageURL)', 1)")
+        try exec(db, "INSERT INTO favicons VALUES (1, 'icon')")
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "INSERT INTO favicon_bitmaps VALUES (1, 1, ?, 128)", -1, &statement, nil) == SQLITE_OK,
+              let statement else { throw TestError.sqlite }
+        defer { sqlite3_finalize(statement) }
+        data.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 1, bytes.baseAddress, Int32(bytes.count), testSQLiteTransient)
+        }
+        guard sqlite3_step(statement) == SQLITE_DONE else { throw TestError.sqlite }
+    }
+
+    private func png(size: Int) throws -> Data {
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: size,
+            pixelsHigh: size,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let data = rep.representation(using: .png, properties: [:]) else { throw TestError.image }
+        return data
+    }
+
+    private func ico(size: Int) throws -> Data {
+        guard let source = NSBitmapImageRep(data: try png(size: size)),
+              let image = source.cgImage else { throw TestError.image }
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            "com.microsoft.ico" as CFString,
+            1,
+            nil
+        ) else { throw TestError.image }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else { throw TestError.image }
+        return data as Data
+    }
+
+    private func md5(_ value: String) -> String {
+        Insecure.MD5.hash(data: Data(value.utf8)).map { String(format: "%02X", $0) }.joined()
+    }
+
+    private enum TestError: Error { case sqlite, image }
+}
+
+private let testSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/BetterCmdTabTests/BrowserTabsParserTests.swift
+++ b/BetterCmdTabTests/BrowserTabsParserTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import BetterCmdTab
+
+@Suite("BrowserTabs parser")
+struct BrowserTabsParserTests {
+    @Test("parses URLs, empty URLs, duplicate titles, windows, and numeric active indices")
+    func parsesBatchedWindows() {
+        let first = "Window A\u{1E}2\u{1E}Same\u{1C}https://one.test/a\u{1F}Same\u{1C}"
+        let second = "Window B\u{1E}1\u{1E}Other\u{1C}https://two.test/b#fragment"
+
+        let windows = BrowserTabs.parseAllWindowTabs(first + "\u{1D}" + second)
+
+        #expect(windows.count == 2)
+        #expect(windows[0].activeIndex == 1)
+        #expect(windows[0].tabs == [
+            BrowserTabInfo(title: "Same", url: "https://one.test/a"),
+            BrowserTabInfo(title: "Same", url: ""),
+        ])
+        #expect(windows[1].title == "Window B")
+        #expect(windows[1].activeIndex == 0)
+        #expect(windows[1].tabs[0].url == "https://two.test/b#fragment")
+    }
+
+    @Test("clamps an invalid active index without title matching")
+    func clampsActiveIndex() {
+        let windows = BrowserTabs.parseAllWindowTabs("Window\u{1E}99\u{1E}A\u{1C}u\u{1F}B\u{1C}v")
+        #expect(windows.first?.activeIndex == 1)
+    }
+}

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -290,6 +290,22 @@ struct SwitcherActiveBrowserTabTests {
         #expect(SwitcherController.activeBrowserTabIndex(
             in: rows, window: AXRef(element: win), activeTabIndex: 0) == nil)
     }
+
+    @Test func focusedWindowTitleRejectsStaleOrAmbiguousActiveIndex() {
+        let tabs = [
+            BrowserTabInfo(title: "Old", url: "https://old.test"),
+            BrowserTabInfo(title: "Current", url: "https://current.test"),
+        ]
+        #expect(SwitcherController.activeBrowserTabIndex(tabs: tabs, windowTitle: " Current ") == 1)
+        #expect(SwitcherController.activeBrowserTabIndex(
+            tabs: tabs,
+            windowTitle: "Current — Google Chrome"
+        ) == 1)
+        #expect(SwitcherController.activeBrowserTabIndex(
+            tabs: tabs + [BrowserTabInfo(title: "Current", url: "https://duplicate.test")],
+            windowTitle: "Current"
+        ) == nil)
+    }
 }
 
 /// Under a stable sort (alphabetical / launch order) the primed list is not

--- a/BetterCmdTabTests/SwitcherRowTests.swift
+++ b/BetterCmdTabTests/SwitcherRowTests.swift
@@ -204,6 +204,27 @@ struct SwitcherRowTests {
         #expect(rows.allSatisfy { $0.window != nil })
     }
 
+    @Test("browser tab rows carry URL, active state, and page-stable preview keys")
+    func browserTabIdentity() {
+        let parent = browserWindowRow(title: "Browser Window")
+        let rows = parent.browserTabRows(tabs: [
+            BrowserTabInfo(title: "Duplicate", url: "https://example.test/a#one"),
+            BrowserTabInfo(title: "Duplicate", url: "https://example.test/b"),
+        ], activeIndex: 1)
+
+        #expect(rows[0].browserTab?.url == "https://example.test/a#one")
+        #expect(rows.map(\.browserTab?.isActive) == [false, true])
+        #expect(rows[0].browserTabPreviewKey?.pageIdentity == "https://example.test/a")
+        #expect(rows[0].browserTabPreviewKey != rows[1].browserTabPreviewKey)
+
+        let reordered = parent.browserTabRows(tabs: [
+            BrowserTabInfo(title: "Duplicate", url: "https://example.test/b"),
+            BrowserTabInfo(title: "Duplicate", url: "https://example.test/a#two"),
+        ], activeIndex: 0)
+        #expect(rows[0].browserTabPreviewKey != reordered[0].browserTabPreviewKey)
+        #expect(rows[0].browserTabPreviewKey != reordered[1].browserTabPreviewKey) // index is part of identity
+    }
+
     @Test("browserTabRows leaves a single-tab (or empty) window collapsed")
     func browserTabsNoExpandUnderTwo() {
         let parent = browserWindowRow(title: "Solo")

--- a/BetterCmdTabTests/ThumbnailLRUTests.swift
+++ b/BetterCmdTabTests/ThumbnailLRUTests.swift
@@ -126,4 +126,47 @@ struct ThumbnailLRUTests {
         #expect(acceptedNewer)
         #expect(gate.count == 0)
     }
+
+    @Test("window and browser-tab thumbnails share limits without key collisions")
+    func mixedThumbnailKeysShareBudget() {
+        let tab = BrowserTabPreviewKey(pid: 7, windowID: 9, index: 0, pageIdentity: "https://example.test")
+        var lru = ThumbnailLRU(countLimit: 2, costLimit: 15)
+        lru.set(image, cost: 7, capturedAt: epoch, for: .window(9))
+        lru.set(image, cost: 7, capturedAt: epoch, for: .browserTab(tab))
+        #expect(lru.count == 2)
+        #expect(lru.totalCost == 14)
+        let windowImage = lru.image(for: .window(9))
+        let tabImage = lru.image(for: .browserTab(tab))
+        #expect(windowImage != nil)
+        #expect(tabImage != nil)
+
+        lru.set(image, cost: 7, capturedAt: epoch, for: .window(10))
+        #expect(lru.count == 2)
+        #expect(lru.totalCost == 14)
+    }
+
+    @Test("a late browser-tab completion cannot consume a newer tab request")
+    func requestGateRejectsLateBrowserCapture() {
+        let first = ThumbnailKey.browserTab(.init(pid: 1, windowID: 2, index: 0, pageIdentity: "a"))
+        let second = ThumbnailKey.browserTab(.init(pid: 1, windowID: 2, index: 1, pageIdentity: "b"))
+        var gate = ThumbnailRequestGate()
+        let old = gate.begin(first)!
+        let new = gate.begin(second)!
+        let acceptedOld = gate.finish(first, token: old)
+        #expect(acceptedOld)
+        #expect(gate.count == 1)
+        let acceptedNew = gate.finish(second, token: new)
+        #expect(acceptedNew)
+    }
+
+    @Test("a browser-tab request cannot approve its own stale key")
+    @MainActor func browserCaptureRequiresCurrentTarget() {
+        let current = BrowserTabPreviewKey(pid: 1, windowID: 2, index: 0, pageIdentity: "current")
+        let stale = BrowserTabPreviewKey(pid: 1, windowID: 2, index: 1, pageIdentity: "stale")
+        let cache = WindowThumbnailCache.shared
+        cache.setActiveBrowserTab(current)
+        #expect(cache.isActiveBrowserTab(current))
+        #expect(!cache.isActiveBrowserTab(stale))
+        cache.setActiveBrowserTab(nil)
+    }
 }


### PR DESCRIPTION
## Summary

- include browser tab URLs and exact active-tab indices in the existing batched AppleScript scan
- show cached Safari and Chromium favicons in tab rows, search results, previews, and the Peek tabs strip
- cache active browser-tab screenshots in RAM for the Previews layout, behind an off-by-default Experimental toggle
- keep SQLite reads, image decoding, and capture work off the panel reveal path
- prevent stale preview reuse after tab changes and retry transient favicon database failures
- slightly reduce displayed favicon sizing so it matches native application icons

## Why

Browser tab rows previously exposed only titles and reused the parent browser icon and window thumbnail. This made tabs hard to distinguish and could associate a captured image with the wrong page after tabs were reordered or changed.

The implementation keys previews by process, window, tab index, and normalized page identity, uses the browsers' existing local favicon databases read-only, and preserves the shared thumbnail memory budget.

## Validation

- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test` — 475 tests in 56 suites passed
- Debug build succeeded
- Release build succeeded
- `git diff --check` passed
- Safari and Helium favicon database schemas verified locally

## Notes

Browser tab screenshots remain disabled by default under Experimental → Previews. No browser extension, network request, screenshot persistence, or new recurring task is introduced.

Closes #40