### PR TITLE
fix: show application names in the Previews layout (#125)

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -236,13 +236,12 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         usesCompactTabIcon = row.browserTab != nil
         // "Window title under icon" preference: when off, keep the app icon but
         // drop the title text so the tile is just the thumbnail + icon. Browser
-        // tabs always show their title — it's the only thing distinguishing one
-        // tab tile from another (they share the parent window).
-        // Browser tabs always show their tab title (the only thing distinguishing
+        // tabs always show their tab title (the only thing distinguishing
         // sibling tabs). Otherwise the title is gated by "Show window title". When
-        // app names are hidden, use windowTitleText so a windowless/launch row
-        // never re-surfaces the app name as its title.
-        let previewTitle = row.titleSlot(showAppNames: effective.showApplicationNames)
+        // app names are shown they prefix the title ("App — Title", #125); when
+        // hidden, windowTitleText keeps a windowless/launch row from re-surfacing
+        // the app name as its title.
+        let previewTitle = row.previewTitleSlot(showAppNames: effective.showApplicationNames)
         nameLabel.stringValue = (effective.showWindowTitleLabel || row.browserTab != nil) ? previewTitle : ""
 
         // Dock/notification count badge — shown beside the title, never over the

--- a/BetterCmdTab/Switcher/SwitcherRow.swift
+++ b/BetterCmdTab/Switcher/SwitcherRow.swift
@@ -352,6 +352,20 @@ struct SwitcherRow {
     func titleSlot(showAppNames: Bool) -> String {
         showAppNames ? displayTitle : windowTitleText
     }
+
+    /// Title line for the Previews tile, which has no dedicated app-name slot
+    /// (List/Grid do): prefixes the app name when names are shown so tiles of
+    /// different apps are tellable apart (#125). Browser tabs keep the bare tab
+    /// title (the app would repeat on every sibling tab) and system dialogs keep
+    /// the window title (their process name is cryptic).
+    func previewTitleSlot(showAppNames: Bool) -> String {
+        guard showAppNames, browserTab == nil, !isSystemDialog else {
+            return titleSlot(showAppNames: showAppNames)
+        }
+        let title = windowTitleText
+        guard !title.isEmpty, title != appName else { return displayTitle }
+        return appName + " — " + title
+    }
 }
 
 /// Cached System Settings app icon, used for system permission/dialog rows.

--- a/BetterCmdTabTests/SwitcherRowTests.swift
+++ b/BetterCmdTabTests/SwitcherRowTests.swift
@@ -110,6 +110,31 @@ struct SwitcherRowTests {
         #expect(blank.titleSlot(showAppNames: true) == "Notes")
     }
 
+    @Test("previews title prefixes the app name when names are shown (#125)")
+    func previewTitleSlotPrefixesAppName() {
+        let row = SwitcherRow(app: hostApp, window: axElement(), windowTitle: "Inbox",
+                              isMinimized: false, cgWindowID: 7)
+        #expect(row.previewTitleSlot(showAppNames: true) == "\(row.appName) — Inbox")
+        #expect(row.previewTitleSlot(showAppNames: false) == "Inbox")
+
+        // Windowless / blank-titled rows show just the app name — never "Name — Name".
+        let windowless = SwitcherRow(app: hostApp, window: nil, windowTitle: "", isMinimized: false)
+        #expect(windowless.previewTitleSlot(showAppNames: true) == windowless.appName)
+        let blank = SwitcherRow(app: hostApp, window: axElement(), windowTitle: "",
+                                isMinimized: false, cgWindowID: 8)
+        #expect(blank.previewTitleSlot(showAppNames: true) == blank.appName)
+
+        // Recently-closed rows prefix too.
+        let closed = SwitcherRow(recentlyClosed: RecentEntry(
+            bundleID: "com.example.notes", appName: "Notes", title: "Groceries",
+            documentPath: nil, closedAt: Date()))
+        #expect(closed.previewTitleSlot(showAppNames: true) == "Notes — Groceries")
+
+        // Browser tabs keep the bare tab title (app repeats on every sibling tab).
+        let tab = browserWindowRow(title: "Browser Window").browserTabRows(tabTitles: ["Docs"]).first!
+        #expect(tab.previewTitleSlot(showAppNames: true) == "Docs")
+    }
+
     @Test("empty window title falls back to app name")
     func emptyTitleFallback() {
         // window must be non-nil to enter the title branch — but we can't


### PR DESCRIPTION
Closes #125.

## Problem

With **Show application names** enabled, the Previews layout still showed only the window title — the toggle had no visible effect there. Tiles like "Appearance" gave no clue which app they belonged to, and multiple instances of the same app were indistinguishable.

Root cause: List and Grid render the app name in a dedicated slot (`appNameSlot`), but Previews has a single title line fed by `titleSlot`, which returns the window title with the app name only as a blank-title fallback.

## Fix

- New `SwitcherRow.previewTitleSlot(showAppNames:)` — with names shown, the Previews title line becomes **"App — Title"**, collapsing to just the app name when the window title is blank or identical (never "Name — Name").
- Browser-tab tiles keep the bare tab title (the app name would repeat on every sibling tab); system-dialog tiles keep the window title (their host process name is cryptic).
- Names hidden → behavior unchanged. List/Grid untouched.

No layout changes: the existing label-band measurement and title truncation handle the longer string.

## Tests

New `previewTitleSlotPrefixesAppName` covers the prefix, blank/windowless fallbacks, recently-closed rows, and browser tabs. Full suite: 492 tests / 58 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)