### PR TITLE
fix: match the ⌘` chord on ISO keyboards (keycode 10 ↔ 50)

### DIFF
--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -317,6 +317,16 @@ final class HotkeyTap: @unchecked Sendable {
         return held == wanted || held == wanted.union(.maskShift)
     }
 
+    /// Trigger keycode match tolerating the ISO ⌘` quirk: ISO keyboards report
+    /// the key above Tab as kVK_ISO_Section (10) where the binding (and ANSI
+    /// hardware) says kVK_ANSI_Grave (50), and macOS swaps the two on some ISO
+    /// boards. Both sides normalize 10→50 so the chord fires either way. Only
+    /// for chord matching — character translation keeps the raw keycode so
+    /// typing § into search stays §.
+    static func chordKeyMatches(_ eventKeyCode: Int64, _ boundKeyCode: Int64) -> Bool {
+        normalizedChordKeyCode(eventKeyCode) == normalizedChordKeyCode(boundKeyCode)
+    }
+
     /// Vim-nav modifier gate: true when the only device-independent modifiers
     /// down are the held trigger's own hold modifier(s). The panel is held
     /// open by whatever modifier the user recorded — ⌘ for the default ⌘Tab,
@@ -1136,7 +1146,7 @@ final class HotkeyTap: @unchecked Sendable {
             // through the tab strip instead of the app list. Esc exits the
             // drill (one level up — the panel stays open).
             if tabDrillNow && isSwitchingNow() {
-                if anyModHeld, let appKey = cfg.appKey, keyCode == appKey {
+                if anyModHeld, let appKey = cfg.appKey, Self.chordKeyMatches(keyCode, appKey) {
                     deliver(shiftHeld ? .tabPrev : .tabNext); return nil
                 }
                 if keyCode == Self.escKey {
@@ -1174,14 +1184,14 @@ final class HotkeyTap: @unchecked Sendable {
             // other apps instead of opening the switcher (issue #79). Once the
             // switcher is open the superset `appModHeld`/`windowModHeld` keeps
             // cycling alive with ⌥/⌃/⇧ window-management chord keys held.
-            if appModHeld, let appKey = cfg.appKey, keyCode == appKey,
+            if appModHeld, let appKey = cfg.appKey, Self.chordKeyMatches(keyCode, appKey),
                switchingNow || Self.triggerChordMatches(flags, configured: cfg.appModifier) {
                 if suppressTrigger { return Unmanaged.passUnretained(event) }
                 let dir: Event = shiftHeld ? .prevApp : .nextApp
                 deliver(dir)
                 return nil
             }
-            if windowModHeld, let windowKey = cfg.windowKey, keyCode == windowKey,
+            if windowModHeld, let windowKey = cfg.windowKey, Self.chordKeyMatches(keyCode, windowKey),
                switchingNow || Self.triggerChordMatches(flags, configured: cfg.windowModifier) {
                 if suppressTrigger { return Unmanaged.passUnretained(event) }
                 let dir: Event = shiftHeld ? .prevWindow : .nextWindow

--- a/BetterCmdTab/Input/NativeOverridePlan.swift
+++ b/BetterCmdTab/Input/NativeOverridePlan.swift
@@ -102,6 +102,14 @@ private let searchPunctuationKeyCodes: [UInt32] = [
     24, 27, 30, 33, 39, 41, 43, 47, 42, // = - ] [ ' ; , . \
 ]
 
+/// kVK_ISO_Section (10) and kVK_ANSI_Grave (50) are both "the key above Tab":
+/// ISO keyboards report 10 where ANSI hardware reports 50, and macOS swaps the
+/// two on some ISO boards. Treated as one key wherever a *chord* is matched or
+/// registered — never in character translation (typing § must stay §).
+func normalizedChordKeyCode<T: BinaryInteger>(_ keyCode: T) -> T {
+    keyCode == 10 ? 50 : keyCode
+}
+
 // Fixed control keycodes (kVK_*) used for in-panel chords.
 private let kcReturn: UInt32 = 36
 private let kcKeypadEnter: UInt32 = 76
@@ -173,9 +181,12 @@ func computeNativeOverridePlan(
     // symbolic hotkey enabled while we still RegisterEventHotKey that exact chord,
     // so macOS rejects it with eventHotKeyExistsErr (-9878) on every retry forever
     // (issue #16). The `||` dedupes when both roles sit on the same keycode.
+    // Keycodes normalized so a binding recorded as ISO Section (10) still frees
+    // the native ⌘` symbolic hotkey — otherwise macOS keeps it armed while we
+    // register the same physical chord, the -9878 pattern from issue #16.
     func reservesCommandOnly(_ keyCode: UInt32) -> Bool {
-        (trigger.appEnabled && trigger.appIsCommandOnly && trigger.appKeyCode == keyCode)
-            || (trigger.windowEnabled && trigger.windowIsCommandOnly && trigger.windowKeyCode == keyCode)
+        (trigger.appEnabled && trigger.appIsCommandOnly && normalizedChordKeyCode(trigger.appKeyCode) == keyCode)
+            || (trigger.windowEnabled && trigger.windowIsCommandOnly && normalizedChordKeyCode(trigger.windowKeyCode) == keyCode)
     }
     if reservesCommandOnly(48) {
         symbolic.append(PrivateAPI.SymbolicHotKey.commandTab.rawValue)      // 1
@@ -266,6 +277,17 @@ func computeNativeOverridePlan(
             }
         }
     }
+
+    // ISO alias: register every 10/50 chord under both keycodes, so the default
+    // ⌘` (stored 50) fires on ISO hardware emitting kVK_ISO_Section (10) and a
+    // binding recorded as 10 survives the macOS 10↔50 swap quirk. RegisterEvent-
+    // HotKey matches raw hardware keycodes, so normalization alone can't cover
+    // the Carbon path. Appending keeps first-wins dedupe semantics intact, and
+    // an unused keycode 10 registration on ANSI hardware is inert.
+    let isoTwins = chords.filter { $0.keyCode == 10 || $0.keyCode == 50 }.map {
+        ChordSpec(keyCode: $0.keyCode == 10 ? 50 : 10, modifiers: $0.modifiers, kind: $0.kind)
+    }
+    chords += isoTwins
 
     // Dedupe by (keyCode, modifiers), first-wins — RegisterEventHotKey rejects a
     // duplicate registration, and first-wins lets the specific control/action

--- a/BetterCmdTabTests/HotkeyTapTriggerMatchTests.swift
+++ b/BetterCmdTabTests/HotkeyTapTriggerMatchTests.swift
@@ -43,4 +43,21 @@ struct HotkeyTapTriggerMatchTests {
         #expect(!HotkeyTap.triggerChordMatches(.maskCommand, configured: .maskAlternate))
         #expect(HotkeyTap.triggerChordMatches(.maskAlternate, configured: .maskAlternate))
     }
+
+    // MARK: ISO ⌘` alias — kVK_ISO_Section (10) ↔ kVK_ANSI_Grave (50)
+
+    @Test func isoSectionAliasesGrave() {
+        // ISO hardware emitting 10 must match the default ⌘` binding stored as
+        // 50, and vice versa (the macOS 10↔50 swap quirk).
+        #expect(HotkeyTap.chordKeyMatches(10, 50))
+        #expect(HotkeyTap.chordKeyMatches(50, 10))
+        #expect(HotkeyTap.chordKeyMatches(10, 10))
+        #expect(HotkeyTap.chordKeyMatches(50, 50))
+    }
+
+    @Test func nonAliasKeycodesMatchExactly() {
+        #expect(HotkeyTap.chordKeyMatches(48, 48))
+        #expect(!HotkeyTap.chordKeyMatches(10, 48))
+        #expect(!HotkeyTap.chordKeyMatches(49, 50))
+    }
 }

--- a/BetterCmdTabTests/NativeOverridePlanTests.swift
+++ b/BetterCmdTabTests/NativeOverridePlanTests.swift
@@ -46,14 +46,15 @@ struct NativeOverridePlanTests {
 
     @Test func secureInputOff_native_stillArmsSwitcher() {
         // The switcher is always armed so it wins the instant the tap goes deaf:
-        // native ⌘Tab disabled + the 4 switching chords registered even off SEI.
-        // No in-panel parity chords off SEI (the tap handles those).
+        // native ⌘Tab disabled + the 4 switching chords (plus the 2 ISO twins of
+        // ⌘`) registered even off SEI. No in-panel parity chords off SEI (the
+        // tap handles those).
         for open in [false, true] {
             let plan = computeNativeOverridePlan(trigger: Self.native(), secureInputActive: false,
                                                  panelOpen: open, holdModifierDown: open,
                                                  panelActions: Self.panelActions)
             #expect(plan.symbolicKeysToDisable == [1, 2, 6])
-            #expect(plan.carbonChords.count == 4)
+            #expect(plan.carbonChords.count == 6)
             #expect(!Self.hasNav(plan))
         }
     }
@@ -64,7 +65,7 @@ struct NativeOverridePlanTests {
         let plan = computeNativeOverridePlan(trigger: Self.remapped(), secureInputActive: false,
                                              panelOpen: false, holdModifierDown: false)
         #expect(plan.symbolicKeysToDisable.isEmpty)
-        #expect(plan.carbonChords.count == 4)
+        #expect(plan.carbonChords.count == 6)    // 4 switching + 2 ISO twins of ⌥`
         #expect(plan.carbonChords.contains(ChordSpec(keyCode: 48, modifiers: Self.opt, kind: .nextApp)))
     }
 
@@ -74,8 +75,9 @@ struct NativeOverridePlanTests {
         let plan = computeNativeOverridePlan(trigger: Self.native(), secureInputActive: true,
                                              panelOpen: false, holdModifierDown: false)
         #expect(plan.symbolicKeysToDisable == [1, 2, 6])
-        // 4 switching chords (app ⌘Tab + window ⌘` differ), no in-panel chords.
-        #expect(plan.carbonChords.count == 4)
+        // 4 switching chords (app ⌘Tab + window ⌘` differ) + 2 ISO twins of ⌘`,
+        // no in-panel chords.
+        #expect(plan.carbonChords.count == 6)
         #expect(!Self.hasNav(plan))
         #expect(plan.carbonChords.contains(ChordSpec(keyCode: 48, modifiers: Self.cmd, kind: .nextApp)))
         #expect(plan.carbonChords.contains(ChordSpec(keyCode: 48, modifiers: Self.cmd | Self.shift, kind: .prevApp)))
@@ -98,7 +100,7 @@ struct NativeOverridePlanTests {
         let plan = computeNativeOverridePlan(trigger: Self.remapped(), secureInputActive: true,
                                              panelOpen: false, holdModifierDown: false)
         #expect(plan.symbolicKeysToDisable.isEmpty)
-        #expect(plan.carbonChords.count == 4)
+        #expect(plan.carbonChords.count == 6)    // 4 switching + 2 ISO twins of ⌥`
         #expect(plan.carbonChords.contains(ChordSpec(keyCode: 48, modifiers: Self.opt, kind: .nextApp)))
         #expect(plan.carbonChords.contains(ChordSpec(keyCode: 50, modifiers: Self.opt | Self.shift, kind: .prevWindow)))
     }
@@ -109,19 +111,20 @@ struct NativeOverridePlanTests {
         let plan = computeNativeOverridePlan(trigger: spec, secureInputActive: true,
                                              panelOpen: false, holdModifierDown: false)
         #expect(plan.symbolicKeysToDisable == [1, 2])
-        #expect(plan.carbonChords.count == 4)            // app ≠ window ⇒ window chords too
+        #expect(plan.carbonChords.count == 6)   // app ≠ window ⇒ window chords + ISO twins too
     }
 
     // MARK: In-panel — gated on panel open AND hold modifier down
 
     @Test func panelOpen_holdReleased_noInPanelChords() {
         // Panel open but the hold modifier is up (gesture / stay-open / scoped):
-        // only the switching chords, so a plain ⌘C is never intercepted.
+        // only the switching chords (+ ISO twins), so a plain ⌘C is never
+        // intercepted.
         let plan = computeNativeOverridePlan(trigger: Self.native(), secureInputActive: true,
                                              panelOpen: true, holdModifierDown: false,
                                              panelActions: Self.panelActions)
         #expect(!Self.hasNav(plan))
-        #expect(plan.carbonChords.count == 4)
+        #expect(plan.carbonChords.count == 6)
     }
 
     @Test func inPanelChords_requireSecureInput_panelOpen_andHold() {
@@ -374,6 +377,33 @@ struct NativeOverridePlanTests {
         let plan = computeNativeOverridePlan(trigger: trigger, secureInputActive: false,
                                              panelOpen: false, holdModifierDown: false)
         #expect(plan.symbolicKeysToDisable == [1, 2])
+    }
+
+    // MARK: ISO ⌘` alias (kVK_ISO_Section 10 ↔ kVK_ANSI_Grave 50) — ISO boards
+    // report the key above Tab as 10 where the default binding says 50, and
+    // macOS swaps the two on some ISO keyboards.
+
+    @Test func nativeWindowChord_registersISOSectionTwins() {
+        // The default ⌘` (kc 50) must also be registered on kc 10 so the Carbon
+        // survivor fires from ISO hardware; ⌘Tab (48) gets no twin.
+        let plan = computeNativeOverridePlan(trigger: Self.native(), secureInputActive: false,
+                                             panelOpen: false, holdModifierDown: false)
+        #expect(plan.carbonChords.contains(ChordSpec(keyCode: 10, modifiers: Self.cmd, kind: .nextWindow)))
+        #expect(plan.carbonChords.contains(ChordSpec(keyCode: 10, modifiers: Self.cmd | Self.shift, kind: .prevWindow)))
+        #expect(!plan.carbonChords.contains { $0.keyCode == 10 && ($0.kind == .nextApp || $0.kind == .prevApp) })
+    }
+
+    @Test func windowBoundToISOSection_freesBacktickSymbolic_andRegistersBothKeycodes() {
+        // A binding recorded on quirky ISO hardware stores kc 10 — the native ⌘`
+        // symbolic (id 6) must still be freed, and both keycodes registered so
+        // the chord survives the hardware flipping back to 50.
+        let trigger = TriggerSpec(appKeyCode: 48, appCarbonModifiers: Self.cmd, appIsCommandOnly: true,
+                                  windowKeyCode: 10, windowCarbonModifiers: Self.cmd, windowIsCommandOnly: true)
+        let plan = computeNativeOverridePlan(trigger: trigger, secureInputActive: false,
+                                             panelOpen: false, holdModifierDown: false)
+        #expect(plan.symbolicKeysToDisable == [1, 2, 6])
+        #expect(plan.carbonChords.contains(ChordSpec(keyCode: 10, modifiers: Self.cmd, kind: .nextWindow)))
+        #expect(plan.carbonChords.contains(ChordSpec(keyCode: 50, modifiers: Self.cmd, kind: .nextWindow)))
     }
 
     @Test func remappedToOption_onReservedKeycode_freesNothing() {


### PR DESCRIPTION
## Problem

ISO keyboards report the key above Tab as `kVK_ISO_Section` (10), while the default window-switch binding stores `kVK_ANSI_Grave` (50) — and macOS is known to swap the two on some ISO boards. The chord was matched by raw keycode equality, so on ISO hardware:

- the default ⌘` never fired from the key above Tab,
- the Carbon survivor chord (Secure Event Input path) registered on 50 missed hardware emitting 10,
- a binding recorded as 10 left the native ⌘` symbolic hotkey armed — the `eventHotKeyExistsErr` (-9878) pattern from #16.

## Fix

Alias 10↔50 **only where chords are matched or registered**, never in character translation:

- `normalizedChordKeyCode` helper in `NativeOverridePlan.swift`; `HotkeyTap.chordKeyMatches` used at the three trigger-keycode comparisons (tab-drill + app/window chords).
- `reservesCommandOnly` normalizes, so a kc-10 binding frees the native ⌘` symbolic hotkey.
- An ISO-twin pass before dedupe registers every 10/50 chord under both keycodes — `RegisterEventHotKey` matches raw hardware keycodes, so normalization alone can't cover the Carbon path. An unused kc-10 registration on ANSI hardware is inert.

Deliberately untouched: the character-translation path (typing `§` into search stays `§`) and the recorded-binding read path (recorder and tap see the same hardware, raw match is consistent).

## Tests

New coverage: 10↔50 matching both ways, ISO twins registered for the default ⌘`, kc-10 binding frees symbolic id 6 and registers both keycodes. Existing chord-count expectations updated (plans with ⌘` now carry 6 switching chords). Full unit target: 509 tests green.

On-device verification on physical ISO hardware still pending (no ISO keyboard available here); ANSI behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)