### PR TITLE
feat: add switch sound picker

### DIFF
--- a/BetterCmdTab/App/AppDelegate.swift
+++ b/BetterCmdTab/App/AppDelegate.swift
@@ -121,6 +121,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func bootController() {
         guard controller == nil else { return }
+        CommitFeedback.prepare()
         let c = SwitcherController()
         c.onAccessibilityRevoked = { [weak self] in
             self?.axWaiter?.waitForTrust()

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -664,6 +664,8 @@ final class Preferences: ObservableObject {
     static let defaultTitleRefreshIntervalMs = 200
     static let titleRefreshIntervalRange: ClosedRange<Int> = 50...2000
 
+    static let defaultCommitSoundName = "Tink"
+
     static let defaultSwipeSensitivity = 5
     static let swipeSensitivityRange: ClosedRange<Int> = 1...10
 
@@ -725,6 +727,8 @@ final class Preferences: ObservableObject {
         static let recentlyClosedLimit = "Switcher.recentlyClosedLimit"
         static let hapticOnCommit = "Switcher.hapticOnCommit"
         static let soundOnCommit = "Switcher.soundOnCommit"
+        static let commitSoundName = "Switcher.commitSoundName"
+        static let customCommitSoundFilename = "Switcher.customCommitSoundFilename"
         static let hideMenuBarIcon = "Switcher.hideMenuBarIcon"
         static let experimentalSwipeTrigger = "Switcher.experimentalSwipeTrigger"
         static let swipeMode = "Switcher.swipeMode"
@@ -1098,11 +1102,33 @@ final class Preferences: ObservableObject {
         }
     }
 
-    /// Play a subtle click sound when a selection is committed. Default off.
+    /// Play the selected sound when a selection is committed. Default off.
     @Published var soundOnCommit: Bool {
         didSet {
             guard oldValue != soundOnCommit else { return }
             UserDefaults.standard.set(soundOnCommit, forKey: Keys.soundOnCommit)
+        }
+    }
+
+    /// System sound used for commit feedback. Kept even while a custom sound is
+    /// selected so it remains the fallback if that local file disappears.
+    @Published var commitSoundName: String {
+        didSet {
+            guard oldValue != commitSoundName else { return }
+            UserDefaults.standard.set(commitSoundName, forKey: Keys.commitSoundName)
+        }
+    }
+
+    /// File owned by BetterCmdTab under Application Support. Machine-local by
+    /// design: settings exports carry the system fallback, not a filesystem path.
+    @Published var customCommitSoundFilename: String? {
+        didSet {
+            guard oldValue != customCommitSoundFilename else { return }
+            if let customCommitSoundFilename {
+                UserDefaults.standard.set(customCommitSoundFilename, forKey: Keys.customCommitSoundFilename)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Keys.customCommitSoundFilename)
+            }
         }
     }
 
@@ -1824,6 +1850,8 @@ final class Preferences: ObservableObject {
 
         self.hapticOnCommit = defaults.object(forKey: Keys.hapticOnCommit) as? Bool ?? false
         self.soundOnCommit = defaults.object(forKey: Keys.soundOnCommit) as? Bool ?? false
+        self.commitSoundName = defaults.string(forKey: Keys.commitSoundName) ?? Self.defaultCommitSoundName
+        self.customCommitSoundFilename = defaults.string(forKey: Keys.customCommitSoundFilename)
 
         self.hideMenuBarIcon = defaults.object(forKey: Keys.hideMenuBarIcon) as? Bool ?? false
 
@@ -1959,6 +1987,8 @@ final class Preferences: ObservableObject {
 
         hapticOnCommit = defaults.object(forKey: Keys.hapticOnCommit) as? Bool ?? false
         soundOnCommit = defaults.object(forKey: Keys.soundOnCommit) as? Bool ?? false
+        commitSoundName = defaults.string(forKey: Keys.commitSoundName) ?? Self.defaultCommitSoundName
+        customCommitSoundFilename = defaults.string(forKey: Keys.customCommitSoundFilename)
         hideMenuBarIcon = defaults.object(forKey: Keys.hideMenuBarIcon) as? Bool ?? false
 
         experimentalSwipeTrigger = defaults.object(forKey: Keys.experimentalSwipeTrigger) as? Bool ?? false

--- a/BetterCmdTab/App/SettingsPortability.swift
+++ b/BetterCmdTab/App/SettingsPortability.swift
@@ -22,14 +22,16 @@ extension Preferences {
     /// `disabledSymbolicHotKeys` is the crash-heal record of which native
     /// hotkeys THIS machine has disabled (importing another Mac's record could
     /// leave native ⌘Tab dead after a crash); `recentlyClosed` is session
-    /// history. The accent keys were retired in 26.7 (the switcher always
-    /// follows the macOS accent) — skipping them on import keeps old exports
-    /// from re-planting dead keys.
+    /// history; the custom sound file lives only in this Mac's Application
+    /// Support directory. The accent keys were retired in 26.7 (the switcher
+    /// always follows the macOS accent) — skipping them on import keeps old
+    /// exports from re-planting dead keys.
     static let exportExcludedKeys: Set<String> = [
         "Switcher.disabledSymbolicHotKeys",
         "Switcher.recentlyClosed",
         "Switcher.accentChoice",
         "Switcher.customAccentHex",
+        "Switcher.customCommitSoundFilename",
     ]
 
     /// File extension for exported settings documents.

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -681,40 +681,6 @@
         }
       }
     },
-    "A soft click when you pick an app." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein leiser Klick, wenn du eine App auswählst."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un clic suave al seleccionar una app."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un léger clic lorsque vous sélectionnez une app."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cichy klik, gdy wybierasz aplikację."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择应用时发出轻柔点击声。"
-          }
-        }
-      }
-    },
     "A tap when you pick an app. Force Touch trackpads only." : {
       "localizations" : {
         "de" : {
@@ -2043,6 +2009,40 @@
         }
       }
     },
+    "Choose Custom Sound…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eigenen Ton auswählen…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir sonido personalizado…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir un son personnalisé…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz własny dźwięk…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择自定义声音…"
+          }
+        }
+      }
+    },
     "Choose an app to set switcher rules for." : {
       "localizations" : {
         "de" : {
@@ -2583,6 +2583,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法导入设置"
+          }
+        }
+      }
+    },
+    "Custom: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eigener Ton: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizado: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisé : %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Własny: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义：%@"
           }
         }
       }
@@ -6499,6 +6533,40 @@
         }
       }
     },
+    "Play a sound when you pick an app." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einen Ton abspielen, wenn du eine App auswählst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproduce un sonido al seleccionar una app."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jouer un son lorsque vous sélectionnez une app."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odtwarzaj dźwięk po wybraniu aplikacji."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择应用时播放声音。"
+          }
+        }
+      }
+    },
     "Playing audio" : {
       "localizations" : {
         "de" : {
@@ -9389,6 +9457,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此浏览器"
+          }
+        }
+      }
+    },
+    "The selected file isn't a supported sound." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die ausgewählte Datei ist kein unterstützter Ton."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El archivo seleccionado no es un sonido compatible."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le fichier sélectionné n’est pas un son pris en charge."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybrany plik nie jest obsługiwanym dźwiękiem."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所选文件不是受支持的声音。"
           }
         }
       }

--- a/BetterCmdTab/Settings/GeneralSettingsViewController.swift
+++ b/BetterCmdTab/Settings/GeneralSettingsViewController.swift
@@ -10,7 +10,7 @@ final class GeneralSettingsViewController: SettingsTabViewController {
     private let launchSwitch = NSSwitch()
     private let hideMenuBarSwitch = NSSwitch()
     private let hapticSwitch = NSSwitch()
-    private let soundSwitch = NSSwitch()
+    private let soundPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let betaSwitch = NSSwitch()
     private let intervalPopUp = NSPopUpButton(frame: .zero, pullsDown: false)
     private let exportButton = NSButton(title: String(localized: "Export…"), target: nil, action: nil)
@@ -18,6 +18,14 @@ final class GeneralSettingsViewController: SettingsTabViewController {
     private let restoreShortcutsButton = NSButton(title: "", target: nil, action: nil)
 
     private var cancellables = Set<AnyCancellable>()
+    private lazy var systemSoundNames = CommitFeedback.systemSoundNames()
+
+    private enum SoundItemTag: Int {
+        case off
+        case system
+        case custom
+        case chooseCustom
+    }
 
     /// Cadences offered in the update popup. The package's `selectableCadences`
     /// excludes `.manual`; it's appended here so update checks (and their
@@ -58,14 +66,20 @@ final class GeneralSettingsViewController: SettingsTabViewController {
             accessory: hapticSwitch,
             searchItemID: SearchID.haptic
         )
-        configureSwitch(soundSwitch, action: #selector(toggleSound(_:)))
+        soundPopup.controlSize = .small
+        soundPopup.target = self
+        soundPopup.action = #selector(changeSound(_:))
         addRow(
             to: feedback,
             title: String(localized: "Sound on switch"),
-            subtitle: String(localized: "A soft click when you pick an app."),
-            accessory: soundSwitch,
+            subtitle: String(localized: "Play a sound when you pick an app."),
+            accessory: soundPopup,
             searchItemID: SearchID.sound
         )
+        soundPopup.cell?.lineBreakMode = .byTruncatingMiddle
+        soundPopup.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        soundPopup.widthAnchor.constraint(lessThanOrEqualToConstant: 180).isActive = true
+        rebuildSoundMenu()
 
         // Updates section
         let updates = addSection(title: String(localized: "Updates"), anchor: SettingsAnchor.updates)
@@ -159,7 +173,7 @@ final class GeneralSettingsViewController: SettingsTabViewController {
         let prefs = Preferences.shared
         hideMenuBarSwitch.state = prefs.hideMenuBarIcon ? .on : .off
         hapticSwitch.state = prefs.hapticOnCommit ? .on : .off
-        soundSwitch.state = prefs.soundOnCommit ? .on : .off
+        rebuildSoundMenu()
 
         let updater = GitHubUpdater.shared
         betaSwitch.state = updater.includePreReleases ? .on : .off
@@ -191,7 +205,17 @@ final class GeneralSettingsViewController: SettingsTabViewController {
 
         prefs.$soundOnCommit
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.soundSwitch.state = $0 ? .on : .off }
+            .sink { [weak self] _ in self?.rebuildSoundMenu() }
+            .store(in: &cancellables)
+
+        prefs.$commitSoundName
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildSoundMenu() }
+            .store(in: &cancellables)
+
+        prefs.$customCommitSoundFilename
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildSoundMenu() }
             .store(in: &cancellables)
     }
 
@@ -227,8 +251,102 @@ final class GeneralSettingsViewController: SettingsTabViewController {
         Preferences.shared.hapticOnCommit = (sender.state == .on)
     }
 
-    @objc private func toggleSound(_ sender: NSSwitch) {
-        Preferences.shared.soundOnCommit = (sender.state == .on)
+    @objc private func changeSound(_ sender: NSPopUpButton) {
+        guard let item = sender.selectedItem,
+              let tag = SoundItemTag(rawValue: item.tag) else {
+            rebuildSoundMenu()
+            return
+        }
+
+        let prefs = Preferences.shared
+        switch tag {
+        case .off:
+            prefs.soundOnCommit = false
+            CommitFeedback.stop()
+        case .system:
+            guard let name = item.representedObject as? String else { return }
+            CommitFeedback.selectSystemSound(named: name)
+            prefs.soundOnCommit = true
+            CommitFeedback.preview()
+        case .custom:
+            prefs.soundOnCommit = true
+            CommitFeedback.preview()
+        case .chooseCustom:
+            chooseCustomSound()
+        }
+    }
+
+    private func rebuildSoundMenu() {
+        let prefs = Preferences.shared
+        let menu = NSMenu()
+
+        let offItem = NSMenuItem(title: String(localized: "Off"), action: nil, keyEquivalent: "")
+        offItem.tag = SoundItemTag.off.rawValue
+        menu.addItem(offItem)
+        menu.addItem(.separator())
+
+        var selectedSystemItem: NSMenuItem?
+        for name in systemSoundNames {
+            let item = NSMenuItem(title: name, action: nil, keyEquivalent: "")
+            item.tag = SoundItemTag.system.rawValue
+            item.representedObject = name
+            menu.addItem(item)
+            if name == prefs.commitSoundName { selectedSystemItem = item }
+        }
+
+        menu.addItem(.separator())
+        var customItem: NSMenuItem?
+        if let filename = prefs.customCommitSoundFilename {
+            let displayName = URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+            let item = NSMenuItem(
+                title: String(format: String(localized: "Custom: %@"), displayName),
+                action: nil,
+                keyEquivalent: ""
+            )
+            item.tag = SoundItemTag.custom.rawValue
+            menu.addItem(item)
+            customItem = item
+        }
+
+        let chooseItem = NSMenuItem(title: String(localized: "Choose Custom Sound…"), action: nil, keyEquivalent: "")
+        chooseItem.tag = SoundItemTag.chooseCustom.rawValue
+        menu.addItem(chooseItem)
+
+        soundPopup.menu = menu
+        if !prefs.soundOnCommit {
+            soundPopup.select(offItem)
+        } else if let customItem {
+            soundPopup.select(customItem)
+        } else {
+            soundPopup.select(selectedSystemItem ?? menu.item(withTitle: Preferences.defaultCommitSoundName) ?? offItem)
+        }
+    }
+
+    private func chooseCustomSound() {
+        let panel = NSOpenPanel()
+        panel.title = String(localized: "Choose Custom Sound…")
+        panel.prompt = String(localized: "Choose")
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.audio]
+
+        let completion: (NSApplication.ModalResponse) -> Void = { response in
+            defer { self.rebuildSoundMenu() }
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                try CommitFeedback.installCustomSound(from: url)
+                Preferences.shared.soundOnCommit = true
+                CommitFeedback.preview()
+            } catch {
+                self.presentError(String(localized: "Sound on switch"), error)
+            }
+        }
+        if let window = view.window {
+            panel.beginSheetModal(for: window, completionHandler: completion)
+        } else {
+            completion(panel.runModal())
+        }
     }
 
     @objc private func restoreNativeShortcuts() {
@@ -262,7 +380,7 @@ final class GeneralSettingsViewController: SettingsTabViewController {
                 let data = try Preferences.shared.exportedJSONData()
                 try data.write(to: url, options: .atomic)
             } catch {
-                self.presentBackupError(String(localized: "Couldn't export settings"), error)
+                self.presentError(String(localized: "Couldn't export settings"), error)
             }
         }
         if let window = view.window {
@@ -290,7 +408,7 @@ final class GeneralSettingsViewController: SettingsTabViewController {
                 let data = try Data(contentsOf: url)
                 try Preferences.shared.importSettings(from: data)
             } catch {
-                self.presentBackupError(String(localized: "Couldn't import settings"), error)
+                self.presentError(String(localized: "Couldn't import settings"), error)
             }
         }
         if let window = view.window {
@@ -300,7 +418,7 @@ final class GeneralSettingsViewController: SettingsTabViewController {
         }
     }
 
-    private func presentBackupError(_ title: String, _ error: Error) {
+    private func presentError(_ title: String, _ error: Error) {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = title

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -252,7 +252,7 @@ enum SettingsCatalog {
         item(SearchID.haptic, .general, SettingsAnchor.feedback, String(localized: "General"), String(localized: "Feedback"),
              String(localized: "Haptic feedback on switch"), ["haptic", "vibration", "force touch", "trackpad"]),
         item(SearchID.sound, .general, SettingsAnchor.feedback, String(localized: "General"), String(localized: "Feedback"),
-             String(localized: "Sound on switch"), ["sound", "click", "audio"]),
+             String(localized: "Sound on switch"), ["sound", "click", "audio", "system sound", "custom sound", "audio file"]),
         // General · Updates
         item(SearchID.updateInterval, .general, SettingsAnchor.updates, String(localized: "General"), String(localized: "Updates"),
              String(localized: "Check for updates"), ["update", "upgrade", "interval", "cadence"]),

--- a/BetterCmdTab/System/CommitFeedback.swift
+++ b/BetterCmdTab/System/CommitFeedback.swift
@@ -1,13 +1,102 @@
 import AppKit
+import os
+import UniformTypeIdentifiers
 
 /// Optional sensory feedback played the moment the switcher commits a
 /// selection. Both channels are off by default and read live from Preferences,
 /// so toggling them takes effect on the next commit without a restart.
 @MainActor
 enum CommitFeedback {
-    /// Cached so we don't re-decode the sound file on every commit. The system
-    /// sound is loaded by name from the standard library locations.
-    private static let clickSound: NSSound? = NSSound(named: NSSound.Name("Tink"))
+    private static let fallbackSoundName = Preferences.defaultCommitSoundName
+    private static var cachedSoundName = ""
+    private static var cachedCustomFilename: String?
+    private static var cachedSound: NSSound?
+    private static var hasLoadedSound = false
+
+    private enum CustomSoundError: LocalizedError {
+        case unsupported
+
+        var errorDescription: String? {
+            String(localized: "The selected file isn't a supported sound.")
+        }
+    }
+
+    /// Read only when the General pane is built, never while opening or
+    /// committing the switcher.
+    static func systemSoundNames() -> [String] {
+        let directory = URL(fileURLWithPath: "/System/Library/Sounds", isDirectory: true)
+        var names = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ))?.compactMap { url -> String? in
+            guard UTType(filenameExtension: url.pathExtension)?.conforms(to: .audio) == true else { return nil }
+            return url.deletingPathExtension().lastPathComponent
+        } ?? []
+        if !names.contains(fallbackSoundName) { names.append(fallbackSoundName) }
+        return names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    static func selectSystemSound(named name: String) {
+        let prefs = Preferences.shared
+        let oldCustomFilename = prefs.customCommitSoundFilename
+        prefs.commitSoundName = name
+        prefs.customCommitSoundFilename = nil
+        invalidateSoundCache()
+        if let oldCustomFilename, let url = customSoundURL(for: oldCustomFilename) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    static func installCustomSound(from sourceURL: URL) throws {
+        let destination = try copyCustomSound(from: sourceURL, to: customSoundsDirectory)
+
+        let prefs = Preferences.shared
+        let oldCustomFilename = prefs.customCommitSoundFilename
+        prefs.customCommitSoundFilename = destination.lastPathComponent
+        invalidateSoundCache()
+        if let oldCustomFilename,
+           oldCustomFilename != destination.lastPathComponent,
+           let oldURL = customSoundURL(for: oldCustomFilename) {
+            try? FileManager.default.removeItem(at: oldURL)
+        }
+    }
+
+    static func copyCustomSound(from sourceURL: URL, to directory: URL) throws -> URL {
+        guard NSSound(contentsOf: sourceURL, byReference: true) != nil else {
+            throw CustomSoundError.unsupported
+        }
+
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let filename = sourceURL.lastPathComponent
+        guard !filename.isEmpty else { throw CustomSoundError.unsupported }
+        let destination = directory.appendingPathComponent(filename)
+        let ext = sourceURL.pathExtension
+        let temporaryBase = directory.appendingPathComponent(".CustomSwitchSound-\(UUID().uuidString)")
+        let temporary = ext.isEmpty ? temporaryBase : temporaryBase.appendingPathExtension(ext)
+
+        do {
+            try fileManager.copyItem(at: sourceURL, to: temporary)
+            guard NSSound(contentsOf: temporary, byReference: true) != nil else {
+                throw CustomSoundError.unsupported
+            }
+            if fileManager.fileExists(atPath: destination.path) {
+                _ = try fileManager.replaceItemAt(destination, withItemAt: temporary)
+            } else {
+                try fileManager.moveItem(at: temporary, to: destination)
+            }
+        } catch {
+            try? fileManager.removeItem(at: temporary)
+            throw error
+        }
+        return destination
+    }
+
+    static func prepare() {
+        let prefs = Preferences.shared
+        if prefs.soundOnCommit { _ = selectedSound(using: prefs) }
+    }
 
     static func play() {
         let prefs = Preferences.shared
@@ -21,11 +110,65 @@ enum CommitFeedback {
             )
         }
 
-        if prefs.soundOnCommit, let sound = clickSound {
-            // Restart from the top if a previous click is still ringing out so
-            // rapid commits each get a tick instead of being swallowed.
-            if sound.isPlaying { sound.stop() }
-            sound.play()
+        guard prefs.soundOnCommit, let sound = selectedSound(using: prefs) else { return }
+        restart(sound)
+    }
+
+    static func preview() {
+        guard let sound = selectedSound(using: Preferences.shared) else { return }
+        restart(sound)
+    }
+
+    static func stop() {
+        if cachedSound?.isPlaying == true { cachedSound?.stop() }
+    }
+
+    private static var customSoundsDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("BetterCmdTab", isDirectory: true)
+            .appendingPathComponent("Sounds", isDirectory: true)
+    }
+
+    private static func customSoundURL(for filename: String) -> URL? {
+        guard URL(fileURLWithPath: filename).lastPathComponent == filename else { return nil }
+        return customSoundsDirectory.appendingPathComponent(filename)
+    }
+
+    private static func selectedSound(using prefs: Preferences) -> NSSound? {
+        if hasLoadedSound,
+           cachedSoundName == prefs.commitSoundName,
+           cachedCustomFilename == prefs.customCommitSoundFilename {
+            return cachedSound
         }
+
+        hasLoadedSound = true
+        cachedSoundName = prefs.commitSoundName
+        cachedCustomFilename = prefs.customCommitSoundFilename
+
+        if let filename = prefs.customCommitSoundFilename {
+            if let url = customSoundURL(for: filename),
+               let sound = NSSound(contentsOf: url, byReference: true) {
+                cachedSound = sound
+                return sound
+            }
+            Log.ui.warning("Could not load custom switch sound; using the system fallback")
+        }
+
+        cachedSound = NSSound(named: NSSound.Name(prefs.commitSoundName))
+            ?? NSSound(named: NSSound.Name(fallbackSoundName))
+        return cachedSound
+    }
+
+    private static func invalidateSoundCache() {
+        cachedSound?.stop()
+        cachedSound = nil
+        hasLoadedSound = false
+    }
+
+    private static func restart(_ sound: NSSound) {
+        // Restart from the top if a previous sound is still ringing out so
+        // rapid commits each get feedback instead of being swallowed.
+        if sound.isPlaying { sound.stop() }
+        sound.play()
     }
 }

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -6,6 +6,30 @@ import Testing
 @Suite("Preferences enums")
 struct PreferencesEnumTests {
 
+    @MainActor
+    @Test("system commit sounds include the historical Tink default")
+    func systemCommitSounds() {
+        let names = CommitFeedback.systemSoundNames()
+        #expect(names.contains(Preferences.defaultCommitSoundName))
+        #expect(names.count > 1)
+        #expect(names == names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+    }
+
+    @MainActor
+    @Test("custom commit sound is copied and can be replaced")
+    func customCommitSoundCopy() throws {
+        let sounds = URL(fileURLWithPath: "/System/Library/Sounds", isDirectory: true)
+        let candidates = try FileManager.default.contentsOfDirectory(at: sounds, includingPropertiesForKeys: nil)
+        let source = try #require(candidates.first { NSSound(contentsOf: $0, byReference: true) != nil })
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let installed = try CommitFeedback.copyCustomSound(from: source, to: directory)
+        #expect(try Data(contentsOf: installed) == Data(contentsOf: source))
+        #expect(try CommitFeedback.copyCustomSound(from: source, to: directory) == installed)
+        #expect(try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil).count == 1)
+    }
+
     @Test("storedSpaceScope prefers the enum key, falls back to the legacy bool")
     func storedSpaceScopeMigration() throws {
         let defaults = try #require(UserDefaults(suiteName: "storedSpaceScopeMigrationTests"))

--- a/BetterCmdTabTests/SettingsPortabilityTests.swift
+++ b/BetterCmdTabTests/SettingsPortabilityTests.swift
@@ -40,12 +40,14 @@ struct SettingsPortabilityTests {
         let savedMin = prefs.showMinimizedWindows
         let savedOpacity = prefs.panelOpacity
         let savedPinned = prefs.pinnedBundleIDs
+        let savedSoundName = prefs.commitSoundName
         defer {
             try? prefs.importSettings(from: envelope([
                 Preferences.Keys.sortOrder: savedSort.rawValue,
                 Preferences.Keys.showMinimizedWindows: savedMin,
                 Preferences.Keys.panelOpacity: savedOpacity,
                 Preferences.Keys.pinnedBundleIDs: savedPinned,
+                Preferences.Keys.commitSoundName: savedSoundName,
             ]))
         }
 
@@ -56,11 +58,13 @@ struct SettingsPortabilityTests {
             Preferences.Keys.showMinimizedWindows: false,
             Preferences.Keys.panelOpacity: 55,
             Preferences.Keys.pinnedBundleIDs: ["com.apple.finder", "com.apple.Safari"],
+            Preferences.Keys.commitSoundName: savedSoundName == "Ping" ? "Pop" : "Ping",
         ]))
         #expect(prefs.sortOrder == target)
         #expect(prefs.showMinimizedWindows == false)
         #expect(prefs.panelOpacity == 55)
         #expect(prefs.pinnedBundleIDs == ["com.apple.finder", "com.apple.Safari"])
+        #expect(prefs.commitSoundName == (savedSoundName == "Ping" ? "Pop" : "Ping"))
     }
 
     @Test("pre-#57 import (legacy currentSpaceOnly bool, no spaceScope) applies through the fallback")
@@ -244,11 +248,15 @@ struct SettingsPortabilityTests {
         let prefs = Preferences.shared
         let defaults = UserDefaults.standard
         let key = "Switcher.disabledSymbolicHotKeys"
+        let customSoundKey = Preferences.Keys.customCommitSoundFilename
         let saved = defaults.object(forKey: key)
+        let savedCustomSound = prefs.customCommitSoundFilename
         defer {
             if let saved { defaults.set(saved, forKey: key) } else { defaults.removeObject(forKey: key) }
+            prefs.customCommitSoundFilename = savedCustomSound
         }
         defaults.set([55], forKey: key)
+        prefs.customCommitSoundFilename = "local.aiff"
 
         // Export must not carry this machine's crash-heal record.
         let data = try prefs.exportedJSONData()
@@ -256,10 +264,12 @@ struct SettingsPortabilityTests {
         let values = try #require(root["values"] as? [String: Any])
         #expect(values[key] == nil)
         #expect(values["Switcher.recentlyClosed"] == nil)
+        #expect(values[customSoundKey] == nil)
 
         // Import must not overwrite this machine's record with the file's.
-        try prefs.importSettings(from: envelope([key: [1, 2]]))
+        try prefs.importSettings(from: envelope([key: [1, 2], customSoundKey: "another-mac.aiff"]))
         #expect(defaults.array(forKey: key) as? [Int] == [55])
+        #expect(defaults.string(forKey: customSoundKey) == "local.aiff")
     }
 
     @Test("keys outside the Switcher namespace are ignored on import")


### PR DESCRIPTION
## Summary

- replace the binary switch sound toggle with a picker for Off and every bundled macOS system sound
- let users import, preview, persist, and safely replace a custom audio file
- keep custom files machine-local while preserving a portable system fallback
- cap long custom filenames in Settings and prepare the selected sound before the hotkey path starts

## Why

The previous setting always played Tink. Users requested both the built-in macOS sound library and their own audio files.

The layout hardening fixes an unbounded popup intrinsic width caused by long custom filenames. The file path validates before and after copying, uses a temporary file for replacement, and falls back to the selected system sound if the local file disappears.

Closes #113.

## Validation

- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test -only-testing:BetterCmdTabTests/PreferencesEnumTests`
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test` — 477 tests in 56 suites passed
- `xcodebuild -scheme "BetterCmdTab" -configuration Release build`
- `git diff --check`
- verified a 240-character filename is constrained from 1693 pt to 180 pt
