### PR TITLE
fix: let bound action keys win over the type-to-search opener

### DIFF
--- a/BetterCmdTab/Input/HotkeyTap.swift
+++ b/BetterCmdTab/Input/HotkeyTap.swift
@@ -1351,17 +1351,15 @@ final class HotkeyTap: @unchecked Sendable {
                             // hints the tap would silently swallow here.
                             //
                             // `translate` is needed only by the vim check and the
-                            // type-to-search opener ahead of `panelKeyMap`, so it
-                            // is computed only when either flag is on — keeping the
-                            // default (both off) hot path free of any added cost: a
-                            // bound action key (⌘W/⌘M/⌘H/⌘Q/⌘F) still short-circuits
-                            // in `panelKeyMap` below without ever paying a translate.
-                            // When it is computed, the resolved character is reused
-                            // by the branches below, so a keystroke is still
-                            // translated at most once.
+                            // type-to-search opener, so it is computed only when a
+                            // branch that needs it actually runs — a bound action
+                            // key (⌘W/⌘M/⌘H/⌘Q/⌘F) short-circuits in `panelKeyMap`
+                            // below without ever paying a translate. When it is
+                            // computed, the resolved character is reused by the
+                            // branches below, so a keystroke is still translated
+                            // at most once.
                             let vimOn = vimNavigationFlag.withLock { $0 }
-                            let typeToSearch = typeToSearchFlag.withLock { $0 }
-                            let typed = (vimOn || typeToSearch) ? translate(keyCode: UInt16(keyCode)) : nil
+                            var typed: Character? = vimOn ? translate(keyCode: UInt16(keyCode)) : nil
                             if vimOn,
                                Self.onlyTriggerModifiersHeld(
                                    flags,
@@ -1372,22 +1370,15 @@ final class HotkeyTap: @unchecked Sendable {
                                 deliver(vimEvent)
                                 return nil
                             }
-                            // Type-to-search opener: route every letter and digit
-                            // (incl. the reserved action keys w/m/h/q/f) into the
-                            // query instead of firing a panel action, so a search
-                            // like "whatsapp", "figma" or "1password" works — in
-                            // any keyboard layout. Before `panelKeyMap` so action keys
-                            // don't win; after the vim check so h/j/k/l still
-                            // navigate. ⌥/⌃ pass through (⌘ holds the panel open, ⇧
-                            // is a capital). Only the first keystroke routes here —
-                            // `enterSearch` then sets search mode, after which the
-                            // `isSearchingNow()` branch handles all input.
-                            if typeToSearch, !optionHeld, !controlHeld,
-                               let ch = typed,
-                               let lower = Self.typeToSearchLetter(for: ch) {
-                                deliver(.letterInput(lower))
-                                return nil
-                            }
+                            // Bound in-panel action keys (#5) win over the
+                            // type-to-search opener below: the panel is held by ⌘,
+                            // so a W keystroke IS the recorded ⌘W — it must close
+                            // the window, not type "w" into a fresh query. To type
+                            // a bound letter into search, open it with / first (the
+                            // `isSearchingNow()` branch swallows everything
+                            // printable) or clear the binding in Settings, which
+                            // removes the key from this map and frees the letter
+                            // for the opener.
                             if let action = panelKeyMap.withLock({ $0[keyCode] }) {
                                 switch action {
                                 case .close: deliver(.closeWindow)
@@ -1397,6 +1388,22 @@ final class HotkeyTap: @unchecked Sendable {
                                 case .fullscreen: deliver(.fullscreen)
                                 }
                                 return nil
+                            }
+                            // Type-to-search opener: route every unbound letter and
+                            // digit into the query instead of letter-jump, so a
+                            // search like "figma" or "1password" works — in any
+                            // keyboard layout. After the vim check so h/j/k/l still
+                            // navigate. ⌥/⌃ pass through (⌘ holds the panel open, ⇧
+                            // is a capital). Only the first keystroke routes here —
+                            // `enterSearch` then sets search mode, after which the
+                            // `isSearchingNow()` branch handles all input.
+                            if typeToSearchFlag.withLock({ $0 }), !optionHeld, !controlHeld {
+                                if typed == nil { typed = translate(keyCode: UInt16(keyCode)) }
+                                if let ch = typed,
+                                   let lower = Self.typeToSearchLetter(for: ch) {
+                                    deliver(.letterInput(lower))
+                                    return nil
+                                }
                             }
                             if let letter = typed ?? translate(keyCode: UInt16(keyCode)) {
                                 // Layout-agnostic drill-in trigger: regardless of

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -443,36 +443,36 @@
         }
       }
     },
-    "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing / — action keys like W or Q then type into the search rather than acting on a window." : {
+    "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing / — bound action keys like ⌘W or ⌘Q still act on the highlighted window; press / first to type those letters." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeigt auf jedem Fenster einen Buchstaben an und springt durch Tippen dieses Buchstabens dorthin. Ausgeschaltet filtert Tippen stattdessen die Liste, ohne / zu drücken — Aktionstasten wie W oder Q schreiben dann in die Suche, statt auf ein Fenster zu wirken."
+            "value" : "Zeigt auf jedem Fenster einen Buchstaben an und springt durch Tippen dieses Buchstabens dorthin. Ausgeschaltet filtert Tippen stattdessen die Liste, ohne / zu drücken — belegte Aktionstasten wie ⌘W oder ⌘Q wirken weiterhin auf das markierte Fenster; drücke zuerst /, um diese Buchstaben zu tippen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Muestra una letra en cada ventana y salta a ella escribiendo esa letra. Desactívalo para filtrar la lista simplemente escribiendo, sin pulsar / — las teclas de acción como W o Q escriben entonces en la búsqueda en lugar de actuar sobre una ventana."
+            "value" : "Muestra una letra en cada ventana y salta a ella escribiendo esa letra. Desactívalo para filtrar la lista simplemente escribiendo, sin pulsar / — las teclas de acción asignadas como ⌘W o ⌘Q siguen actuando sobre la ventana resaltada; pulsa / primero para escribir esas letras."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Affiche une lettre sur chaque fenêtre et y accède lorsque vous tapez cette lettre. Désactivez-le pour filtrer la liste en tapant directement, sans appuyer sur / — les touches d’action comme W ou Q s’écrivent alors dans la recherche au lieu d’agir sur une fenêtre."
+            "value" : "Affiche une lettre sur chaque fenêtre et y accède lorsque vous tapez cette lettre. Désactivez-le pour filtrer la liste en tapant directement, sans appuyer sur / — les touches d’action assignées comme ⌘W ou ⌘Q agissent toujours sur la fenêtre en surbrillance ; appuyez d’abord sur / pour taper ces lettres."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pokazuj literę na każdym oknie i przeskocz do niego, wpisując tę literę. Wyłącz, aby pisząc od razu filtrować listę, bez naciskania / — klawisze akcji, jak W czy Q, trafiają wtedy do wyszukiwania zamiast działać na oknie."
+            "value" : "Pokazuj literę na każdym oknie i przeskocz do niego, wpisując tę literę. Wyłącz, aby pisząc od razu filtrować listę, bez naciskania / — przypisane klawisze akcji, jak ⌘W czy ⌘Q, nadal działają na podświetlonym oknie; naciśnij najpierw /, aby wpisać te litery."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在每个窗口上显示字母，输入该字母即可跳转。关闭后直接输入即可筛选列表，无需按 / —— W、Q 等操作键会输入到搜索中，而不是对窗口执行操作。"
+            "value" : "在每个窗口上显示字母，输入该字母即可跳转。关闭后直接输入即可筛选列表，无需按 / —— 已绑定的 ⌘W、⌘Q 等操作键仍会对高亮窗口执行操作；先按 / 即可输入这些字母。"
           }
         }
       }

--- a/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
+++ b/BetterCmdTab/Settings/BehaviorSettingsViewController.swift
@@ -218,7 +218,7 @@ final class BehaviorSettingsViewController: SettingsTabViewController {
         let search = addSection(title: String(localized: "Search"), anchor: SettingsAnchor.search)
         configureSwitch(letterHintsSwitch, action: #selector(toggleLetterHints(_:)))
         addRow(to: search, title: String(localized: "Letter hints"),
-               subtitle: String(localized: "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing / — action keys like W or Q then type into the search rather than acting on a window."),
+               subtitle: String(localized: "Show a letter on each window and jump to it by typing that letter. Turn it off to start typing and filter the list instead, without pressing / — bound action keys like ⌘W or ⌘Q still act on the highlighted window; press / first to type those letters."),
                accessory: letterHintsSwitch, searchItemID: SearchID.letterHints)
 
         let letterTimeoutTitle = String(localized: "Letter chain timeout")

--- a/BetterCmdTabTests/HotkeyTapVimNavigationTests.swift
+++ b/BetterCmdTabTests/HotkeyTapVimNavigationTests.swift
@@ -56,13 +56,13 @@ struct HotkeyTapVimNavigationTests {
         }
     }
 
-    /// Type-to-search routing (letter hints off + fuzzy on): every a–z letter,
-    /// including the reserved action keys w/m/h/q/f, must feed the query so a
-    /// search like "whatsapp"/"figma" works instead of firing close/minimize/etc.
-    /// This is the pure decision behind the tap's opener branch.
+    /// Type-to-search routing (letter hints off + fuzzy on): every a–z letter
+    /// must feed the query so a search like "whatsapp"/"figma" works. The action
+    /// letters w/m/h/q/f route here too — the tap consults `panelKeyMap` FIRST,
+    /// so while a key is bound the action wins (⌘ is held, so W means ⌘W) and
+    /// this helper is never asked; clearing the binding frees the letter for
+    /// the opener, which is why the helper must not exclude it.
     @Test func typeToSearchRoutesEveryLetterIncludingReserved() {
-        // Reserved action letters must NOT be excluded (the bug: w/m/h/q/f hit
-        // panelKeyMap and closed/quit instead of opening search).
         for c: Character in ["w", "m", "h", "q", "f"] {
             #expect(HotkeyTap.typeToSearchLetter(for: c) == c)
         }


### PR DESCRIPTION
## Summary
With **Letter hints off** and **Type-to-filter search on**, pressing a bound in-panel action key (⌘W, ⌘M, ⌘H, ⌘Q, ⌘F) opened the search and typed the letter instead of acting on the highlighted window. The panel is held by ⌘ the whole time, so a W keystroke *is* the recorded ⌘W chord — it must close the window.

## Change
- `HotkeyTap.swift`: check `panelKeyMap` **before** the type-to-search opener (previously the opener deliberately won so queries like "whatsapp" could be typed). Bound keys also no longer pay a keyboard-layout translate on the hot path.
- Unbound letters/digits still open the search; once search is active (via `/` or any opener letter) all printable input — including w/m/h/q/f — feeds the query, unchanged.
- Clearing a binding in Settings frees its letter for the opener.
- Updated the Letter hints subtitle (en + de/es/fr/pl/zh-Hans) which documented the old priority, and the test doc comments.

## Trade-off
Searching a phrase that *starts* with a bound letter (e.g. "whatsapp") now needs `/` first.

## Testing
- Full unit suite: 510 tests in 61 suites pass.
- Debug + Release builds succeed.
- Manually verified: ⌘W closes the highlighted window with hints off + type-to-filter on; typing still filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)