### PR TITLE
fix: recover empty switcher catalog and stale previews

### DIFF
--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -162,14 +162,65 @@ final class AppCatalogCache {
         axCatalogPanelVisible.withLock { $0 = visible }
     }
 
-    /// Retry only apps whose AX observer failed to install. The common path is
-    /// one empty-set check; a gap gets a targeted pid refresh, never a full sweep.
+    /// Re-establish AX-observer coverage for two kinds of gap:
+    ///
+    ///  1. Apps whose observer *failed to install* (`AXObserverCreate` returned
+    ///     nil because the app wasn't AX-ready at `didLaunch`) — tracked in
+    ///     `axObserverFailures`.
+    ///  2. Apps whose observer *died silently*: the create succeeded, then the AX
+    ///     server stopped delivering (app wedged, subscription lost). These never
+    ///     enter `axObserverFailures`, so without this sweep their window set goes
+    ///     stale forever and the switcher can open with a missing/empty list.
+    ///
+    /// Invoked on every idle→active transition (see `SwitcherController`), so it
+    /// self-heals the cache the next time the user reaches for the switcher — no
+    /// polling timer. Iterating the running-app list is a handful of entries and
+    /// `installAXObserver` is idempotent, so a no-gap call stays cheap.
     func refreshObserverGaps() {
-        guard !axObserverFailures.isEmpty else { return }
-        let live = Set(axObserverFailures.filter { NSRunningApplication(processIdentifier: $0) != nil })
-        axObserverFailures = live
-        for pid in live { installAXObserver(forPid: pid) }
-        bumpApps(pids: live)
+        let failed = Set(axObserverFailures.filter { NSRunningApplication(processIdentifier: $0) != nil })
+        axObserverFailures = failed
+        var missing = Set<pid_t>()
+        for app in NSWorkspace.shared.runningApplications
+        where app.activationPolicy == .regular || app.activationPolicy == .accessory {
+            let pid = app.processIdentifier
+            if axObservers[pid] == nil, axObserversInstalling[pid] == nil {
+                missing.insert(pid)
+            }
+        }
+        let gaps = failed.union(missing)
+        guard !gaps.isEmpty else { return }
+        for pid in gaps { installAXObserver(forPid: pid) }
+        bumpApps(pids: gaps)
+    }
+
+    /// True when a completed scan's cache holds no apps yet regular apps are
+    /// running — a pathological "observers stopped feeding the cache" state, not
+    /// a legitimate "filters hid everything" (every `.regular` app gets an entry
+    /// in `computeEntries`, even windowless, so an empty post-scan cache can only
+    /// mean the incremental feed broke). The reveal path uses this to fire a
+    /// recovery full-refresh instead of presenting a stuck-empty panel. Pure
+    /// in-memory read plus one short running-app scan — no AX calls.
+    var looksEmptyButAppsRunning: Bool {
+        Self.cacheLooksBroken(
+            hasCompletedFullScan: hasCompletedFullScan,
+            isEmpty: entries.isEmpty,
+            hasRunningRegularApp: NSWorkspace.shared.runningApplications.contains {
+                $0.activationPolicy == .regular
+            }
+        )
+    }
+
+    /// Pure decision behind `looksEmptyButAppsRunning`, split out so the
+    /// "broken cache" rule can be unit-tested without a live WindowServer. The
+    /// cache is broken only when a full scan has completed (so emptiness isn't
+    /// just "not warmed up yet") AND it holds nothing AND at least one regular
+    /// app is running (which `computeEntries` would always have catalogued).
+    nonisolated static func cacheLooksBroken(
+        hasCompletedFullScan: Bool,
+        isEmpty: Bool,
+        hasRunningRegularApp: Bool
+    ) -> Bool {
+        hasCompletedFullScan && isEmpty && hasRunningRegularApp
     }
 
     /// Pids that currently have at least one catalogued window, for the

--- a/BetterCmdTab/Catalog/AppCatalogCache.swift
+++ b/BetterCmdTab/Catalog/AppCatalogCache.swift
@@ -572,9 +572,18 @@ final class AppCatalogCache {
         // Clamp per-call blocking when the target app is slow. Without this
         // `AXObserverAddNotification` can stall its thread indefinitely.
         AXUIElementSetMessagingTimeout(axApp, 0.2)
+        var subscribed = 0
         for name in axNotifications {
-            _ = AXObserverAddNotification(observer, axApp, name as CFString, refcon)
+            if AXObserverAddNotification(observer, axApp, name as CFString, refcon) == .success {
+                subscribed += 1
+            }
         }
+        // Every subscription timed out against a wedged app: the observer would
+        // sit in `axObservers` deaf forever, invisible to the
+        // `refreshObserverGaps` missing-observer sweep. Report it as a failed
+        // install instead so the failure-retry path rebuilds it once the app
+        // answers AX again.
+        guard subscribed > 0 else { return nil }
         return observer
     }
 

--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -214,6 +214,16 @@ enum CatalogFilter {
     private static let spaceMemo = OSAllocatedUnfairLock<SpaceMemo?>(initialState: nil)
     static let spaceMemoTTL: TimeInterval = 0.1
 
+    /// Drop the memoized Space resolution so the next `resolveSpacesMemoized`
+    /// recomputes against live WindowServer state. Called when the active Space
+    /// flips: the memo's `allowedSpaces` was resolved for the *previous* active
+    /// Space, so a reveal within the 100 ms TTL right after a Space switch could
+    /// otherwise filter a `.currentSpace`/`.visibleSpaces` scope against the old
+    /// Space and hide every window (empty panel). One unfair-lock write — cheap.
+    static func invalidateSpaceMemo() {
+        spaceMemo.withLock { $0 = nil }
+    }
+
     /// Pure reuse decision for the Space-resolution memo, split out so it can
     /// be unit-tested without WindowServer.
     static func spaceMemoValid(

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1843,7 +1843,13 @@ final class SwitcherController: SwitcherViewDelegate {
                 } else {
                     Activator.invalidatePendingActivation()
                     secureInputMonitor.start()
-                    cache.refreshObserverGaps()
+                    // Deferred off the keydown critical path: the sweep walks
+                    // the running-app list, and its heal lands via async
+                    // bumps anyway, so running it one runloop turn after
+                    // reveal() changes nothing observable.
+                    DispatchQueue.main.async { [weak self] in
+                        self?.cache.refreshObserverGaps()
+                    }
                 }
             }
             hotkey.setSwitching(newValue.isSwitching)

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -568,6 +568,12 @@ final class SwitcherController: SwitcherViewDelegate {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.updateTriggerSuppression()
+                // The memoized Space resolution (100 ms TTL) was computed for the
+                // Space we just left; drop it so a reveal right after the flip
+                // resolves against the new active Space instead of filtering a
+                // scoped list to empty. No-op cost when the scope is `.allSpaces`
+                // (that path never memoizes an allow-set that hides anything).
+                CatalogFilter.invalidateSpaceMemo()
             }
         }
         workspaceObservers.append(activeSpaceObserver)
@@ -2926,7 +2932,7 @@ final class SwitcherController: SwitcherViewDelegate {
                 index = 0
             }
         } else if hadCachedRows || cache.hasCompletedFullScan {
-            // Zero rows out of an already-scanned cache means the filters
+            // Zero rows out of an already-scanned cache normally means the filters
             // legitimately hide everything — e.g. only a windowless Finder is
             // running and its default when-no-windows exception drops it, or
             // an active scope matched nothing windowed in a warm cache.
@@ -2939,6 +2945,22 @@ final class SwitcherController: SwitcherViewDelegate {
             rows = []
             labels = []
             index = 0
+            // …but an empty cache while regular apps are running is NOT a
+            // legitimate filter result — it means the incremental AX/workspace
+            // feed silently broke and the cache lost its contents (the frequent
+            // "⌘Tab opens with nothing"). Fire a one-shot recovery full-refresh
+            // so the panel repopulates a few frames later instead of staying
+            // stuck empty until some future AX event happens to land. Gated on
+            // the pathological signal so the #31 legitimate-empty path never
+            // pays for (or flashes from) a rescan.
+            if cache.looksEmptyButAppsRunning {
+                Log.switcher.error("Catalog empty while apps running — scheduling recovery refresh")
+                cache.scheduleFullRefresh { [weak self] in
+                    guard let self, gen == self.revealGeneration else { return }
+                    let fresh = self.cache.rows(orderedBy: self.mru.order, filter: self.activeFilterConfig)
+                    self.applyFullSnapshot(fresh, anchorPid: targetPid)
+                }
+            }
         } else {
             baseRows = snapshotApps.map { app in
                 SwitcherRow(

--- a/BetterCmdTab/Switcher/WindowThumbnailCache.swift
+++ b/BetterCmdTab/Switcher/WindowThumbnailCache.swift
@@ -247,8 +247,12 @@ final class WindowThumbnailCache {
         guard !didRequestPermission else { return }
         didRequestPermission = true
         DispatchQueue.global(qos: .utility).async {
-            if !CGPreflightScreenCaptureAccess() {
-                _ = CGRequestScreenCaptureAccess()
+            guard !CGPreflightScreenCaptureAccess() else { return }
+            // Granting flips a prior "denied" enumeration into a stale 5 s
+            // backoff; drop it so the next reveal captures immediately instead of
+            // showing app icons until the backoff elapses.
+            if CGRequestScreenCaptureAccess(), #available(macOS 14.0, *) {
+                Task { await SCWindowProvider.shared.clearFailureBackoff() }
             }
         }
     }
@@ -423,8 +427,28 @@ private actor SCWindowProvider {
     /// a denied permission doesn't fire XPC round trips per tile per repaint.
     private let failureBackoff: TimeInterval = 5.0
 
+    /// A transient enumeration failure (SCK busy, a just-opened window not yet in
+    /// the inventory) clears on its own in a fraction of a second, so pacing it
+    /// behind the 5 s permission backoff needlessly blanks every tile until the
+    /// next reveal. Only a *denied permission* — which the app tolerates
+    /// indefinitely — warrants the long backoff. `performRefresh` picks the
+    /// window based on whether Screen Recording is currently granted.
+    private let transientFailureBackoff: TimeInterval = 0.5
+    /// Whether the last failure happened while Screen Recording was granted
+    /// (transient) vs denied (permission). Selects the backoff length above.
+    private var lastFailureWasTransient = false
+
     private var refreshGeneration: UInt64 = 0
     private var inFlightRefresh: (generation: UInt64, task: Task<Void, Never>)?
+
+    /// Reset the failure pacing so the next enumeration retries immediately.
+    /// Called when Screen Recording is granted at runtime: without this, a denial
+    /// recorded moments earlier would keep every tile on its app icon for up to
+    /// `failureBackoff` seconds after the user already fixed the permission.
+    func clearFailureBackoff() {
+        lastFailureAt = .distantPast
+        lastFailureWasTransient = false
+    }
 
     /// Resolve and capture entirely inside the actor so the non-Sendable
     /// ScreenCaptureKit `SCWindow` never crosses an isolation boundary.
@@ -503,7 +527,8 @@ private actor SCWindowProvider {
     }
 
     private func performRefresh(generation: UInt64) async {
-        guard Date().timeIntervalSince(lastFailureAt) >= failureBackoff else { return }
+        let backoff = lastFailureWasTransient ? transientFailureBackoff : failureBackoff
+        guard Date().timeIntervalSince(lastFailureAt) >= backoff else { return }
         do {
             let content = try await SCShareableContent.excludingDesktopWindows(
                 false,
@@ -520,10 +545,13 @@ private actor SCWindowProvider {
             fetchedAt = Date()
         } catch {
             guard !Task.isCancelled, generation == refreshGeneration else { return }
-            // Permission missing or transient failure — leave the previous map
-            // (possibly empty); the CG fallback path still gets a chance.
+            // Leave the previous map (possibly empty); the CG fallback path still
+            // gets a chance. Classify the failure so the pacing above can retry a
+            // transient hiccup quickly while still holding back per-tile XPC when
+            // the permission is genuinely denied.
             fetchedAt = .distantPast
             lastFailureAt = Date()
+            lastFailureWasTransient = CGPreflightScreenCaptureAccess()
         }
     }
 

--- a/BetterCmdTab/Switcher/WindowThumbnailCache.swift
+++ b/BetterCmdTab/Switcher/WindowThumbnailCache.swift
@@ -248,9 +248,12 @@ final class WindowThumbnailCache {
         didRequestPermission = true
         DispatchQueue.global(qos: .utility).async {
             guard !CGPreflightScreenCaptureAccess() else { return }
-            // Granting flips a prior "denied" enumeration into a stale 5 s
-            // backoff; drop it so the next reveal captures immediately instead of
-            // showing app icons until the backoff elapses.
+            // Narrow first-request race: preflight can report a stale "denied"
+            // right after the user granted, while the request call sees the
+            // fresh TCC state — drop the 5 s denied-backoff so this reveal
+            // captures immediately. (Grants that land later are healed by
+            // `performRefresh` reclassifying failures as transient once
+            // preflight reads granted — ~0.5 s, no relaunch.)
             if CGRequestScreenCaptureAccess(), #available(macOS 14.0, *) {
                 Task { await SCWindowProvider.shared.clearFailureBackoff() }
             }

--- a/BetterCmdTabTests/AppCatalogCacheRecoveryTests.swift
+++ b/BetterCmdTabTests/AppCatalogCacheRecoveryTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import BetterCmdTab
+
+@Suite("AppCatalogCache recovery")
+struct AppCatalogCacheRecoveryTests {
+
+    // MARK: - Broken-cache detection (the "⌘Tab opens empty" rescue trigger)
+
+    @Test("empty cache after a completed scan with apps running is broken")
+    func emptyAfterScanWithAppsIsBroken() {
+        #expect(AppCatalogCache.cacheLooksBroken(
+            hasCompletedFullScan: true,
+            isEmpty: true,
+            hasRunningRegularApp: true))
+    }
+
+    @Test("a cold cache (no scan yet) is never treated as broken")
+    func coldCacheIsNotBroken() {
+        // Before the first scan, emptiness is expected — the placeholder path
+        // handles it, so the rescan must not fire here.
+        #expect(!AppCatalogCache.cacheLooksBroken(
+            hasCompletedFullScan: false,
+            isEmpty: true,
+            hasRunningRegularApp: true))
+    }
+
+    @Test("a populated cache is never broken, even scanned with apps running")
+    func populatedCacheIsNotBroken() {
+        #expect(!AppCatalogCache.cacheLooksBroken(
+            hasCompletedFullScan: true,
+            isEmpty: false,
+            hasRunningRegularApp: true))
+    }
+
+    @Test("empty cache with no regular apps is legitimately empty, not broken")
+    func emptyWithNoAppsIsLegitimate() {
+        // The #31 case: filters legitimately hide everything (or nothing is
+        // running) — present the empty state without a wasteful rescan.
+        #expect(!AppCatalogCache.cacheLooksBroken(
+            hasCompletedFullScan: true,
+            isEmpty: true,
+            hasRunningRegularApp: false))
+    }
+}


### PR DESCRIPTION
## Highlights
Fixes the switcher sometimes opening with **no apps** and/or **no window previews** after
the app has been running for a while. The ⌘Tab trigger already works in these cases — the
app list and the preview thumbnails were the parts coming up empty — so this restores the
panel's contents and makes it self-heal instead of staying broken until a relaunch.

## Problem
Once `AppCatalogCache` completes its first full scan it relies entirely on the incremental
AX/`NSWorkspace` observer feed. When that feed silently degrades (an app stops answering
AX, a subscription is lost to the 0.2s messaging timeout, an observer dies without
`AXObserverCreate` ever returning `nil`), `entries` goes empty and `reveal()` reads zero
rows as "filters legitimately hide everything" (the #31 empty-state path) and presents an
empty panel **with no recovery scan**. Separately, any transient capture failure — or a
late Screen Recording grant — blanks every preview tile for a full 5s backoff.

## How to reproduce
1. Grant Accessibility (and Screen Recording for previews) and use ⌘Tab normally.
2. Keep the app running for a while with several apps open (or force an app to hang / churn
   AX notifications).
3. Press ⌘Tab → the panel opens empty (no apps) or icons-only (no thumbnails) and stays so
   until an unrelated AX/workspace event repopulates the cache, or the app is restarted.

## Changes
- **`reveal()` empty-branch recovery** — a scanned-but-empty cache **while regular apps are
  running** now fires a one-shot recovery `scheduleFullRefresh`, so the panel repopulates a
  few frames later instead of staying stuck. Keeps the #31 no-flash path for the genuinely
  empty case (the pathological signal is extracted as the pure, tested
  `AppCatalogCache.cacheLooksBroken`).
- **`refreshObserverGaps()`** now also reinstalls AX observers that **died silently** (a
  live regular/accessory app with no installed observer), not just ones that failed to
  install — self-heals on the next switcher open, no polling timer.
- **Thumbnail backoff split** — the 5s backoff is reserved for a *denied* Screen Recording
  permission; transient capture failures use ~0.5s, and the backoff is cleared when the
  permission is granted at runtime, so previews come back on the next reveal instead of
  after 5s.
- **Space memo invalidation** — the `CatalogFilter` Space memo (100ms TTL) is dropped on
  active-Space change so a scoped list isn't filtered against the Space just left.

Performance-conscious: no polling timers, recovery work stays off the main thread
(`snapshotQueue`), and the extra checks are cheap in-memory reads gated on the pathological
path only.

## Testing
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test` — 481 tests
  pass, including the new `AppCatalogCacheRecoveryTests` (4 cases for the broken-cache rule:
  scanned+empty+apps-running → recover; cold cache, populated cache, and empty-with-no-apps
  → no recovery / keep #31 behavior).
- Debug build succeeds.
- Manual: after a stale-cache state, ⌘Tab now repopulates within a frame; revoking then
  re-granting Screen Recording brings previews back without the 5s wait or a relaunch; the
  #31 legitimately-empty state still shows without a flash.
