### PR TITLE
Show source browser icon on separate tab entries (#131)

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -763,6 +763,9 @@ final class Preferences: ObservableObject {
         /// collapsed row + `\` peek is the default. Browser tabs aren't separate
         /// NSWindows, so the rows are built from an async Apple Events tab scan.
         static let expandBrowserTabsAsWindows = "Switcher.expandBrowserTabsAsWindows"
+        /// Badge each expanded browser-tab row's favicon with the source
+        /// browser's app icon (#131). Default off — favicon-only stays the look.
+        static let showBrowserIconOnTabs = "Switcher.showBrowserIconOnTabs"
         static let showUnreadBadges = "Switcher.showUnreadBadges"
         /// Pre-graduation key (badges used to live behind the Experimental tab);
         /// read once at launch to carry a user's earlier choice over to the new key.
@@ -1393,6 +1396,20 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Badge each browser-tab row's favicon with the source browser's app
+    /// icon, so the same site open in two browsers is tellable apart (#131).
+    /// Applies to tab rows from `expandBrowserTabsAsWindows` (global or
+    /// per-shortcut override) and the `\` drill-in. Default off.
+    @Published var showBrowserIconOnTabs: Bool {
+        didSet {
+            guard oldValue != showBrowserIconOnTabs else { return }
+            UserDefaults.standard.set(showBrowserIconOnTabs, forKey: Keys.showBrowserIconOnTabs)
+            // Off → release the composited favicons right away instead of
+            // holding ~8 MB until NSCache memory pressure.
+            if !showBrowserIconOnTabs { IconCache.clearBadges() }
+        }
+    }
+
     /// Show app unread-badge counts (e.g. Mail's unread mail) on switcher rows,
     /// read from the Dock via the Accessibility API. On by default.
     @Published var showUnreadBadges: Bool {
@@ -1920,6 +1937,7 @@ final class Preferences: ObservableObject {
         self.windowDrillEnabled = defaults.object(forKey: Keys.windowDrillEnabled) as? Bool ?? true
         self.expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         self.expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
+        self.showBrowserIconOnTabs = defaults.object(forKey: Keys.showBrowserIconOnTabs) as? Bool ?? false
         self.experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
         self.experimentalBrowserTabPreviews = defaults.object(forKey: Keys.experimentalBrowserTabPreviews) as? Bool ?? false
         self.experimentalLivePreviews = defaults.object(forKey: Keys.experimentalLivePreviews) as? Bool ?? false
@@ -2064,6 +2082,7 @@ final class Preferences: ObservableObject {
         windowDrillEnabled = defaults.object(forKey: Keys.windowDrillEnabled) as? Bool ?? true
         expandTabsAsWindows = defaults.object(forKey: Keys.expandTabsAsWindows) as? Bool ?? false
         expandBrowserTabsAsWindows = defaults.object(forKey: Keys.expandBrowserTabsAsWindows) as? Bool ?? false
+        showBrowserIconOnTabs = defaults.object(forKey: Keys.showBrowserIconOnTabs) as? Bool ?? false
         experimentalBrowserTabMRU = defaults.object(forKey: Keys.experimentalBrowserTabMRU) as? Bool ?? false
         experimentalBrowserTabPreviews = defaults.object(forKey: Keys.experimentalBrowserTabPreviews) as? Bool ?? false
         experimentalLivePreviews = defaults.object(forKey: Keys.experimentalLivePreviews) as? Bool ?? false

--- a/BetterCmdTab/Catalog/BrowserFaviconCache.swift
+++ b/BetterCmdTab/Catalog/BrowserFaviconCache.swift
@@ -98,16 +98,27 @@ enum BrowserFaviconCache {
             var result: [String: NSImage] = [:]
             var complete = true
             for url in normalized {
-                sqlite3_reset(statement)
-                sqlite3_clear_bindings(statement)
-                sqlite3_bind_text(statement, 1, url, -1, SQLITE_TRANSIENT)
-                let status = sqlite3_step(statement)
-                guard status == SQLITE_ROW else {
-                    if status != SQLITE_DONE { complete = false }
-                    continue
+                // Safari's favicon store strips trailing slashes from page
+                // URLs (AppleScript reports "…/pl/", page_url stores "…/pl"),
+                // so a URL that misses verbatim is retried without the slash.
+                var candidates = [url]
+                if url.hasSuffix("/") { candidates.append(String(url.dropLast())) }
+                var uuid: String?
+                for candidate in candidates {
+                    sqlite3_reset(statement)
+                    sqlite3_clear_bindings(statement)
+                    sqlite3_bind_text(statement, 1, candidate, -1, SQLITE_TRANSIENT)
+                    let status = sqlite3_step(statement)
+                    if status == SQLITE_ROW {
+                        if let text = sqlite3_column_text(statement, 0) { uuid = String(cString: text) }
+                        break
+                    }
+                    if status != SQLITE_DONE {
+                        complete = false
+                        break
+                    }
                 }
-                guard let text = sqlite3_column_text(statement, 0) else { continue }
-                let uuid = String(cString: text)
+                guard let uuid else { continue }
                 let digest = Insecure.MD5.hash(data: Data(uuid.utf8)).map { String(format: "%02X", $0) }.joined()
                 if let image = decode(iconsURL.appendingPathComponent(digest)) { result[url] = image }
             }

--- a/BetterCmdTab/Catalog/IconCache.swift
+++ b/BetterCmdTab/Catalog/IconCache.swift
@@ -48,8 +48,29 @@ enum IconCache {
         if let tab = row.browserTab,
            let key = BrowserFaviconCache.key(bundleID: row.bundleIdentifier, url: tab.url),
            let favicon = BrowserFaviconCache.image(forKey: key) {
-            return favicon
+            guard Preferences.shared.showBrowserIconOnTabs else { return favicon }
+            let cacheKey = key as NSString
+            // Identity check against the live favicon: BrowserFaviconCache
+            // reloading a fresh favicon under the same key (site changed its
+            // icon, cache eviction + re-read) hands back a new object, which
+            // misses here and rebuilds the composite instead of serving the
+            // stale one. On a hit the browser icon is never resolved — no
+            // app-icon cache lookup, no wasted flatten.
+            if let hit = badgedCache.object(forKey: cacheKey), hit.source === favicon {
+                return hit.image
+            }
+            guard let browserIcon = appIcon(for: row) else { return favicon }
+            let composite = badged(favicon, browserIcon: browserIcon)
+            badgedCache.setObject(
+                BadgedIcon(source: favicon, image: composite),
+                forKey: cacheKey, cost: badgedBytesPerImage
+            )
+            return composite
         }
+        return appIcon(for: row)
+    }
+
+    private static func appIcon(for row: SwitcherRow) -> NSImage? {
         if let pid = row.pid {
             let key = NSNumber(value: pid)
             if let cached = cache.object(forKey: key) { return cached }
@@ -77,6 +98,165 @@ enum IconCache {
     static func clear() {
         cache.removeAllObjects()
         bundleCache.removeAllObjects()
+        badgedCache.removeAllObjects()
+    }
+
+    /// A composited favicon plus the favicon object it was built from, so a
+    /// hit can cheaply detect that `BrowserFaviconCache` swapped in a fresh
+    /// favicon (pointer compare) and rebuild instead of serving a stale badge.
+    private final class BadgedIcon {
+        let source: NSImage
+        let image: NSImage
+        init(source: NSImage, image: NSImage) {
+            self.source = source
+            self.image = image
+        }
+    }
+
+    /// Favicons with the source browser's icon composited on (#131), keyed by
+    /// the same bundleID+url favicon key so each tab pays the draw once.
+    /// Count and cost limits agree (128 entries ≈ 8 MB) — a cost ceiling below
+    /// the count limit would evict live composites on every reveal for users
+    /// with more badged tab rows than the cost allows.
+    private static let badgedCache: NSCache<NSString, BadgedIcon> = {
+        let c = NSCache<NSString, BadgedIcon>()
+        c.countLimit = maxCapacity
+        c.totalCostLimit = maxCapacity * badgedBytesPerImage
+        return c
+    }()
+
+    /// Drop all composited favicons. Called when the badge pref turns off so
+    /// up to ~8 MB of now-unreachable composites don't sit resident.
+    static func clearBadges() {
+        badgedCache.removeAllObjects()
+    }
+
+    /// Composite the source browser's app icon onto the favicon's bottom-right
+    /// quadrant. `browserIcon` is the already-flattened cached app icon, so the
+    /// draw is a plain bitmap blit — no Tahoe AutoLayout hazard.
+    /// ponytail: synchronous draw on the reveal path (~two blits per cold tab
+    /// row, paid once per favicon); chunk-prewarm like app icons if a cold
+    /// reveal with 50+ tab rows ever measures slow.
+    /// Badge geometry, CSS-style absolute positioning: the favicon sits
+    /// centered in a `faviconSlotFraction` box, the browser icon is a
+    /// `badgeFraction` square anchored to the canvas's bottom-right corner —
+    /// its size is set here, not by the favicon. (Browser app icons carry
+    /// their own built-in transparent padding, so the visible glyph reads
+    /// ~80% of the rect.)
+    private static let faviconSlotFraction: CGFloat = 0.60
+    private static let badgeFraction: CGFloat = 0.58
+    /// Reported point size of every badged composite. Fixed — not derived from
+    /// the favicon — so all tab rows render the same size: Safari ships 64px
+    /// favicons while Chromium mostly stores 32px, and favicon-relative sizing
+    /// made Safari rows visibly larger than the rest.
+    private static let badgedPointSize: CGFloat = 64
+    /// Raster edge for badged composites: 2× the fixed 64pt display size
+    /// covers Retina exactly; rendering at `renderEdge` (256) would quadruple
+    /// the per-entry cost for pixels the size clamp never shows.
+    private static let badgedRenderEdge = 128
+    private static let badgedBytesPerImage = badgedRenderEdge * badgedRenderEdge * 4
+
+    private static func badged(_ favicon: NSImage, browserIcon: NSImage) -> NSImage {
+        let pad = paddingFractions(of: browserIcon)
+        let composite = renderBitmap(edge: badgedRenderEdge) { size in
+            let edge = size.width
+            let slot = edge * faviconSlotFraction
+            let s = favicon.size
+            let scale = min(slot / max(1, s.width), slot / max(1, s.height))
+            let fit = NSSize(width: s.width * scale, height: s.height * scale)
+            favicon.draw(
+                in: NSRect(x: (edge - fit.width) / 2,
+                           y: (edge - fit.height) / 2,
+                           width: fit.width, height: fit.height),
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1.0
+            )
+            let badge = edge * badgeFraction
+            // Push the rect past the canvas corner by the icon's *measured*
+            // transparent padding: the visible glyph sits flush in the
+            // bottom-right corner without getting clipped, whatever margins
+            // this particular app icon ships with.
+            browserIcon.draw(
+                in: NSRect(x: edge - badge + badge * pad.right,
+                           y: -badge * pad.bottom,
+                           width: badge, height: badge),
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1.0
+            )
+        }
+        guard let composite else { return favicon }
+        // The 256px raster stays as hi-DPI backing; the grid layout clamps
+        // tab-row icons to `min(tileIconSize, image.size.width)`, so the
+        // fixed point size keeps tab rows compact and uniform.
+        composite.size = NSSize(width: badgedPointSize, height: badgedPointSize)
+        return composite
+    }
+
+    /// Measured padding per flattened browser icon, weak-keyed so an entry
+    /// dies with its icon. One probe per browser instead of one per favicon —
+    /// a cold reveal with 40 tabs of one browser would otherwise re-scan the
+    /// same immutable icon 40 times on the main thread.
+    private static let paddingMemo = NSMapTable<NSImage, NSValue>(
+        keyOptions: .weakMemory, valueOptions: .strongMemory
+    )
+
+    /// Fractions of `icon`'s edge that are fully transparent padding on its
+    /// right and bottom sides, measured from a 32px alpha probe — app icons
+    /// ship with varying built-in margins, and the badge is offset by exactly
+    /// this much so its visible glyph lands flush in the canvas corner.
+    /// Runs only on a badged-cache miss; memoized per icon object.
+    private static func paddingFractions(of icon: NSImage) -> (right: CGFloat, bottom: CGFloat) {
+        if let hit = paddingMemo.object(forKey: icon) {
+            let p = hit.pointValue
+            return (p.x, p.y)
+        }
+        let probe = 32
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: probe,
+            pixelsHigh: probe,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else { return (0, 0) }
+        rep.size = NSSize(width: probe, height: probe)
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        guard let ctx = NSGraphicsContext(bitmapImageRep: rep) else { return (0, 0) }
+        NSGraphicsContext.current = ctx
+        icon.draw(
+            in: NSRect(x: 0, y: 0, width: probe, height: probe),
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 1.0
+        )
+        ctx.flushGraphics()
+        guard let data = rep.bitmapData else { return (0, 0) }
+        let bytesPerRow = rep.bytesPerRow
+        let threshold: UInt8 = 16
+        var maxX = -1
+        var maxRow = -1  // rep row 0 is the top, so the largest row is the visual bottom
+        for y in 0..<probe {
+            let row = data + y * bytesPerRow
+            for x in 0..<probe where row[x * 4 + 3] > threshold {
+                if x > maxX { maxX = x }
+                maxRow = y
+            }
+        }
+        let fractions: (right: CGFloat, bottom: CGFloat) = maxX >= 0
+            ? (CGFloat(probe - 1 - maxX) / CGFloat(probe), CGFloat(probe - 1 - maxRow) / CGFloat(probe))
+            : (0, 0)
+        paddingMemo.setObject(
+            NSValue(point: NSPoint(x: fractions.right, y: fractions.bottom)),
+            forKey: icon
+        )
+        return fractions
     }
 
     /// Icons flattened per run-loop turn. The flatten must stay on the main
@@ -165,11 +345,25 @@ enum IconCache {
     /// `NSInternalInconsistencyException: Modifications to the layout
     /// engine must not be performed from a background thread...`
     private static func flattened(_ image: NSImage) -> NSImage? {
-        let size = NSSize(width: renderEdge, height: renderEdge)
+        renderBitmap(edge: renderEdge) { size in
+            image.draw(
+                in: NSRect(origin: .zero, size: size),
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1.0
+            )
+        }
+    }
+
+    /// Shared offscreen-render scaffolding for `flattened` and `badged`:
+    /// draw once into a fixed `edge`² RGBA bitmap and wrap it in an
+    /// immutable `NSImage`. `draw` runs with the bitmap context current.
+    private static func renderBitmap(edge: Int, _ draw: (NSSize) -> Void) -> NSImage? {
+        let size = NSSize(width: edge, height: edge)
         guard let rep = NSBitmapImageRep(
             bitmapDataPlanes: nil,
-            pixelsWide: renderEdge,
-            pixelsHigh: renderEdge,
+            pixelsWide: edge,
+            pixelsHigh: edge,
             bitsPerSample: 8,
             samplesPerPixel: 4,
             hasAlpha: true,
@@ -184,12 +378,7 @@ enum IconCache {
         guard let ctx = NSGraphicsContext(bitmapImageRep: rep) else { return nil }
         NSGraphicsContext.current = ctx
         ctx.imageInterpolation = .high
-        image.draw(
-            in: NSRect(origin: .zero, size: size),
-            from: .zero,
-            operation: .sourceOver,
-            fraction: 1.0
-        )
+        draw(size)
         ctx.flushGraphics()
         let result = NSImage(size: size)
         result.addRepresentation(rep)

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -3301,6 +3301,40 @@
         }
       }
     },
+    "Full Disk Access" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Festplattenvollzugriff"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso total al disco"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accès complet au disque"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pełny dostęp do dysku"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完全磁盘访问权限"
+          }
+        }
+      }
+    },
     "Full Screen" : {
       "localizations" : {
         "de" : {
@@ -5036,6 +5070,40 @@
         }
       }
     },
+    "Lets BetterCmdTab read Safari's favicon store so Safari tab entries show site icons. Optional — other browsers don't need it." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt BetterCmdTab, Safaris Favicon-Speicher zu lesen, damit Safari-Tab-Einträge Website-Symbole zeigen. Optional — andere Browser brauchen es nicht."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite a BetterCmdTab leer el almacén de favicons de Safari para que las entradas de pestañas de Safari muestren los iconos de los sitios. Opcional: otros navegadores no lo necesitan."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permet à BetterCmdTab de lire le stockage des favicons de Safari pour que les entrées d'onglets Safari affichent les icônes des sites. Facultatif — les autres navigateurs n'en ont pas besoin."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozwala BetterCmdTab odczytywać magazyn favicon Safari, aby wpisy kart Safari pokazywały ikony stron. Opcjonalne — inne przeglądarki tego nie potrzebują."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许 BetterCmdTab 读取 Safari 的网站图标存储，使 Safari 标签页条目显示网站图标。可选——其他浏览器不需要此权限。"
+          }
+        }
+      }
+    },
     "Lets the app keep ⌘Tab for itself: the chord is passed through to the app instead of opening the switcher. Useful for apps with their own window switching — virtual machines, remote desktop, some games.\n\n• Never — the switcher always opens.\n• Always — the app keeps ⌘Tab whenever it's focused.\n• In full screen — only while the app is in full screen." : {
       "localizations" : {
         "de" : {
@@ -5984,6 +6052,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认关闭。它们可能会变更或失效。"
+          }
+        }
+      }
+    },
+    "Not granted" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht erteilt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No concedido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non accordé"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie przyznano"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未授予"
           }
         }
       }
@@ -8165,6 +8267,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示无窗口应用"
+          }
+        }
+      }
+    },
+    "Badge each tab entry's favicon with the source browser's app icon, so you can tell which browser a tab belongs to when the same site is open in more than one." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versieht das Favicon jedes Tab-Eintrags mit dem App-Symbol des zugehörigen Browsers, damit erkennbar ist, zu welchem Browser ein Tab gehört, wenn dieselbe Seite in mehreren geöffnet ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añade al favicon de cada entrada de pestaña el icono de la app del navegador de origen, para distinguir a qué navegador pertenece una pestaña cuando el mismo sitio está abierto en varios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoute au favicon de chaque entrée d’onglet l’icône de l’app du navigateur d’origine, pour savoir à quel navigateur appartient un onglet lorsque le même site est ouvert dans plusieurs."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaje do favikony każdego wpisu karty ikonę aplikacji przeglądarki źródłowej, aby było widać, do której przeglądarki należy karta, gdy ta sama strona jest otwarta w kilku."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在每个标签页条目的网站图标上叠加来源浏览器的应用图标，当同一网站在多个浏览器中打开时，可以分辨标签页属于哪个浏览器。"
+          }
+        }
+      }
+    },
+    "Show browser icon on tab entries" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Symbol auf Tab-Einträgen anzeigen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar el icono del navegador en las entradas de pestañas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’icône du navigateur sur les entrées d’onglets"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokazuj ikonę przeglądarki na wpisach kart"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在标签页条目上显示浏览器图标"
           }
         }
       }

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -38,6 +38,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
     private let tabDrillSwitch = NSSwitch()
     private let expandTabsSwitch = NSSwitch()
     private let expandBrowserTabsSwitch = NSSwitch()
+    private let browserIconOnTabsSwitch = NSSwitch()
 
     // Search
     private let letterHintsSwitch = NSSwitch()
@@ -201,6 +202,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         addRow(to: tabs, title: String(localized: "Show browser tabs as separate entries"),
                subtitle: String(localized: "List each tab of a browser window (Safari, Chrome, Arc, Brave, Edge, …) as its own row alongside the other windows, instead of one collapsed window. Needs Apple Events access (below); off keeps one row per window — peek its tabs with \\."),
                accessory: expandBrowserTabsSwitch, searchItemID: SearchID.expandBrowserTabs)
+        configureSwitch(browserIconOnTabsSwitch, action: #selector(toggleBrowserIconOnTabs(_:)))
+        addRow(to: tabs, title: String(localized: "Show browser icon on tab entries"),
+               subtitle: String(localized: "Badge each tab entry's favicon with the source browser's app icon, so you can tell which browser a tab belongs to when the same site is open in more than one."),
+               accessory: browserIconOnTabsSwitch, searchItemID: SearchID.browserIconOnTabs)
 
         let grantButton = NSButton(title: String(localized: "Grant permissions…"), target: self, action: #selector(grantBrowserPermissions))
         grantButton.bezelStyle = .rounded
@@ -367,6 +372,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         windowDrillSwitch.state = prefs.windowDrillEnabled ? .on : .off
         expandTabsSwitch.state = prefs.expandTabsAsWindows ? .on : .off
         expandBrowserTabsSwitch.state = prefs.expandBrowserTabsAsWindows ? .on : .off
+        browserIconOnTabsSwitch.state = prefs.showBrowserIconOnTabs ? .on : .off
         letterHintsSwitch.state = prefs.letterHintsEnabled ? .on : .off
         applyLetterTimeout(prefs.letterChainTimeoutMs)
         letterTimeoutSlider.isEnabled = prefs.letterHintsEnabled
@@ -492,6 +498,10 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         // Listing browser tabs needs Apple Events consent; opting in while
         // Settings is foreground is the moment TCC can surface the prompt.
         if on { BrowserTabs.requestPermissionForRunningBrowsers() }
+    }
+
+    @objc private func toggleBrowserIconOnTabs(_ sender: NSSwitch) {
+        Preferences.shared.showBrowserIconOnTabs = (sender.state == .on)
     }
 
     @objc private func grantBrowserPermissions() {

--- a/BetterCmdTab/Settings/PrivacySettingsViewController.swift
+++ b/BetterCmdTab/Settings/PrivacySettingsViewController.swift
@@ -9,14 +9,16 @@ final class PrivacySettingsViewController: SettingsTabViewController {
 
     private let permissionIcon = NSImageView()
     private let permissionButton = NSButton(title: "", target: nil, action: nil)
+    private let fullDiskIcon = NSImageView()
+    private let fullDiskButton = NSButton(title: "", target: nil, action: nil)
 
-    private var observationTask: Task<Void, Never>?
+    private var observationTasks: [Task<Void, Never>] = []
 
     deinit {
         // Releasing a Task handle does not cancel the task. This is the final
         // backstop for teardown paths that skip both viewWillDisappear and
         // BetterSettings' prepareForMemoryRelease hook.
-        observationTask?.cancel()
+        observationTasks.forEach { $0.cancel() }
     }
 
     override func setupContent() {
@@ -35,32 +37,20 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         // Permissions section.
         let permissions = addSection(title: String(localized: "Permissions"), anchor: SettingsAnchor.permissions)
 
-        permissionIcon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
-        permissionIcon.translatesAutoresizingMaskIntoConstraints = false
-        permissionIcon.setContentHuggingPriority(.required, for: .horizontal)
-        NSLayoutConstraint.activate([
-            permissionIcon.widthAnchor.constraint(equalToConstant: 16),
-            permissionIcon.heightAnchor.constraint(equalToConstant: 16),
-        ])
-
-        permissionButton.bezelStyle = .rounded
-        permissionButton.controlSize = .small
-        permissionButton.target = self
-        permissionButton.action = #selector(grantAccess)
-
-        let permissionAccessory = NSStackView()
-        permissionAccessory.orientation = .horizontal
-        permissionAccessory.spacing = 8
-        permissionAccessory.alignment = .centerY
-        permissionAccessory.addArrangedSubview(permissionIcon)
-        permissionAccessory.addArrangedSubview(permissionButton)
-
         addRow(
             to: permissions,
             title: String(localized: "Accessibility access"),
             subtitle: String(localized: "Lets BetterCmdTab capture the shortcut and read your open windows. Required to work."),
-            accessory: permissionAccessory,
+            accessory: makePermissionAccessory(icon: permissionIcon, button: permissionButton, action: #selector(grantAccess)),
             searchItemID: SearchID.accessibility
+        )
+
+        addRow(
+            to: permissions,
+            title: String(localized: "Full Disk Access"),
+            subtitle: String(localized: "Lets BetterCmdTab read Safari's favicon store so Safari tab entries show site icons. Optional — other browsers don't need it."),
+            accessory: makePermissionAccessory(icon: fullDiskIcon, button: fullDiskButton, action: #selector(grantFullDiskAccess)),
+            searchItemID: SearchID.fullDiskAccess
         )
 
         // The Recovery section (restore macOS keyboard shortcuts) moved to the
@@ -73,6 +63,30 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         toggle.action = action
     }
 
+    /// Status icon + grant button pair used by every permission row.
+    private func makePermissionAccessory(icon: NSImageView, button: NSButton, action: Selector) -> NSStackView {
+        icon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.setContentHuggingPriority(.required, for: .horizontal)
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 16),
+            icon.heightAnchor.constraint(equalToConstant: 16),
+        ])
+
+        button.bezelStyle = .rounded
+        button.controlSize = .small
+        button.target = self
+        button.action = action
+
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.spacing = 8
+        stack.alignment = .centerY
+        stack.addArrangedSubview(icon)
+        stack.addArrangedSubview(button)
+        return stack
+    }
+
     override func viewWillAppear() {
         super.viewWillAppear()
 
@@ -82,26 +96,40 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         // immediately, then every change (TCC notification / app activation / adaptive
         // poll), replacing the hand-rolled 1 Hz timer + didBecomeActive observer. The
         // engine disarms when this task is cancelled on disappear / memory release.
-        observationTask?.cancel() // never leak a second armed observation
-        observationTask = Task { @MainActor [weak self] in
-            for await snapshot in BetterPermissions.changes(.accessibility) {
-                self?.refreshAccessibilityStatus(isUsable: snapshot.status.isUsable)
-            }
-        }
+        cancelObservations() // never leak a second armed observation
+        observationTasks = [
+            Task { @MainActor [weak self] in
+                for await snapshot in BetterPermissions.changes(.accessibility) {
+                    guard let self else { return }
+                    self.refreshPermission(icon: self.permissionIcon, button: self.permissionButton,
+                                           isUsable: snapshot.status.isUsable, optional: false)
+                }
+            },
+            Task { @MainActor [weak self] in
+                for await snapshot in BetterPermissions.changes(.fullDiskAccess) {
+                    guard let self else { return }
+                    self.refreshPermission(icon: self.fullDiskIcon, button: self.fullDiskButton,
+                                           isUsable: snapshot.status.isUsable, optional: true)
+                }
+            },
+        ]
     }
 
     override func viewWillDisappear() {
         super.viewWillDisappear()
-        observationTask?.cancel()
-        observationTask = nil
+        cancelObservations()
+    }
+
+    private func cancelObservations() {
+        observationTasks.forEach { $0.cancel() }
+        observationTasks.removeAll()
     }
 
     // BetterSettings can tear down the active tab (window close / memory eviction)
     // without a matching viewWillDisappear, which would orphan the observation Task and
     // leave the BetterPermissions accessibility detector armed for the process lifetime.
     override func prepareForMemoryRelease() {
-        observationTask?.cancel()
-        observationTask = nil
+        cancelObservations()
         super.prepareForMemoryRelease()
     }
 
@@ -116,17 +144,28 @@ final class PrivacySettingsViewController: SettingsTabViewController {
         }
     }
 
-    private func refreshAccessibilityStatus(isUsable: Bool) {
+    @objc private func grantFullDiskAccess() {
+        // FDA has no prompt API — the button always deep-links to the
+        // System Settings pane; the observation picks up the grant on return.
+        BetterPermissions.openSettings(for: .fullDiskAccess)
+    }
+
+    /// Shared status render for a permission row. `optional` picks the
+    /// not-granted look: a neutral gray minus for nice-to-have permissions,
+    /// an orange warning for required ones.
+    private func refreshPermission(icon: NSImageView, button: NSButton, isUsable: Bool, optional: Bool) {
         if isUsable {
             // Granted: show the state only — no actionable button.
-            permissionIcon.image = NSImage(systemSymbolName: "checkmark.circle.fill", accessibilityDescription: String(localized: "Granted"))
-            permissionIcon.contentTintColor = .systemGreen
-            permissionButton.isHidden = true
+            icon.image = NSImage(systemSymbolName: "checkmark.circle.fill", accessibilityDescription: String(localized: "Granted"))
+            icon.contentTintColor = .systemGreen
+            button.isHidden = true
         } else {
-            permissionIcon.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: String(localized: "Required"))
-            permissionIcon.contentTintColor = .systemOrange
-            permissionButton.isHidden = false
-            permissionButton.title = String(localized: "Grant Access")
+            icon.image = optional
+                ? NSImage(systemSymbolName: "minus.circle.fill", accessibilityDescription: String(localized: "Not granted"))
+                : NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: String(localized: "Required"))
+            icon.contentTintColor = optional ? .secondaryLabelColor : .systemOrange
+            button.isHidden = false
+            button.title = String(localized: "Grant Access")
         }
     }
 }

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -76,6 +76,7 @@ enum SearchID {
     static let sound = "general.sound"
     static let hideFromScreenSharing = "general.hideFromScreenSharing"
     static let accessibility = "general.accessibility"
+    static let fullDiskAccess = "privacy.fullDiskAccess"
     static let restoreShortcuts = "privacy.restoreShortcuts"
     static let updateInterval = "general.updateInterval"
     static let beta = "general.beta"
@@ -99,6 +100,7 @@ enum SearchID {
     static let windowDrill = "switcher.windowDrill"
     static let expandTabs = "switcher.expandTabs"
     static let expandBrowserTabs = "switcher.expandBrowserTabs"
+    static let browserIconOnTabs = "switcher.browserIconOnTabs"
     static let tabPermissions = "switcher.tabPermissions"
     static let letterHints = "switcher.letterHints"
     static let applicationNames = "switcher.applicationNames"
@@ -290,6 +292,8 @@ enum SettingsCatalog {
         // Privacy · Permissions
         item(SearchID.accessibility, .privacy, SettingsAnchor.permissions, String(localized: "Privacy"), String(localized: "Permissions"),
              String(localized: "Accessibility access"), ["accessibility", "permission", "grant", "trusted"]),
+        item(SearchID.fullDiskAccess, .privacy, SettingsAnchor.permissions, String(localized: "Privacy"), String(localized: "Permissions"),
+             String(localized: "Full Disk Access"), ["full", "disk", "access", "fda", "permission", "safari", "favicon", "favicons"]),
 
         // Behavior · Display
         item(SearchID.displayMonitor, .switcher, SettingsAnchor.display, String(localized: "Behavior"), String(localized: "Display"),
@@ -305,6 +309,8 @@ enum SettingsCatalog {
              String(localized: "Show tabs as separate entries"), ["tabs", "tab", "expand", "separate", "rows", "per tab", "finder", "terminal", "native tabs"]),
         item(SearchID.expandBrowserTabs, .switcher, SettingsAnchor.tabs, String(localized: "Behavior"), String(localized: "Tabs"),
              String(localized: "Show browser tabs as separate entries"), ["tabs", "tab", "browser", "expand", "separate", "rows", "per tab", "safari", "chrome", "arc", "brave", "edge"]),
+        item(SearchID.browserIconOnTabs, .switcher, SettingsAnchor.tabs, String(localized: "Behavior"), String(localized: "Tabs"),
+             String(localized: "Show browser icon on tab entries"), ["tabs", "tab", "browser", "icon", "badge", "favicon", "source", "safari", "chrome", "arc", "brave", "edge"]),
         item(SearchID.tabPermissions, .switcher, SettingsAnchor.tabs, String(localized: "Behavior"), String(localized: "Tabs"),
              String(localized: "Browser tab access"), ["tabs", "apple events", "automation", "permission", "browser", "consent"]),
         // Switcher · Search

--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -3501,9 +3501,9 @@ final class SwitcherController: SwitcherViewDelegate {
 
     /// Replace each browser-family window row with one row per tab, using titles
     /// already resolved in `browserTabsCache`. Rows whose tabs aren't cached yet
-    /// (or resolved to <2 tabs) stay collapsed until the background scan lands.
-    /// Already-expanded tab rows pass through untouched, so re-applying is
-    /// idempotent. No-op (returns the input) when the pref is off — pure, no AX.
+    /// stay collapsed until the background scan lands. Already-expanded tab rows
+    /// pass through untouched, so re-applying is idempotent. No-op (returns the
+    /// input) when the pref is off — pure, no AX.
     private func expandBrowserTabs(_ source: [SwitcherRow]) -> [SwitcherRow] {
         // Applications-only mode collapses to one row per app; re-expanding a
         // browser into per-tab rows would defeat it, so leave the rows untouched.
@@ -3521,13 +3521,15 @@ final class SwitcherController: SwitcherViewDelegate {
         out.reserveCapacity(source.count)
         for row in source {
             // Expand only a still-collapsed (`browserTab == nil`) browser window
-            // whose tabs are cached and number 2+. Anything else — already a tab
-            // row, non-browser, uncached, or single-tab — passes through as-is.
+            // whose tabs are cached — including a single tab, so the row still
+            // gets its favicon (+ source-browser badge, #131) instead of the
+            // bare app icon. Anything else — already a tab row, non-browser,
+            // uncached, or negative-cached empty — passes through as-is.
             guard row.browserTab == nil,
                   let window = row.window,
                   BrowserTabs.Family.from(bundleID: row.bundleIdentifier) != nil,
                   let cached = browserTabsCache[AXRef(element: window)],
-                  cached.tabs.count > 1 else { out.append(row); continue }
+                  !cached.tabs.isEmpty else { out.append(row); continue }
             out.append(contentsOf: row.browserTabRows(tabs: cached.tabs, activeIndex: cached.activeIndex))
         }
         return out

--- a/BetterCmdTab/Switcher/SwitcherRow.swift
+++ b/BetterCmdTab/Switcher/SwitcherRow.swift
@@ -180,10 +180,12 @@ struct SwitcherRow {
     /// Expand this collapsed browser-window row into one row per tab. Each output
     /// row shows a tab's title and carries its 0-based index plus this window's
     /// title (`parentTitle`) so commit can resolve the AppleScript window without
-    /// a raise. Fewer than 2 titles, a non-running subject, or no window → just
-    /// this row (nothing to expand). Pure — no AX messaging.
+    /// a raise. No tabs, a non-running subject, or no window → just this row.
+    /// A single tab still expands — the tab row carries its URL, which is what
+    /// gives the row a favicon (+ the #131 browser badge) instead of the bare
+    /// app icon. Pure — no AX messaging.
     func browserTabRows(tabs: [BrowserTabInfo], activeIndex: Int) -> [SwitcherRow] {
-        guard case .running(let app) = subject, window != nil, tabs.count > 1 else { return [self] }
+        guard case .running(let app) = subject, window != nil, !tabs.isEmpty else { return [self] }
         let parentTitle = windowTitle
         return tabs.enumerated().map { i, tab in
             SwitcherRow(

--- a/BetterCmdTabTests/BrowserFaviconCacheTests.swift
+++ b/BetterCmdTabTests/BrowserFaviconCacheTests.swift
@@ -35,6 +35,30 @@ struct BrowserFaviconCacheTests {
         #expect(found["https://example.test/icon"] != nil)
     }
 
+    @Test("Safari lookup retries a trailing-slash URL without the slash")
+    func safariTrailingSlash() throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let icons = root.appendingPathComponent("favicons")
+        try FileManager.default.createDirectory(at: icons, withIntermediateDirectories: true)
+        let database = root.appendingPathComponent("favicons.db")
+        let db = try open(database)
+        defer { sqlite3_close(db) }
+        try exec(db, "CREATE TABLE page_url (url TEXT UNIQUE, uuid TEXT NOT NULL)")
+
+        // Safari stores page URLs with the trailing slash stripped.
+        let uuid = "33333333-3333-3333-3333-333333333333"
+        try exec(db, "INSERT INTO page_url VALUES ('https://example.test/pl', '\(uuid)')")
+        try png(size: 5).write(to: icons.appendingPathComponent(md5(uuid)))
+
+        let found = BrowserFaviconCache.loadSafari(
+            urls: ["https://example.test/pl/"],
+            databaseURL: database,
+            iconsURL: icons
+        )
+        #expect(found["https://example.test/pl/"]?.size.width == 5)
+    }
+
     @Test("Chromium starts with last_used, decodes data, and falls back silently")
     func chromiumProfilesAndFailures() throws {
         let root = temporaryDirectory()

--- a/BetterCmdTabTests/SwitcherRowTests.swift
+++ b/BetterCmdTabTests/SwitcherRowTests.swift
@@ -225,13 +225,17 @@ struct SwitcherRowTests {
         #expect(rows[0].browserTabPreviewKey != reordered[1].browserTabPreviewKey) // index is part of identity
     }
 
-    @Test("browserTabRows leaves a single-tab (or empty) window collapsed")
-    func browserTabsNoExpandUnderTwo() {
+    @Test("a single tab expands into a tab row; an empty window stays collapsed")
+    func browserTabsSingleTabExpands() {
         let parent = browserWindowRow(title: "Solo")
-        #expect(parent.browserTabRows(tabTitles: ["Only"]).count == 1)
+        // Single tab → a real tab row (carries the URL, so the row gets a
+        // favicon + #131 browser badge instead of the bare app icon).
+        let single = parent.browserTabRows(tabTitles: ["Only"])
+        #expect(single.count == 1)
+        #expect(single.first?.browserTab?.index == 0)
+        // Empty (negative-cached) window keeps its collapsed identity.
         #expect(parent.browserTabRows(tabTitles: []).count == 1)
-        // Unchanged row keeps its collapsed identity (no browserTab marker).
-        #expect(parent.browserTabRows(tabTitles: ["Only"]).first?.browserTab == nil)
+        #expect(parent.browserTabRows(tabTitles: []).first?.browserTab == nil)
     }
 
     @Test("browserTabRows is a no-op for a non-running subject")


### PR DESCRIPTION
Closes #131.

## What

New off-by-default **Show browser icon on tab entries** toggle (Settings → Behavior → Tabs). When **Show browser tabs as separate entries** is on, each tab row's favicon gets the source browser's app icon composited into its bottom-right corner — so the same site open in two browsers, or tabs with generic/missing favicons, are tellable apart. Default off keeps the current look.


## How

- **Compositing lives in `IconCache.icon(for:)`** — the single chokepoint all three layouts (list / grid / previews) read row icons through, so no item-view layout code changes. Drawn once per (browser, url), cached with matching count/cost limits (~8 MB ceiling, 128px raster = 2× the fixed 64pt display size).
- **No invalidation plumbing**: a cache hit is validated by favicon object identity, so a favicon refreshed by `BrowserFaviconCache` rebuilds the composite automatically. Toggling the pref off releases the cache immediately.
- **Badge geometry**: the badge rect is pushed past the canvas corner by the icon's *measured* transparent padding (32px alpha probe, memoized per icon) so the visible glyph sits flush in the corner without clipping, whatever margins the app icon ships with. Composites report a fixed 64pt size so Safari's 64px favicons and Chromium's 32px ones render uniformly.

## Fixes surfaced while shipping

- **Safari favicons never loaded**: Safari's AppleScript bridge reports tab URLs with a trailing slash while its favicon store strips it in `page_url` — the exact-match lookup always missed. Now retried without the slash (covered by a fixture-DB test).
- **Single-tab browser windows never expanded**: both `expandBrowserTabsCore` and `SwitcherRow.browserTabRows` required 2+ tabs, so a one-tab window kept the bare app icon. Both guards relaxed to non-empty (contract test added); tab-strip/drill guards untouched.
- **New Full Disk Access row** (Settings → Privacy → Permissions): Safari's favicon store lives under TCC-protected `~/Library/Safari`, so without FDA those favicons silently fall back. Live status via BetterPermissions, deep-link to the System Settings pane, neutral "optional" styling.

Both new settings are localized (de/es/fr/pl/zh-Hans), searchable, and participate in settings export/import automatically.

## Testing

- Full suite: 488 tests green (2 new: Safari trailing-slash lookup, single-tab expansion contract).
- Two multi-agent review rounds; all confirmed findings fixed (incl. cache-thrash limits, hot-path probe memoization).
- Verified on device: badge rendering across favicon sources (Safari 64px / Chromium 32px), Safari favicon end-to-end with FDA granted, single- and multi-tab expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
