### PR TITLE
feat: narrow the List layout via a width slider (#124)

### DIFF
--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -341,6 +341,7 @@ struct ShortcutOverride: Equatable, Sendable {
     var fontScale: SwitcherFontScale?
     var fontFace: SwitcherFontFace?
     var gridMaxColumns: Int?
+    var listWidthPercent: Int?
     var panelOpacity: Int?
     var panelCornerRadius: Int?
     var backdropMaterial: BackdropMaterial?
@@ -368,7 +369,7 @@ struct ShortcutOverride: Equatable, Sendable {
             && stayOpenOnQuickTap == nil
             && layoutMode == nil && panelScalePercent == nil && panelAppearance == nil
             && fontScale == nil && fontFace == nil
-            && gridMaxColumns == nil
+            && gridMaxColumns == nil && listWidthPercent == nil
             && panelOpacity == nil && panelCornerRadius == nil && backdropMaterial == nil
             && showWindowTitleLabel == nil && previewTitleAlignment == nil
             && titleTruncationMode == nil
@@ -399,6 +400,7 @@ struct ShortcutOverride: Equatable, Sendable {
         if let fontScale { d["fontScale"] = fontScale.rawValue }
         if let fontFace { d["fontFace"] = fontFace.rawValue }
         put("gridMaxColumns", gridMaxColumns)
+        put("listWidthPercent", listWidthPercent.map(Preferences.clampListWidthPercent))
         put("panelOpacity", panelOpacity)
         put("panelCornerRadius", panelCornerRadius)
         if let backdropMaterial { d["backdropMaterial"] = backdropMaterial.rawValue }
@@ -421,7 +423,7 @@ struct ShortcutOverride: Equatable, Sendable {
         "applicationsOnly", "expandBrowserTabsAsWindows", "stayOpenOnRelease",
         "stayOpenOnQuickTap", "layoutMode", "panelSize", "panelScalePercent",
         "panelAppearance", "fontScale", "fontFace",
-        "gridMaxColumns", "panelOpacity", "panelCornerRadius", "backdropMaterial",
+        "gridMaxColumns", "listWidthPercent", "panelOpacity", "panelCornerRadius", "backdropMaterial",
         "showWindowTitleLabel", "previewTitleAlignment", "titleTruncationMode",
         "boldSelectedLabel", "showApplicationNames", "showUnreadBadges",
         "letterHintsEnabled",
@@ -450,6 +452,8 @@ struct ShortcutOverride: Equatable, Sendable {
         fontScale = dictionary["fontScale"].flatMap(SwitcherFontScale.init(rawValue:))
         fontFace = dictionary["fontFace"].flatMap(SwitcherFontFace.init(rawValue:))
         gridMaxColumns = dictionary["gridMaxColumns"].flatMap(Int.init)
+        listWidthPercent = dictionary["listWidthPercent"].flatMap(Int.init)
+            .map(Preferences.clampListWidthPercent)
         panelOpacity = dictionary["panelOpacity"].flatMap(Int.init)
         panelCornerRadius = dictionary["panelCornerRadius"].flatMap(Int.init)
         backdropMaterial = dictionary["backdropMaterial"].flatMap(BackdropMaterial.init(rawValue:))
@@ -676,6 +680,11 @@ final class Preferences: ObservableObject {
     /// user pins an explicit count. Bounded so a hand-edited/corrupted import
     /// can't land a negative or absurd value in the live pref.
     static let gridMaxColumnsRange: ClosedRange<Int> = 0...12
+    /// List layout row width as a percentage of the automatic (screen-scaled)
+    /// width (#124). `100` keeps the automatic width; lower values narrow the
+    /// list without shrinking text or icons. Floored so a hand-edited/corrupted
+    /// import can't shrink rows to slivers.
+    nonisolated static let listWidthPercentRange: ClosedRange<Int> = 30...100
     /// Upper bound on recently-closed entries surfaced in search. `0` disables.
     static let recentlyClosedLimitRange: ClosedRange<Int> = 0...50
 
@@ -775,6 +784,7 @@ final class Preferences: ObservableObject {
         static let showApplicationNames = "Switcher.showApplicationNames"
         static let panelOpacity = "Switcher.panelOpacity"
         static let panelCornerRadius = "Switcher.panelCornerRadius"
+        static let listWidthPercent = "Switcher.listWidthPercent"
         static let backdropMaterial = "Switcher.backdropMaterial"
         /// Legacy pre-#57 bool ("only current Space"). Still written (in sync
         /// with `spaceScope`) so older builds and old exports stay coherent;
@@ -1487,6 +1497,18 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// List-layout row width as a percentage of the automatic (screen-scaled)
+    /// width; `100` = full automatic width. Narrows the List layout on large
+    /// displays without shrinking text or icons (#124).
+    @Published var listWidthPercent: Int {
+        didSet {
+            let clamped = Self.clampListWidthPercent(listWidthPercent)
+            if clamped != listWidthPercent { listWidthPercent = clamped; return }
+            guard oldValue != listWidthPercent else { return }
+            UserDefaults.standard.set(listWidthPercent, forKey: Keys.listWidthPercent)
+        }
+    }
+
     /// Background blur material for the panel (NSVisualEffectView fallback path).
     @Published var backdropMaterial: BackdropMaterial {
         didSet {
@@ -1816,6 +1838,10 @@ final class Preferences: ObservableObject {
         min(gridMaxColumnsRange.upperBound, max(gridMaxColumnsRange.lowerBound, value))
     }
 
+    nonisolated static func clampListWidthPercent(_ value: Int) -> Int {
+        min(listWidthPercentRange.upperBound, max(listWidthPercentRange.lowerBound, value))
+    }
+
     static func clampRecentlyClosedLimit(_ value: Int) -> Int {
         min(recentlyClosedLimitRange.upperBound, max(recentlyClosedLimitRange.lowerBound, value))
     }
@@ -1964,6 +1990,8 @@ final class Preferences: ObservableObject {
         self.panelOpacity = Self.clampOpacity(opacity)
         let radius = defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0
         self.panelCornerRadius = Self.clampCornerRadius(radius)
+        let listWidth = defaults.object(forKey: Keys.listWidthPercent) as? Int ?? 100
+        self.listWidthPercent = Self.clampListWidthPercent(listWidth)
         let materialRaw = defaults.string(forKey: Keys.backdropMaterial)
         self.backdropMaterial = materialRaw.flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
         self.spaceScope = Self.storedSpaceScope(defaults)
@@ -2096,6 +2124,7 @@ final class Preferences: ObservableObject {
         boldSelectedLabel = defaults.object(forKey: Keys.boldSelectedLabel) as? Bool ?? true
         panelOpacity = Self.clampOpacity(defaults.object(forKey: Keys.panelOpacity) as? Int ?? 100)
         panelCornerRadius = Self.clampCornerRadius(defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0)
+        listWidthPercent = Self.clampListWidthPercent(defaults.object(forKey: Keys.listWidthPercent) as? Int ?? 100)
         backdropMaterial = defaults.string(forKey: Keys.backdropMaterial).flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
         spaceScope = Self.storedSpaceScope(defaults)
         directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -5444,6 +5444,40 @@
         }
       }
     },
+    "Maximum list width" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximale Listenbreite"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancho máximo de la lista"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Largeur maximale de la liste"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksymalna szerokość listy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表最大宽度"
+          }
+        }
+      }
+    },
     "Medium" : {
       "localizations" : {
         "de" : {
@@ -6291,6 +6325,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开切换器：滑动浏览应用（按 Return/点击确认，Esc 取消）。切换空间：跳到该方向的空间，每次一步。快速切换：切到上一个应用，类似快速点按 ⌘Tab — 再次滑动可切回。"
+          }
+        }
+      }
+    },
+    "Width of the List layout relative to automatic — lower it to narrow the panel on large displays." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Breite des Listen-Layouts relativ zur automatischen Breite — verringern, um das Panel auf großen Displays schmaler zu machen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancho de la disposición Lista respecto al automático: redúcelo para estrechar el panel en pantallas grandes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Largeur de la disposition Liste par rapport à l'automatique — réduisez-la pour rétrécir le panneau sur les grands écrans."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Szerokość układu listy względem automatycznej — zmniejsz, aby zwęzić panel na dużych ekranach."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表布局相对于自动宽度的比例——调低可在大屏幕上收窄面板。"
           }
         }
       }

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -10,6 +10,8 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     private var titleAlignmentRadio: SettingsRadioGroupView!
     private var truncationRadio: SettingsRadioGroupView!
     private let gridPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let listWidthSlider = NSSlider()
+    private let listWidthValueField = NSTextField()
     private let scaleSlider = NSSlider()
     private let scaleValueField = NSTextField()
     private let fontSizePopup = NSPopUpButton(frame: .zero, pullsDown: false)
@@ -66,6 +68,29 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
             scaleSlider.widthAnchor.constraint(equalToConstant: 140),
         ])
         addRow(to: layout, title: sizeTitle, accessory: scaleStack, searchItemID: SearchID.size)
+
+        let listWidthTitle = String(localized: "Maximum list width")
+        listWidthSlider.minValue = Double(Preferences.listWidthPercentRange.lowerBound)
+        listWidthSlider.maxValue = Double(Preferences.listWidthPercentRange.upperBound)
+        listWidthSlider.isContinuous = true
+        listWidthSlider.controlSize = .small
+        listWidthSlider.target = self
+        listWidthSlider.action = #selector(listWidthChanged(_:))
+        listWidthSlider.translatesAutoresizingMaskIntoConstraints = false
+        listWidthSlider.setAccessibilityLabel(listWidthTitle)
+        configureIntegerField(listWidthValueField,
+                              action: #selector(listWidthValueCommitted(_:)),
+                              accessibilityLabel: listWidthTitle)
+        let listWidthStack = NSStackView(views: [listWidthSlider, unitInput(for: listWidthValueField, unit: "%")])
+        listWidthStack.orientation = .horizontal
+        listWidthStack.spacing = 8
+        listWidthStack.alignment = .centerY
+        NSLayoutConstraint.activate([
+            listWidthSlider.widthAnchor.constraint(equalToConstant: 140),
+        ])
+        addRow(to: layout, title: listWidthTitle,
+               subtitle: String(localized: "Width of the List layout relative to automatic — lower it to narrow the panel on large displays."),
+               accessory: listWidthStack, searchItemID: SearchID.listMaxWidth)
 
         configurePopup(gridPopup, titles: gridValues.map { $0 == 0 ? String(localized: "Automatic") : "\($0)" }, action: #selector(gridChanged))
         addRow(to: layout, title: String(localized: "Grid columns"),
@@ -275,6 +300,10 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.selectGrid($0) }
             .store(in: &cancellables)
+        prefs.$listWidthPercent
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.applyListWidth($0) }
+            .store(in: &cancellables)
         prefs.$showWindowTitleLabel
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.windowTitleSwitch.state = $0 ? .on : .off }
@@ -328,6 +357,7 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         applyScale(prefs.panelScalePercent)
         selectAppearance(prefs.panelAppearance)
         selectGrid(prefs.gridMaxColumns)
+        applyListWidth(prefs.listWidthPercent)
         windowTitleSwitch.state = prefs.showWindowTitleLabel ? .on : .off
         selectTitleAlignment(prefs.previewTitleAlignment)
         selectTruncationMode(prefs.titleTruncationMode)
@@ -370,6 +400,27 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         let i = gridPopup.indexOfSelectedItem
         guard gridValues.indices.contains(i) else { return }
         Preferences.shared.gridMaxColumns = gridValues[i]
+    }
+
+    @objc private func listWidthChanged(_ sender: NSSlider) {
+        Preferences.shared.listWidthPercent = sender.integerValue
+        applyListWidth(sender.integerValue)
+    }
+
+    @objc private func listWidthValueCommitted(_ sender: NSTextField) {
+        guard let value = committedInteger(from: sender) else {
+            applyListWidth(Preferences.shared.listWidthPercent)
+            return
+        }
+        let clamped = Preferences.clampListWidthPercent(value)
+        Preferences.shared.listWidthPercent = clamped
+        applyListWidth(clamped)
+    }
+
+    private func applyListWidth(_ value: Int) {
+        if listWidthSlider.integerValue != value { listWidthSlider.integerValue = value }
+        let text = String(value)
+        if listWidthValueField.stringValue != text { listWidthValueField.stringValue = text }
     }
 
     @objc private func scaleChanged(_ sender: NSSlider) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -125,6 +125,7 @@ enum SearchID {
     static let layout = "appearance.layout"
     static let size = "appearance.size"
     static let gridColumns = "appearance.gridColumns"
+    static let listMaxWidth = "appearance.listMaxWidth"
     static let quickSwitchDelay = "appearance.quickSwitchDelay"
     static let windowTitle = "appearance.windowTitle"
     static let titleAlignment = "appearance.titleAlignment"
@@ -356,6 +357,8 @@ enum SettingsCatalog {
              String(localized: "Layout"), ["layout", "grid", "list", "preview"]),
         item(SearchID.size, .appearance, SettingsAnchor.appearanceLayout, String(localized: "Appearance"), String(localized: "Layout"),
              String(localized: "Size"), ["size", "panel size", "scale", "percent", "compact", "small", "large"]),
+        item(SearchID.listMaxWidth, .appearance, SettingsAnchor.appearanceLayout, String(localized: "Appearance"), String(localized: "Layout"),
+             String(localized: "Maximum list width"), ["list", "width", "max width", "narrow", "wide", "ultrawide", "percent", "cap"]),
         item(SearchID.gridColumns, .appearance, SettingsAnchor.appearanceLayout, String(localized: "Appearance"), String(localized: "Layout"),
              String(localized: "Grid columns"), ["grid", "columns"]),
         // Appearance · Labels

--- a/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
+++ b/BetterCmdTab/Settings/ShortcutOptionsFormView.swift
@@ -91,6 +91,9 @@ final class ShortcutOptionsFormView: NSView {
         addIntRow(to: appearance, title: String(localized: "Grid columns"),
                   subtitle: String(localized: "Applies to the Grid and Previews layouts."),
                   values: [0, 2, 3, 4, 5, 6], display: { $0 == 0 ? String(localized: "Automatic") : "\($0)" }, current: override.gridMaxColumns) { [weak self] in self?.override.gridMaxColumns = $0; self?.persist() }
+        addIntRow(to: appearance, title: String(localized: "Maximum list width"),
+                  subtitle: String(localized: "Width of the List layout relative to automatic — lower it to narrow the panel on large displays."),
+                  values: [100, 90, 80, 70, 60, 50, 40, 30], display: { "\($0)%" }, current: override.listWidthPercent) { [weak self] in self?.override.listWidthPercent = $0; self?.persist() }
         addEnumRow(to: appearance, title: String(localized: "Backdrop material"), options: BackdropMaterial.allCases, display: { $0.displayName }, current: override.backdropMaterial) { [weak self] in self?.override.backdropMaterial = $0; self?.persist() }
         addEnumRow(to: appearance, title: String(localized: "Title alignment"), options: [.leading, .center, .trailing] as [PreviewTitleAlignment], display: { $0.displayName }, current: override.previewTitleAlignment) { [weak self] in self?.override.previewTitleAlignment = $0; self?.persist() }
         addEnumRow(to: appearance, title: String(localized: "Ellipsis position"), options: TitleTruncationMode.allCases, display: { $0.displayName }, current: override.titleTruncationMode) { [weak self] in self?.override.titleTruncationMode = $0; self?.persist() }

--- a/BetterCmdTab/Switcher/EffectiveSettings.swift
+++ b/BetterCmdTab/Switcher/EffectiveSettings.swift
@@ -18,6 +18,7 @@ struct EffectiveSettings {
     let fontScale: SwitcherFontScale
     let fontFace: SwitcherFontFace
     let gridMaxColumns: Int
+    let listWidthPercent: Int
     let panelOpacity: Int
     let panelCornerRadius: Int
     let backdropMaterial: BackdropMaterial
@@ -54,6 +55,7 @@ extension Preferences {
             fontScale: override.fontScale ?? fontScale,
             fontFace: override.fontFace ?? fontFace,
             gridMaxColumns: override.gridMaxColumns ?? gridMaxColumns,
+            listWidthPercent: override.listWidthPercent ?? listWidthPercent,
             panelOpacity: override.panelOpacity ?? panelOpacity,
             panelCornerRadius: override.panelCornerRadius ?? panelCornerRadius,
             backdropMaterial: override.backdropMaterial ?? backdropMaterial,

--- a/BetterCmdTab/Switcher/SwitcherItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherItemView.swift
@@ -394,12 +394,13 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         letterLabel.isHidden = !actionBar.isHidden
 
         let appX = letterX + m.letterColumnWidth + m.interGap
-        appNameLabel.frame = NSRect(x: appX, y: labelY, width: m.appNameWidth, height: labelH)
+        let appNameW = m.fittedAppNameWidth(actualRowWidth: bounds.width)
+        appNameLabel.frame = NSRect(x: appX, y: labelY, width: appNameW, height: labelH)
 
         // When the app-name column is collapsed (names hidden) there is no label
         // between the letter column and the icon — drop its trailing gap so the
         // icon doesn't float on a double gap. Matches the rowWidth reduction.
-        let iconX = appX + m.appNameWidth + (m.appNameWidth > 0 ? m.interGap : 0)
+        let iconX = appX + appNameW + (appNameW > 0 ? m.interGap : 0)
         imageView.frame = NSRect(
             x: iconX + (m.iconSize - displayedIconSize) / 2,
             y: iconY,

--- a/BetterCmdTab/Switcher/SwitcherMetrics.swift
+++ b/BetterCmdTab/Switcher/SwitcherMetrics.swift
@@ -108,6 +108,24 @@ struct SwitcherMetrics: Equatable {
         pref == 0 ? cornerRadius : CGFloat(max(0, pref))
     }
 
+    /// Resolve the list width-percent preference against this metrics set:
+    /// `100` keeps the screen-scaled row width, lower values narrow the list
+    /// proportionally without touching text or icon sizes (#124). Values at or
+    /// above 100 are the identity, so rows never grow past the automatic width.
+    func resolvedRowWidth(percent: Int) -> CGFloat {
+        percent >= 100 ? rowWidth : round(rowWidth * CGFloat(max(0, percent)) / 100)
+    }
+
+    /// App-name column width for a list row that is actually `actualRowWidth`
+    /// wide. The column is metric-fixed, so on a row narrowed below the natural
+    /// `rowWidth` (#124 width slider, multi-column shrink) it must share the
+    /// shortfall proportionally — otherwise it starves the window-title column
+    /// into a bare ellipsis while itself keeping a mostly-empty gap.
+    func fittedAppNameWidth(actualRowWidth: CGFloat) -> CGFloat {
+        guard appNameWidth > 0, rowWidth > 0, actualRowWidth < rowWidth else { return appNameWidth }
+        return round(appNameWidth * max(0, actualRowWidth) / rowWidth)
+    }
+
     /// Whether the Window Preview label band must be reserved (the
     /// `browserTabsExpanded` input to `forScreen`/`forScale`): always when tabs
     /// are expanded as windows, and transiently while searching with the

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -878,7 +878,7 @@ final class SwitcherView: NSView, TabStripDelegate {
 
     private func computeListLayout() -> ListLayout {
         let rowH = metrics.rowHeight
-        let baseRowW = metrics.rowWidth
+        let baseRowW = metrics.resolvedRowWidth(percent: effective.listWidthPercent)
         let outerPadding = metrics.outerPadding
         let count = max(rows.count, 1)
         let screen = layoutScreenFrame()
@@ -891,8 +891,9 @@ final class SwitcherView: NSView, TabStripDelegate {
         let maxRowsByHeight = max(1, Int(floor(maxListHeight / rowH)))
 
         // Minimum column width: still enough for letter + app name + icon + a
-        // bit of title before truncation. Scale with display.
-        let minColWidth: CGFloat = round(380 * metrics.scale)
+        // bit of title before truncation. Scale with display, but never past a
+        // user width cap (#124) — the cap wins over the readability floor.
+        let minColWidth: CGFloat = min(round(380 * metrics.scale), baseRowW)
         let maxColsByWidth = max(1, Int(floor(maxListWidth / minColWidth)))
 
         // Determine how many columns we need to fit `count` without exceeding

--- a/BetterCmdTabTests/SwitcherMetricsTests.swift
+++ b/BetterCmdTabTests/SwitcherMetricsTests.swift
@@ -195,6 +195,34 @@ struct SwitcherMetricsTests {
         #expect(grid.resolvedCornerRadius(pref: -1) == 0)
     }
 
+    @Test("list width percent: 100 = automatic width, lower narrows proportionally, never widens")
+    func resolvedRowWidth() {
+        // Ultrawide-style metrics: scale 1.8 gives a 1296 pt automatic row (#124).
+        let m = SwitcherMetrics.forScale(1.8)
+        #expect(m.resolvedRowWidth(percent: 100) == m.rowWidth)
+        #expect(m.resolvedRowWidth(percent: 50) == round(m.rowWidth / 2))
+        // Values past 100 never widen the row.
+        #expect(m.resolvedRowWidth(percent: 250) == m.rowWidth)
+        // Clamp keeps the pref inside the slider range.
+        #expect(Preferences.clampListWidthPercent(0) == Preferences.listWidthPercentRange.lowerBound)
+        #expect(Preferences.clampListWidthPercent(9999) == Preferences.listWidthPercentRange.upperBound)
+        #expect(Preferences.clampListWidthPercent(70) == 70)
+    }
+
+    @Test("app-name column shares a row's narrowing so the title column keeps space")
+    func fittedAppNameWidth() {
+        let m = SwitcherMetrics.forScale(1.8)
+        // Full-width row: the metric column as-is.
+        #expect(m.fittedAppNameWidth(actualRowWidth: m.rowWidth) == m.appNameWidth)
+        // Wider than natural never grows the column.
+        #expect(m.fittedAppNameWidth(actualRowWidth: m.rowWidth * 2) == m.appNameWidth)
+        // Half-width row halves the column instead of starving the title.
+        #expect(m.fittedAppNameWidth(actualRowWidth: m.rowWidth / 2) == round(m.appNameWidth / 2))
+        // Hidden names stay collapsed regardless of row width.
+        let hidden = SwitcherMetrics.forScale(1.8, showAppNames: false)
+        #expect(hidden.fittedAppNameWidth(actualRowWidth: 300) == 0)
+    }
+
     @Test("fontScale defaults to 1.0 (no behavior change)")
     func fontScaleDefaultIdentity() {
         #expect(SwitcherMetrics.forScale(1.2) == SwitcherMetrics.forScale(1.2, fontScale: 1.0))


### PR DESCRIPTION
Closes #124.

## What

On ultrawide displays the screen-adaptive metric scale (up to 1.8× of the 720 pt base) makes List rows ~1300 pt wide, and the Size slider can't narrow them without shrinking text and icons along the way.

- New **Maximum list width** slider in Appearance → Layout (30–100%, editable % field, same control as Size). 100% = automatic width, i.e. exactly today's behavior; lower values narrow the List layout proportionally while text and icon sizes stay put.
- Per-shortcut overrides get a matching popup (percent steps, like Panel opacity) and inherit through `EffectiveSettings`.
- `.cmdtab` export/import picks up the new `Switcher.listWidthPercent` key automatically; absent key = 100 = no migration needed.

## How

- Resolution is a pure rule, `SwitcherMetrics.resolvedRowWidth(percent:)`, applied at the list layout's single `rowWidth` read in `computeListLayout()`. Values ≥ 100% are the identity, so rows never grow past the automatic width; in multi-column mode the cap also wins over the 380 pt readability floor.
- The app-name column is metric-fixed, so a narrowed row used to keep the full 200 pt (right-aligned) column and starve the window title into a bare ellipsis. `SwitcherMetrics.fittedAppNameWidth(actualRowWidth:)` now shrinks the column proportionally with the row — which also fixes the long-standing squeeze on multi-column rows.

Hot-path cost is one `round`/`min` per layout pass. Grid/Previews layouts are untouched.

## Testing

- 491 unit tests green, including new pure-logic coverage for `resolvedRowWidth` (identity at ≥100, proportional below, clamp) and `fittedAppNameWidth` (full-width identity, proportional shrink, hidden names stay collapsed).
- Verified manually on device: narrow rows at ~50%, the 30% floor, search bar and tab strip at narrow width, live settings preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)