### PR TITLE
fix: show browser tabs in windows switcher

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -3088,13 +3088,18 @@ final class SwitcherController: SwitcherViewDelegate {
 
     private func presentWindowsOnly(_ filtered: [SwitcherRow], pid: pid_t) {
         let sorted = windowMRU.sortRows(filtered, forPid: pid)
-        baseRows = sorted
+        let count = sorted.count
+        let delta = windowsOnlyPrimedDelta
+        let collapsedIndex = count > 0 ? ((delta % count) + count) % count : 0
+        let selectedRow = sorted.indices.contains(collapsedIndex) ? sorted[collapsedIndex] : nil
+
+        baseRows = applyBrowserTabMRU(expandBrowserTabs(sorted))
         baseLabels = RowLabels.labels(for: baseRows)
         rows = baseRows
         labels = baseLabels
-        let count = rows.count
-        let delta = windowsOnlyPrimedDelta
-        index = count > 0 ? ((delta % count) + count) % count : 0
+        index = selectedRow.flatMap {
+            Self.windowSelectionIndex(in: rows, selected: $0)
+        } ?? (rows.isEmpty ? 0 : max(0, min(collapsedIndex, rows.count - 1)))
 
         let sessionScreen = resolveSessionScreen()
         panel.targetScreen = sessionScreen
@@ -3108,6 +3113,7 @@ final class SwitcherController: SwitcherViewDelegate {
         prewarmActiveBrowserTabPreview()
         cache.setPanelVisible(true)
         dockBadgeObserver.start(enabled: effective.showUnreadBadges)
+        scheduleBrowserTabExpansion()
     }
 
     private func scheduleWindowsOnlyRefresh(pid: pid_t, gen: UInt64) {
@@ -3123,9 +3129,10 @@ final class SwitcherController: SwitcherViewDelegate {
         guard phase == .visible, windowsOnlyMode else { return }
         if fresh.isEmpty { cancel(); return }
         let sorted = windowsOnlyPid.map { windowMRU.sortRows(fresh, forPid: $0) } ?? fresh
-        baseRows = sorted
+        baseRows = applyBrowserTabMRU(expandBrowserTabs(sorted))
         baseLabels = RowLabels.labels(for: baseRows)
         refreshDisplay()
+        scheduleBrowserTabExpansion()
     }
 
     /// Apply the flat cross-app window-recency sort when `.mruWindows` is the
@@ -3190,7 +3197,7 @@ final class SwitcherController: SwitcherViewDelegate {
             // panel; if so the rows aren't expanded, so the order must not be
             // consumed (would sort plain window rows by the tab timeline).
             && effective.expandBrowserTabsAsWindows
-            && !effective.applicationsOnly
+            && !applicationsCollapseActive
             && effective.sortOrder == .mruWindows
     }
 
@@ -3248,7 +3255,7 @@ final class SwitcherController: SwitcherViewDelegate {
     private func sinkInactiveBrowserTabs(_ rows: [SwitcherRow]) -> [SwitcherRow] {
         guard effective.sortOrder == .mruWindows,
               effective.expandBrowserTabsAsWindows,
-              !effective.applicationsOnly else { return rows }
+              !applicationsCollapseActive else { return rows }
         return Self.sinkInactiveBrowserTabs(
             rows,
             activeIndexFor: { [browserTabsCache] in browserTabsCache[$0]?.activeIndex },
@@ -3496,7 +3503,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // Applications-only mode collapses to one row per app; re-expanding a
         // browser into per-tab rows would defeat it, so leave the rows untouched.
         guard effective.expandBrowserTabsAsWindows,
-              !effective.applicationsOnly else { return source }
+              !applicationsCollapseActive else { return source }
         return expandBrowserTabsCore(source)
     }
 
@@ -3527,7 +3534,7 @@ final class SwitcherController: SwitcherViewDelegate {
     private var searchUsesExpandedTabs: Bool {
         Preferences.shared.searchExpandsBrowserTabs
             && !effective.expandBrowserTabsAsWindows
-            && !effective.applicationsOnly
+            && !applicationsCollapseActive
     }
 
     /// Rebuild the transient tab-expanded search set (rows + folded strings) from
@@ -3617,10 +3624,11 @@ final class SwitcherController: SwitcherViewDelegate {
         }
         // The cache persists across opens, so prune entries for browser windows
         // that are no longer present (closed since last seen) — keeps it bounded
-        // to the currently-open browser windows over a long session. Unscoped
-        // sessions only: a scoped open sees a scope-filtered row subset, and
-        // pruning against it would evict every out-of-scope browser window.
-        if activeScope == nil, browserTabsCache.contains(where: { !liveKeys.contains($0.key) }) {
+        // to the currently-open browser windows over a long session. Only a full
+        // Apps list is authoritative: scoped and windows-only sessions see a row
+        // subset, so pruning against either would evict unrelated browser windows.
+        if activeScope == nil, !windowsOnlyMode,
+           browserTabsCache.contains(where: { !liveKeys.contains($0.key) }) {
             browserTabsCache = browserTabsCache.filter { liveKeys.contains($0.key) }
         }
         guard !byApp.isEmpty else { return }
@@ -3777,7 +3785,7 @@ final class SwitcherController: SwitcherViewDelegate {
         // Mirror expandBrowserTabs' applications-only guard: with it on, the
         // expansion no-ops, so spawning the osascript scan is pure waste.
         guard effective.expandBrowserTabsAsWindows,
-              !effective.applicationsOnly, phase == .visible else { return }
+              !applicationsCollapseActive, phase == .visible else { return }
         scanBrowserTabs(rows: collapsedBrowserSource(), force: force) { [weak self] in
             self?.reExpandBrowserTabs()
         }
@@ -3792,8 +3800,12 @@ final class SwitcherController: SwitcherViewDelegate {
     /// up the now-warm cache itself).
     private func prewarmBrowserTabs() {
         guard effective.expandBrowserTabsAsWindows,
-              !effective.applicationsOnly else { return }
-        scanBrowserTabs(rows: cache.rows(orderedBy: mru.order, filter: activeFilterConfig), force: false) { [weak self] in
+              !applicationsCollapseActive else { return }
+        var source = cache.rows(orderedBy: mru.order, filter: activeFilterConfig)
+        if windowsOnlyMode, let pid = windowsOnlyPid {
+            source.removeAll { $0.pid != pid }
+        }
+        scanBrowserTabs(rows: source, force: false) { [weak self] in
             self?.reExpandBrowserTabs()
         }
     }
@@ -5074,6 +5086,45 @@ final class SwitcherController: SwitcherViewDelegate {
         return result
     }
 
+    nonisolated static func windowSelectionIndex(
+        in rows: [SwitcherRow],
+        selected: SwitcherRow
+    ) -> Int? {
+        guard let selectedWindow = selected.window else { return nil }
+        let window = AXRef(element: selectedWindow)
+        let selectedTab = selected.browserTab
+        var urlMatch: Int?
+        var urlMatchCount = 0
+        var titleMatch: Int?
+        var titleMatchCount = 0
+        var indexMatch: Int?
+        var activeTab: Int?
+        var firstWindowRow: Int?
+
+        for index in rows.indices {
+            guard let candidate = rows[index].window,
+                  AXRef(element: candidate) == window else { continue }
+            if firstWindowRow == nil { firstWindowRow = index }
+            if activeTab == nil, rows[index].browserTab?.isActive == true {
+                activeTab = index
+            }
+            guard let selectedTab, let candidateTab = rows[index].browserTab else { continue }
+            if candidateTab.index == selectedTab.index { indexMatch = index }
+            if !selectedTab.url.isEmpty, candidateTab.url == selectedTab.url {
+                urlMatch = index
+                urlMatchCount += 1
+            }
+            if !selected.windowTitle.isEmpty, rows[index].windowTitle == selected.windowTitle {
+                titleMatch = index
+                titleMatchCount += 1
+            }
+        }
+
+        if urlMatchCount == 1 { return urlMatch }
+        if titleMatchCount == 1 { return titleMatch }
+        return indexMatch ?? activeTab ?? firstWindowRow
+    }
+
     private func selectionKey() -> (pid_t, String, Bool)? {
         guard rows.indices.contains(index), let pid = rows[index].pid else { return nil }
         return (pid, rows[index].windowTitle, rows[index].window != nil)
@@ -5168,6 +5219,7 @@ final class SwitcherController: SwitcherViewDelegate {
     /// the panel. Replaces the old `applyPrefixReorder`.
     private func refreshDisplay(resetSelectionToTop: Bool = false, anchorPid: pid_t? = nil) {
         guard phase == .visible else { return }
+        let selectedRow: SwitcherRow? = resetSelectionToTop || !rows.indices.contains(index) ? nil : rows[index]
         let key = resetSelectionToTop ? nil : selectionKey()
 
         if searchActive, !searchQuery.isEmpty {
@@ -5299,6 +5351,9 @@ final class SwitcherController: SwitcherViewDelegate {
 
         if resetSelectionToTop {
             index = 0
+        } else if let selectedRow,
+                  let restored = Self.windowSelectionIndex(in: rows, selected: selectedRow) {
+            index = restored
         } else if let key, let restored = rows.firstIndex(where: { keyMatches($0, key) }) {
             index = restored
         } else if let anchorPid, let match = rows.firstIndex(where: { $0.pid == anchorPid }) {
@@ -5338,7 +5393,7 @@ final class SwitcherController: SwitcherViewDelegate {
     private var browserTabsExpandedForMetrics: Bool {
         SwitcherMetrics.reserveTabBand(
             expandAsWindows: effective.expandBrowserTabsAsWindows,
-            applicationsOnly: effective.applicationsOnly,
+            applicationsOnly: applicationsCollapseActive,
             searchActive: searchActive,
             searchExpandsTabs: Preferences.shared.searchExpandsBrowserTabs)
     }

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -3017,7 +3017,10 @@ final class SwitcherController: SwitcherViewDelegate {
         // tabs now so the rows expand as soon as Apple Events answers. Self-
         // guards on the pref; a no-op on the cold (placeholder) branch since
         // those rows carry no windows yet — the post-scan apply kicks it again.
-        scheduleBrowserTabExpansion()
+        // Forced: a reveal must reflect tabs opened/closed in the last few
+        // seconds, so it bypasses the per-window TTL (the 0.4 s forced-scan
+        // rate limit still bounds osascript spawns on rapid re-opens).
+        scheduleBrowserTabExpansion(force: true)
 
         if !cache.hasCompletedFullScan {
             // Reuse the startup scan already in flight. Warm reveals are served
@@ -3113,7 +3116,9 @@ final class SwitcherController: SwitcherViewDelegate {
         prewarmActiveBrowserTabPreview()
         cache.setPanelVisible(true)
         dockBadgeObserver.start(enabled: effective.showUnreadBadges)
-        scheduleBrowserTabExpansion()
+        // Forced for the same reason as the apps-mode reveal: fresh tab state
+        // on open, TTL bypassed, bounded by the forced-scan rate limit.
+        scheduleBrowserTabExpansion(force: true)
     }
 
     private func scheduleWindowsOnlyRefresh(pid: pid_t, gen: UInt64) {
@@ -3659,6 +3664,7 @@ final class SwitcherController: SwitcherViewDelegate {
                         .init(bundleID: bundleID, url: $0.url)
                     })
                 }
+                let scriptBounds = perWindow.map(\.bounds)
                 var activeCounts: [String: Int] = [:]
                 var byActive: [String: (tabs: [BrowserTabInfo], active: Int)] = [:]
                 var titleCounts: [String: Int] = [:]
@@ -3678,6 +3684,14 @@ final class SwitcherController: SwitcherViewDelegate {
                         fetched[t.key] = hit
                     } else if titleCounts[k] == 1, let hit = byTitle[k] {
                         fetched[t.key] = hit
+                    } else if let frame = Self.scanAXFrame(of: t.window),
+                              let bi = Self.uniqueBoundsMatch(frame: frame, in: scriptBounds) {
+                        // Titles are duplicated (two windows on the same page /
+                        // Start Page) or stale (the catalog only tracks titles
+                        // while the panel is visible) — fall back to the window's
+                        // geometry, which needs no freshness and is near-unique.
+                        let w = perWindow[bi]
+                        fetched[t.key] = (w.tabs, w.activeIndex)
                     } else if perWindow.count == 1 && entry.wins.count == 1 {
                         let only = perWindow[0]
                         fetched[t.key] = (only.tabs, only.activeIndex)
@@ -5084,6 +5098,35 @@ final class SwitcherController: SwitcherViewDelegate {
         closedTombstones = closedTombstones.enumerated()
             .compactMap { matchedSigIndices.contains($0.offset) ? $0.element : nil }
         return result
+    }
+
+    /// `Activator.axBounds` with a short messaging timeout so a busy browser
+    /// can't stall the off-main scan worker. Same space as AppleScript `bounds`.
+    nonisolated private static func scanAXFrame(of window: AXUIElement) -> CGRect? {
+        AXUIElementSetMessagingTimeout(window, 0.1)
+        return Activator.axBounds(of: window)
+    }
+
+    /// Resolve an AX window to one of the AppleScript-scanned windows by screen
+    /// geometry: the unique candidate whose edges all sit within `tolerance`
+    /// points of `frame`. Returns nil when no candidate matches or two do (two
+    /// perfectly stacked same-size windows are genuinely indistinguishable).
+    nonisolated static func uniqueBoundsMatch(
+        frame: CGRect,
+        in candidates: [CGRect?],
+        tolerance: CGFloat = 3
+    ) -> Int? {
+        var hit: Int?
+        for (i, c) in candidates.enumerated() {
+            guard let c,
+                  abs(c.minX - frame.minX) <= tolerance,
+                  abs(c.minY - frame.minY) <= tolerance,
+                  abs(c.width - frame.width) <= tolerance,
+                  abs(c.height - frame.height) <= tolerance else { continue }
+            if hit != nil { return nil }
+            hit = i
+        }
+        return hit
     }
 
     nonisolated static func windowSelectionIndex(

--- a/BetterCmdTab/Switcher/SwitcherMetrics.swift
+++ b/BetterCmdTab/Switcher/SwitcherMetrics.swift
@@ -106,8 +106,8 @@ struct SwitcherMetrics: Equatable {
     /// are expanded as windows, and transiently while searching with the
     /// search-tab feature — the matched tab rows then need their title (the only
     /// thing distinguishing sibling tabs) shown even when "show window title" is
-    /// off. Pure single source of truth shared by the controller and the view's
-    /// shrink loop so the two predicates can't drift.
+    /// off. The controller evaluates this once; fitted view metrics preserve the
+    /// resulting label band instead of re-deriving mode-specific state.
     static func reserveTabBand(expandAsWindows: Bool, applicationsOnly: Bool,
                                searchActive: Bool, searchExpandsTabs: Bool) -> Bool {
         (expandAsWindows || (searchActive && searchExpandsTabs)) && !applicationsOnly

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -769,15 +769,11 @@ final class SwitcherView: NSView, TabStripDelegate {
         var candidate = base
         while scale > minScale + 0.001 {
             scale = max(minScale, scale - 0.05)
-            // Shares `SwitcherMetrics.reserveTabBand` with the controller so a
-            // shrink pass reserves the preview label band on the same rule that
-            // produced `base` — otherwise it would drop the tab titles base
-            // computed while searching with the transient browser-tab feature.
-            let reserveBand = SwitcherMetrics.reserveTabBand(
-                expandAsWindows: effective.expandBrowserTabsAsWindows,
-                applicationsOnly: effective.applicationsOnly,
-                searchActive: searchActive,
-                searchExpandsTabs: Preferences.shared.searchExpandsBrowserTabs)
+            // Preserve a tab-only preview label band already present in `base`.
+            // The view doesn't know whether the controller is in windows-only
+            // mode, so re-deriving this from raw preferences can drop tab titles.
+            let reserveBand = base.previewLabelArea > 0
+                && !effective.showWindowTitleLabel
             candidate = SwitcherMetrics.forScale(scale, layoutMode: base.layoutMode, fontScale: effective.fontScale.multiplier, letterHints: letterHints, showAppNames: effective.showApplicationNames, showWindowTitles: effective.showWindowTitleLabel, hoverActionCount: Preferences.shared.enabledHoverActionCount, browserTabsExpanded: reserveBand)
             if fits(candidate) { return candidate }
         }

--- a/BetterCmdTab/Windows/BrowserTabs.swift
+++ b/BetterCmdTab/Windows/BrowserTabs.swift
@@ -518,6 +518,18 @@ enum BrowserTabs {
             let title: String
             let activeIndex: Int
             let tabs: [BrowserTabInfo]
+            /// Screen bounds from AppleScript (top-left origin, y-down — the same
+            /// space as `Activator.axBounds`), the title-independent identity used
+            /// to resolve windows whose titles are duplicated or stale. Nil when
+            /// the script couldn't read them.
+            let bounds: CGRect?
+
+            init(title: String, activeIndex: Int, tabs: [BrowserTabInfo], bounds: CGRect? = nil) {
+                self.title = title
+                self.activeIndex = activeIndex
+                self.tabs = tabs
+                self.bounds = bounds
+            }
         }
 
         let windows: [Window]
@@ -534,10 +546,10 @@ enum BrowserTabs {
     /// and lighter on CPU than calling `tabTitles` per window. No `AXRaise`, so
     /// it never reorders the user's windows.
     ///
-    /// Returns `(windowTitle, activeTab, tabTitles)` per window, in window order,
-    /// plus `failed` (osascript error vs. genuinely empty). The caller maps results
-    /// back to its AX window elements by (trimmed) title; windows whose title isn't
-    /// unique are left for the caller to skip.
+    /// Returns `(windowTitle, activeTab, tabTitles, bounds)` per window, in window
+    /// order, plus `failed` (osascript error vs. genuinely empty). The caller maps
+    /// results back to its AX window elements by (trimmed) title, falling back to
+    /// the window bounds when titles are duplicated or stale.
     ///
     /// Records are framed with ASCII control chars that can't appear in titles:
     /// GS (29) between windows, RS (30) between a window's title, its active-tab
@@ -566,6 +578,11 @@ enum BrowserTabs {
                     try
                         set activeIndex to \(activeExpr)
                     end try
+                    set boundsText to ""
+                    try
+                        set wBounds to bounds of window i
+                        set boundsText to ((item 1 of wBounds) as text) & " " & ((item 2 of wBounds) as text) & " " & ((item 3 of wBounds) as text) & " " & ((item 4 of wBounds) as text)
+                    end try
                     set tabText to ""
                     set tc to count of tabs of window i
                     repeat with j from 1 to tc
@@ -577,7 +594,7 @@ enum BrowserTabs {
                         set tabText to tabText & tabTitle & (ASCII character 28) & tabURL
                         if j < tc then set tabText to tabText & (ASCII character 31)
                     end repeat
-                    set outText to outText & wTitle & (ASCII character 30) & (activeIndex as text) & (ASCII character 30) & tabText
+                    set outText to outText & wTitle & (ASCII character 30) & (activeIndex as text) & (ASCII character 30) & tabText & (ASCII character 30) & boundsText
                     if i < wc then set outText to outText & (ASCII character 29)
                 end repeat
                 return outText
@@ -597,10 +614,17 @@ enum BrowserTabs {
         var out: [AllWindowTabs.Window] = []
         for block in raw.components(separatedBy: "\u{1D}") {
             let parts = block.components(separatedBy: "\u{1E}")
-            guard parts.count == 3, let oneBased = Int(parts[1]) else { continue }
+            guard parts.count >= 3, let oneBased = Int(parts[1]) else { continue }
             let tabs = parseTabs(parts[2])
             let activeIndex = tabs.isEmpty ? 0 : min(max(0, oneBased - 1), tabs.count - 1)
-            out.append(.init(title: parts[0], activeIndex: activeIndex, tabs: tabs))
+            var bounds: CGRect?
+            if parts.count >= 4 {
+                let n = parts[3].split(separator: " ").compactMap { Double($0) }
+                if n.count == 4, n[2] > n[0], n[3] > n[1] {
+                    bounds = CGRect(x: n[0], y: n[1], width: n[2] - n[0], height: n[3] - n[1])
+                }
+            }
+            out.append(.init(title: parts[0], activeIndex: activeIndex, tabs: tabs, bounds: bounds))
         }
         return out
     }

--- a/BetterCmdTabTests/BrowserTabsParserTests.swift
+++ b/BetterCmdTabTests/BrowserTabsParserTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Testing
 @testable import BetterCmdTab
 
@@ -25,5 +26,27 @@ struct BrowserTabsParserTests {
     func clampsActiveIndex() {
         let windows = BrowserTabs.parseAllWindowTabs("Window\u{1E}99\u{1E}A\u{1C}u\u{1F}B\u{1C}v")
         #expect(windows.first?.activeIndex == 1)
+    }
+
+    @Test("parses the optional bounds field and tolerates a missing or malformed one")
+    func parsesBounds() {
+        let withBounds = "W1\u{1E}1\u{1E}A\u{1C}u\u{1E}10 20 810 620"
+        let noBounds = "W2\u{1E}1\u{1E}B\u{1C}v"
+        let malformed = "W3\u{1E}1\u{1E}C\u{1C}w\u{1E}10 twenty 810"
+
+        let windows = BrowserTabs.parseAllWindowTabs(
+            withBounds + "\u{1D}" + noBounds + "\u{1D}" + malformed
+        )
+
+        #expect(windows.count == 3)
+        #expect(windows[0].bounds == CGRect(x: 10, y: 20, width: 800, height: 600))
+        #expect(windows[1].bounds == nil)
+        #expect(windows[2].bounds == nil)
+    }
+
+    @Test("rejects inverted bounds (right/bottom not past left/top)")
+    func rejectsInvertedBounds() {
+        let windows = BrowserTabs.parseAllWindowTabs("W\u{1E}1\u{1E}A\u{1C}u\u{1E}810 620 10 20")
+        #expect(windows.first?.bounds == nil)
     }
 }

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -416,6 +416,31 @@ struct SwitcherWindowSelectionTests {
 /// app A→Z regardless of which app was focused (#88). The first step now
 /// anchors on the frontmost app's position and wraps from there; a nil anchor
 /// (frontmost filtered out, or an MRU sort) reproduces the legacy start.
+@Suite("Browser window bounds matching (#119)")
+struct BoundsMatchTests {
+    private let a = CGRect(x: 0, y: 25, width: 800, height: 600)
+    private let b = CGRect(x: 900, y: 25, width: 800, height: 600)
+
+    @Test("resolves the unique window whose bounds match within tolerance")
+    func uniqueHit() {
+        let frame = CGRect(x: 1, y: 26, width: 799, height: 601)
+        #expect(SwitcherController.uniqueBoundsMatch(frame: frame, in: [a, b]) == 0)
+        #expect(SwitcherController.uniqueBoundsMatch(frame: b, in: [a, b]) == 1)
+    }
+
+    @Test("two candidates inside tolerance are ambiguous — no match")
+    func ambiguousIsNil() {
+        #expect(SwitcherController.uniqueBoundsMatch(frame: a, in: [a, a]) == nil)
+    }
+
+    @Test("nil candidates and out-of-tolerance frames never match")
+    func misses() {
+        let far = CGRect(x: 50, y: 25, width: 800, height: 600)
+        #expect(SwitcherController.uniqueBoundsMatch(frame: far, in: [a, nil]) == nil)
+        #expect(SwitcherController.uniqueBoundsMatch(frame: a, in: [nil, nil]) == nil)
+    }
+}
+
 @Suite("Primed start anchor (#88)")
 struct PrimedStartAnchorTests {
     @Test func legacyHeadAnchor_whenAnchorNil() {

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -308,6 +308,86 @@ struct SwitcherActiveBrowserTabTests {
     }
 }
 
+@Suite("Switcher window selection")
+struct SwitcherWindowSelectionTests {
+    private var hostApp: NSRunningApplication { .current }
+
+    private func window(_ offset: Int) -> AXUIElement {
+        AXUIElementCreateApplication(getpid() + pid_t(offset))
+    }
+
+    private func row(window: AXUIElement, title: String) -> SwitcherRow {
+        SwitcherRow(app: hostApp, window: window, windowTitle: title,
+                    isMinimized: false, cgWindowID: 99)
+    }
+
+    @Test("collapsed browser window selects its active tab")
+    func collapsedBrowserSelectsActiveTab() {
+        let browser = window(1)
+        let parent = row(window: browser, title: "Browser")
+        let rows = parent.browserTabRows(
+            tabs: [
+                BrowserTabInfo(title: "Inbox", url: "https://example.test/inbox"),
+                BrowserTabInfo(title: "Docs", url: "https://example.test/docs"),
+            ],
+            activeIndex: 1
+        )
+
+        #expect(SwitcherController.windowSelectionIndex(in: rows, selected: parent) == 1)
+    }
+
+    @Test("existing browser-tab selection wins over the active tab")
+    func preservesExistingTab() {
+        let browser = window(1)
+        let rows = row(window: browser, title: "Browser").browserTabRows(
+            tabs: [
+                BrowserTabInfo(title: "Inbox", url: ""),
+                BrowserTabInfo(title: "Docs", url: ""),
+            ],
+            activeIndex: 1
+        )
+
+        #expect(SwitcherController.windowSelectionIndex(in: rows, selected: rows[0]) == 0)
+    }
+
+    @Test("stable page identity beats a stale index after tab insertion")
+    func preservesTabAfterInsertion() {
+        let browser = window(1)
+        let parent = row(window: browser, title: "Browser")
+        let selected = parent.browserTabRows(
+            tabs: [
+                BrowserTabInfo(title: "Inbox", url: "https://example.test/inbox"),
+                BrowserTabInfo(title: "Docs", url: "https://example.test/docs"),
+            ],
+            activeIndex: 0
+        )[1]
+        let refreshed = parent.browserTabRows(
+            tabs: [
+                BrowserTabInfo(title: "New", url: "https://example.test/new"),
+                BrowserTabInfo(title: "Inbox", url: "https://example.test/inbox"),
+                BrowserTabInfo(title: "Docs", url: "https://example.test/docs"),
+            ],
+            activeIndex: 0
+        )
+
+        #expect(SwitcherController.windowSelectionIndex(in: refreshed, selected: selected) == 2)
+    }
+
+    @Test("ordinary window keeps its identity after an earlier window expands")
+    func preservesOrdinaryWindow() {
+        let browserRows = row(window: window(1), title: "Browser")
+            .browserTabRows(tabTitles: ["A", "B", "C"])
+        let ordinary = row(window: window(2), title: "Editor")
+        let rows = browserRows + [ordinary]
+
+        #expect(SwitcherController.windowSelectionIndex(in: rows, selected: ordinary) == browserRows.count)
+        #expect(SwitcherController.windowSelectionIndex(
+            in: rows,
+            selected: row(window: window(3), title: "Missing")
+        ) == nil)
+    }
+}
+
 /// Under a stable sort (alphabetical / launch order) the primed list is not
 /// MRU-ordered, so the old `primedIndex = 1` start always landed on the second
 /// app A→Z regardless of which app was focused (#88). The first step now

--- a/BetterCmdTabTests/SwitcherPhaseTests.swift
+++ b/BetterCmdTabTests/SwitcherPhaseTests.swift
@@ -373,6 +373,29 @@ struct SwitcherWindowSelectionTests {
         #expect(SwitcherController.windowSelectionIndex(in: refreshed, selected: selected) == 2)
     }
 
+    @Test("duplicate tab URLs fall back to a unique title over a stale index")
+    func duplicateUrlFallsBackToTitle() {
+        let browser = window(1)
+        let parent = row(window: browser, title: "Browser")
+        let selected = parent.browserTabRows(
+            tabs: [
+                BrowserTabInfo(title: "Inbox", url: "https://example.test/dup"),
+                BrowserTabInfo(title: "Docs", url: "https://example.test/dup"),
+            ],
+            activeIndex: 0
+        )[1]
+        let refreshed = parent.browserTabRows(
+            tabs: [
+                BrowserTabInfo(title: "New", url: "https://example.test/new"),
+                BrowserTabInfo(title: "Inbox", url: "https://example.test/dup"),
+                BrowserTabInfo(title: "Docs", url: "https://example.test/dup"),
+            ],
+            activeIndex: 0
+        )
+
+        #expect(SwitcherController.windowSelectionIndex(in: refreshed, selected: selected) == 2)
+    }
+
     @Test("ordinary window keeps its identity after an earlier window expands")
     func preservesOrdinaryWindow() {
         let browserRows = row(window: window(1), title: "Browser")


### PR DESCRIPTION
Fixes #119

## Summary
- route the windows-only reveal and refresh paths through the existing browser-tab expansion pipeline
- preserve the selected window or tab across asynchronous scans and tab reordering
- keep browser caches scoped correctly and avoid scanning unrelated browsers
- preserve browser-tab titles when Window Preview scales to fit

## Root cause
The dedicated windows-only reveal returned before the shared browser-tab expansion path. Its initial presentation and later snapshots therefore replaced expanded Safari tabs with collapsed window rows. The asynchronous prewarm could briefly expand them again, which caused the reported flicker.

## Testing
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test -only-testing:BetterCmdTabTests/SwitcherWindowSelectionTests`
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test`

The live Safari flow still requires manual verification with WindowServer, Accessibility, and Automation permissions.