### PR TITLE
fix: keep switcher visible over full-screen Spaces (#46)

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -559,16 +559,7 @@ final class SwitcherController: SwitcherViewDelegate {
         }
         workspaceObservers.append(activationObserver)
         // The active Space flipping (full-screen enter/exit is its own Space)
-        // affects trigger suppression, and is also the moment the WindowServer
-        // can drop the panel's canJoinAllSpaces sticky tag (a full-screen app
-        // quitting destroys its Space — #46/#64; switching displays/Spaces
-        // while the panel is hidden can rot it too — #93/#94).
-        // `isOnActiveSpace` can keep reporting true for a canJoinAllSpaces
-        // window even after the WindowServer has lost the tag, so it can't
-        // gate this. Hidden panels re-assert unconditionally; a deliberately
-        // visible/sticky panel verifies composition after the Space transition
-        // settles and heals only if needed. present() performs the same check
-        // after order-front as the reveal backstop.
+        // affects trigger suppression, so refresh it on every Space change.
         let activeSpaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.activeSpaceDidChangeNotification,
             object: nil,
@@ -577,7 +568,6 @@ final class SwitcherController: SwitcherViewDelegate {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.updateTriggerSuppression()
-                self.panel.activeSpaceDidChange()
             }
         }
         workspaceObservers.append(activeSpaceObserver)

--- a/BetterCmdTab/Switcher/SwitcherPanel.swift
+++ b/BetterCmdTab/Switcher/SwitcherPanel.swift
@@ -5,57 +5,25 @@ import os
 
 @MainActor
 final class SwitcherPanel: NSPanel {
-    enum SpaceVisibilityDecision: Equatable {
-        case none
-        /// Healthy on the first sample — confirm once after a short delay, in
-        /// case both AppKit indicators still carry the previous presentation's
-        /// healthy values (fast dismiss→reopen).
-        case verify
-        /// Unhealthy on the first sample — occlusion may simply be stale this
-        /// soon after order-front; re-sample before healing.
-        case retry
-        case heal
-    }
-
-    struct SpaceCheckGeneration {
-        private(set) var value: UInt = 0
-
-        @discardableResult
-        mutating func advance() -> UInt {
-            value &+= 1
-            return value
-        }
-
-        func matches(_ token: UInt) -> Bool { value == token }
-    }
-
-    /// The complete, known-good Space behavior for this transient system
-    /// overlay. `.canJoinAllApplications` (macOS 13+) explicitly lets overlays
-    /// join other apps' full-screen and Stage Manager sets, while
-    /// `.canJoinAllSpaces` keeps it available across per-display Desktops (#93).
+    /// Space behavior for this transient overlay. `.canJoinAllSpaces` alone
+    /// keeps it on every Desktop and over other apps' full-screen Spaces — the
+    /// app is an LSUIElement accessory, so no full-screen-auxiliary binding is
+    /// needed. `.fullScreenAuxiliary` was removed for #46: it bound the panel as
+    /// an auxiliary of a full-screen window's Space, so quitting that full-screen
+    /// app destroyed the panel's all-Spaces membership and it went invisible on
+    /// the other Spaces. `.stationary`/`.ignoresCycle` are cycling / Exposé-group
+    /// flags, orthogonal to Space membership.
     static let canonicalCollectionBehavior: NSWindow.CollectionBehavior = [
         .canJoinAllSpaces,
         .stationary,
-        .ignoresCycle,
-        .fullScreenAuxiliary,
-        .canJoinAllApplications
+        .ignoresCycle
     ]
 
-    private static let spaceVisibilityRetryDelay: TimeInterval = 0.05
-    private static let spaceTransitionSettleDelay: TimeInterval = 0.20
-    private static let spaceRecoveryVerificationDelay: TimeInterval = 0.10
-    private static let maxSpaceRecoveryAttempts = 2
-
     private var prefCancellable: AnyCancellable?
-    /// Invalidates delayed WindowServer visibility checks across dismiss/reopen
-    /// and across consecutive Space changes. Without this token, a retry queued
-    /// by presentation A can reorder a rapidly-opened presentation B (#64).
-    private var spaceCheckGeneration = SpaceCheckGeneration()
-    /// True between `present()` and `dismiss()`. The reveal edge can't key off
-    /// `isVisible` alone: the boot prewarm orders the panel in off-screen via
-    /// `orderFrontRegardless()` without presenting, and a chord landing in that
-    /// window would then read `isVisible == true` and skip the first real
-    /// presentation's Space verification.
+    /// True between `present()` and `dismiss()`. `resignKey()` keys off this
+    /// (not `isVisible`) for its glass-dim suppression: the boot prewarm orders
+    /// the panel in off-screen via `orderFrontRegardless()` without presenting,
+    /// so `isVisible` would read true before the first real presentation.
     private var isPresented = false
 
     /// The screen the owning controller resolved for this open session. Set
@@ -182,13 +150,7 @@ final class SwitcherPanel: NSPanel {
     /// `opacity` is the resolved per-shortcut panel opacity (#74), 30–100.
     func present(opacity: Int = 100) {
         guard let content = contentView else { return }
-        // `present()` also relays out an already-visible panel during live
-        // filtering. Only a real hidden→visible edge starts a new verification
-        // generation; relayouts remain part of the current presentation.
-        let startsNewPresentation = Self.shouldStartSpaceVerification(isAlreadyVisible: isPresented)
         isPresented = true
-        if startsNewPresentation { spaceCheckGeneration.advance() }
-        let spaceCheckToken = spaceCheckGeneration.value
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         let fitting = Log.reveal.withIntervalSignpost("present.layout") { () -> NSSize in
@@ -248,15 +210,6 @@ final class SwitcherPanel: NSPanel {
         DispatchQueue.main.async { [weak self] in
             guard let self, self.isVisible, self.isPresented else { return }
             if !self.isKeyWindow { self.makeKeyAndOrderFront(nil) }
-            // Live filtering and title/badge refreshes call present() again only
-            // to relayout. They must not fork parallel recovery chains; the one
-            // started at the hidden→visible edge owns this presentation.
-            // Sample immediately so a rotted panel heals at ~50ms; a healthy
-            // first verdict is re-confirmed once (`.verify`) because both AppKit
-            // indicators can briefly retain the previous presentation's values.
-            if startsNewPresentation {
-                self.healSpaceAssignmentIfNeeded(token: spaceCheckToken)
-            }
         }
     }
 
@@ -271,9 +224,6 @@ final class SwitcherPanel: NSPanel {
     /// it. No fade plays because `animationBehavior` is `.none` and implicit
     /// actions are disabled here.
     func dismiss() {
-        // Cancel every queued visibility retry before the panel can be opened as
-        // a new presentation. The closures remain cheap no-ops when they fire.
-        spaceCheckGeneration.advance()
         isPresented = false
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -297,7 +247,6 @@ final class SwitcherPanel: NSPanel {
     /// is unchanged; `ignoresMouseEvents` keeps the invisible panel from
     /// swallowing clicks until `dismiss()` lands. `present()` restores both.
     func vanish() {
-        spaceCheckGeneration.advance()
         isPresented = false
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -306,128 +255,6 @@ final class SwitcherPanel: NSPanel {
         CATransaction.commit()
         ignoresMouseEvents = true
         onFrameDidChange?(nil)
-    }
-
-    /// A visible `present()` call is only a relayout. Space verification belongs
-    /// to the hidden→visible reveal edge and must have one owner per session.
-    static func shouldStartSpaceVerification(isAlreadyVisible: Bool) -> Bool {
-        !isAlreadyVisible
-    }
-
-    /// The WindowServer can lose the `.canJoinAllSpaces` sticky tag when the
-    /// Space topology changes while the panel is ordered out — e.g. quitting a
-    /// full-screen app destroys its Space (#46, #64), or the active Space flips
-    /// onto another display's or a live full-screen app's Space (#93/#94). The
-    /// next order-front then puts the panel only on its original Space:
-    /// switching still works, but the panel is invisible everywhere else.
-    /// `isOnActiveSpace` alone can't detect this — for a canJoinAllSpaces window
-    /// it can keep reporting true after the WindowServer has dropped the tag
-    /// (#93/#94), so also require the panel to actually composite
-    /// (`occlusionState.visible`; at `.popUpMenu`
-    /// level nothing covers it, so on the active Space it is always visible).
-    /// Occlusion state is delivered asynchronously from the WindowServer and
-    /// may still be stale one runloop turn after order-front — in either
-    /// direction: an unhealthy first verdict is confirmed before healing
-    /// (`.retry`), and a healthy first verdict is re-checked once (`.verify`)
-    /// because fast dismiss→reopen can leave both indicators reporting the
-    /// previous presentation's healthy state. Runs after `present()`; the
-    /// healthy path costs two property reads plus one settled confirm.
-    static func spaceVisibilityDecision(
-        isVisible: Bool,
-        isOnActiveSpace: Bool,
-        isOcclusionVisible: Bool,
-        isRetry: Bool
-    ) -> SpaceVisibilityDecision {
-        guard isVisible else { return .none }
-        guard isOnActiveSpace, isOcclusionVisible else {
-            return isRetry ? .heal : .retry
-        }
-        return isRetry ? .none : .verify
-    }
-
-    private func healSpaceAssignmentIfNeeded(
-        token: UInt,
-        isRetry: Bool = false,
-        recoveryAttempt: Int = 0
-    ) {
-        guard spaceCheckGeneration.matches(token) else { return }
-        let onActiveSpace = isOnActiveSpace
-        let decision = Self.spaceVisibilityDecision(
-            isVisible: isVisible,
-            isOnActiveSpace: onActiveSpace,
-            isOcclusionVisible: occlusionState.contains(.visible),
-            isRetry: isRetry
-        )
-        switch decision {
-        case .none:
-            return
-        case .verify, .retry:
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.spaceVisibilityRetryDelay) { [weak self] in
-                self?.healSpaceAssignmentIfNeeded(
-                    token: token,
-                    isRetry: true,
-                    recoveryAttempt: recoveryAttempt
-                )
-            }
-            return
-        case .heal:
-            break
-        }
-
-        guard recoveryAttempt < Self.maxSpaceRecoveryAttempts else {
-            Log.ui.fault("panel still not compositing after bounded Space recovery (#46/#64/#93/#94)")
-            return
-        }
-        Log.ui.error("panel \(onActiveSpace ? "not compositing on active Space" : "not on active Space") after reveal/Space change — re-asserting canJoinAllSpaces (#46/#64/#93/#94)")
-        reassertAllSpacesTag()
-        orderOut(nil)
-        makeKeyAndOrderFront(nil)
-        // Unlike `orderFront`, this is honored even if a Space transition made
-        // another app active between the visibility verdict and the recovery.
-        orderFrontRegardless()
-
-        // WindowServer state is asynchronous. Verify the repair and allow one
-        // additional bounded recovery instead of assuming the first re-order
-        // succeeded under load.
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.spaceRecoveryVerificationDelay) { [weak self] in
-            self?.healSpaceAssignmentIfNeeded(
-                token: token,
-                // A recovery starts a fresh pair of samples. One stale-negative
-                // verdict must not immediately trigger another visible re-order.
-                isRetry: false,
-                recoveryAttempt: recoveryAttempt + 1
-            )
-        }
-    }
-
-    /// A Space can change while the switcher is deliberately kept open (sticky
-    /// mode, swipe trigger). Hidden panels can safely refresh their WindowServer
-    /// tag immediately; visible panels wait for the transition's occlusion state
-    /// to settle and then use the same bounded verifier as a fresh reveal.
-    func activeSpaceDidChange() {
-        let token = spaceCheckGeneration.advance()
-        guard isVisible else {
-            reassertAllSpacesTag()
-            return
-        }
-        // NSWorkspace posts at the active-Space edge, while the WindowServer's
-        // visual transition and occlusion bookkeeping may continue briefly.
-        // Debounce that transition before taking the first sample; a second
-        // unhealthy sample is still required by `spaceVisibilityDecision`.
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.spaceTransitionSettleDelay) { [weak self] in
-            self?.healSpaceAssignmentIfNeeded(token: token)
-        }
-    }
-
-    /// Force the WindowServer to re-apply the collection behavior. Re-assigning
-    /// an identical mask may be short-circuited, so clear it first; the empty
-    /// intermediate state is never user-visible (the panel is hidden or on the
-    /// wrong Space whenever this runs).
-    func reassertAllSpacesTag() {
-        collectionBehavior = []
-        // Restore the canonical mask, not the value we just read: AppKit may
-        // lose the property bit as well as WindowServer's internal sticky tag.
-        collectionBehavior = Self.canonicalCollectionBehavior
     }
 
     /// Convert a Cocoa global rect (bottom-left origin, y-up) to the CGEvent

--- a/BetterCmdTabTests/SwitcherPanelSpaceTests.swift
+++ b/BetterCmdTabTests/SwitcherPanelSpaceTests.swift
@@ -2,89 +2,27 @@ import AppKit
 import Testing
 @testable import BetterCmdTab
 
-/// Regression coverage for the WindowServer Space-tag recovery behind
-/// #46/#64/#93/#94. The real compositor transition still needs a macOS UI smoke
-/// test, but these tests pin the deterministic policy and lifecycle guards.
+/// Regression coverage for #46: the panel must stay visible on every Space,
+/// including other apps' full-screen Spaces, after the Space count changes.
+/// `.fullScreenAuxiliary` bound the panel to a full-screen window's Space, so
+/// quitting that app rotted its all-Spaces membership — matching AltTab's
+/// proven-minimal `.canJoinAllSpaces` config is the fix. The real compositor
+/// transition still needs a macOS UI smoke test; this pins the policy.
 @MainActor
-@Suite("Switcher panel Space recovery")
+@Suite("Switcher panel Space behavior")
 struct SwitcherPanelSpaceTests {
-    @Test("canonical behavior supports Desktops, full-screen Spaces, and other app sets")
-    func canonicalBehavior() {
-        let behavior = SwitcherPanel.canonicalCollectionBehavior
+    @Test("collection behavior joins all Spaces without full-screen-auxiliary binding")
+    func collectionBehaviorAvoidsFullScreenBinding() {
+        let panel = SwitcherPanel()
+        let behavior = panel.collectionBehavior
+        #expect(behavior == SwitcherPanel.canonicalCollectionBehavior)
         #expect(behavior.contains(.canJoinAllSpaces))
         #expect(behavior.contains(.stationary))
         #expect(behavior.contains(.ignoresCycle))
-        #expect(behavior.contains(.fullScreenAuxiliary))
-        #expect(behavior.contains(.canJoinAllApplications))
+        // The #46 guard: these bind the panel to a full-screen window's Space,
+        // which rots when that Space is destroyed. They must never come back.
+        #expect(!behavior.contains(.fullScreenAuxiliary))
+        #expect(!behavior.contains(.canJoinAllApplications))
         #expect(!behavior.contains(.moveToActiveSpace))
-        #expect(!behavior.contains(.primary))
-        #expect(!behavior.contains(.auxiliary))
-    }
-
-    @Test("new panels install the canonical cross-display behavior")
-    func initializerInstallsCanonicalBehavior() {
-        let panel = SwitcherPanel()
-        #expect(panel.collectionBehavior == SwitcherPanel.canonicalCollectionBehavior)
-        #expect(panel.collectionBehavior.contains(.canJoinAllApplications))
-    }
-
-    @Test("reassert replaces a damaged mask and is idempotent")
-    func reassertRestoresCanonicalBehavior() {
-        let panel = SwitcherPanel()
-        panel.collectionBehavior = [.moveToActiveSpace]
-
-        panel.reassertAllSpacesTag()
-        #expect(panel.collectionBehavior == SwitcherPanel.canonicalCollectionBehavior)
-
-        panel.reassertAllSpacesTag()
-        #expect(panel.collectionBehavior == SwitcherPanel.canonicalCollectionBehavior)
-    }
-
-    @Test("hidden Space changes restore the tag immediately")
-    func hiddenSpaceChangeReassertsTag() {
-        let panel = SwitcherPanel()
-        #expect(!panel.isVisible)
-        panel.collectionBehavior = []
-
-        panel.activeSpaceDidChange()
-
-        #expect(panel.collectionBehavior == SwitcherPanel.canonicalCollectionBehavior)
-    }
-
-    @Test("visibility decision needs a settled unhealthy sample before healing")
-    func visibilityDecisionMatrix() {
-        typealias Decision = SwitcherPanel.SpaceVisibilityDecision
-        let decide = SwitcherPanel.spaceVisibilityDecision
-
-        #expect(decide(false, false, false, false) == Decision.none)
-        // A healthy first sample can still be the previous presentation's
-        // stale state — confirm once instead of trusting it outright.
-        #expect(decide(true, true, true, false) == Decision.verify)
-        #expect(decide(true, false, false, false) == Decision.retry)
-        #expect(decide(true, false, false, true) == Decision.heal)
-        #expect(decide(true, true, false, false) == Decision.retry)
-        #expect(decide(true, true, false, true) == Decision.heal)
-        #expect(decide(true, true, true, true) == Decision.none)
-    }
-
-    @Test("visible relayouts do not fork another recovery chain")
-    func verificationStartsOnlyOnRevealEdge() {
-        #expect(SwitcherPanel.shouldStartSpaceVerification(isAlreadyVisible: false))
-        #expect(!SwitcherPanel.shouldStartSpaceVerification(isAlreadyVisible: true))
-    }
-
-    @Test("new generations invalidate delayed checks from an older presentation")
-    func generationInvalidation() {
-        var generation = SwitcherPanel.SpaceCheckGeneration()
-        let presentationA = generation.advance()
-        #expect(generation.matches(presentationA))
-
-        // Models dismiss(A), then present(B): neither transition may leave A's
-        // queued 50 ms callback authorized to touch B.
-        generation.advance()
-        let presentationB = generation.advance()
-
-        #expect(!generation.matches(presentationA))
-        #expect(generation.matches(presentationB))
     }
 }


### PR DESCRIPTION
## Fixes #46 (also #64, #94) — switcher invisible on other Spaces after closing a full-screen app

### Root cause
The panel's `collectionBehavior` carried `.fullScreenAuxiliary` (present since day one — #46 was filed against it) and later `.canJoinAllApplications`. `.fullScreenAuxiliary` binds the window as an *auxiliary of a full-screen window's Space*. When that full-screen app quits and its Space is destroyed (the exact repro), the panel's all-Spaces membership rots: the switcher keeps working but draws nothing on other Spaces.

The 26.7-beta "heal" state machine that tried to detect this (`occlusionState` + `isOnActiveSpace`) and re-order around it **never worked** — the reporter confirmed no change — and its mid-transition `collectionBehavior = []` reset could itself trigger the invisibility.

### Fix
Match AltTab's proven-minimal config (it composites reliably over other apps' full-screen Spaces with zero heal code):

```swift
collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
```

and **delete the entire detect-and-heal apparatus** (`SpaceVisibilityDecision`, `SpaceCheckGeneration`, `healSpaceAssignmentIfNeeded`, `activeSpaceDidChange`, `reassertAllSpacesTag`, the space-check timers/tokens). `.canJoinAllSpaces` alone composites over full-screen for an LSUIElement accessory app; dropping the auxiliary binding removes the rot at its source.

Net **+30 / −275**.

### Kept untouched
- `ScreenSelection` NSMouseInRect fix — the *real* #93 fix (a geometry bug, separate from collection behavior).
- `isPresented` — load-bearing for `resignKey()`'s glass-dim suppression, unrelated to Spaces.
- All `PrivateAPIs` CGS glue.

### Verification
- App compiles; **476/476 tests pass**.
- Replaced the 7 heal-machinery tests with one #46 regression guard (behavior contains `.canJoinAllSpaces`, excludes `.fullScreenAuxiliary` / `.canJoinAllApplications` / `.moveToActiveSpace`).
- **Confirmed working on-device**: full-screen an app → ⌘Q → land on Desktop → switch to an app on another Space → ⌘Tab → panel is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
