### PR TITLE
fix: show all windows in the switcher with Stage Manager on (#116)

### DIFF
--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -127,6 +127,28 @@ enum WindowEnumerator {
     /// user windows kept in the switcher.
     static let dockWindowLevel = Int(CGWindowLevelForKey(.dockWindow))
 
+    private static let windowManagerDefaults = UserDefaults(suiteName: "com.apple.WindowManager")
+
+    /// Whether Stage Manager is on. It reports every *off-stage* window to
+    /// WindowServer at its shrunken strip-tile geometry (~83×103, ordered out)
+    /// while the Accessibility API keeps reporting the window's real frame — so
+    /// two WindowServer-derived heuristics stop holding while it is on (#116):
+    ///
+    ///   1. the sub-100px "junk surface" gate in `cgWindowBucket` would drop
+    ///      every off-stage window out of the CG hint, starving the brute-force
+    ///      AX scan (and making the hint reject anything it did find), and
+    ///   2. "ordered out, next to an ordered-in front" stops meaning "native
+    ///      background tab" — Stage Manager orders windows out *en masse*, so
+    ///      `resolveTabStacks`' near-frame rule folds real cascaded windows away.
+    ///
+    /// `GloballyEnabled` in `com.apple.WindowManager` is the system toggle; the
+    /// key is absent until Stage Manager is first enabled, which reads as false.
+    /// The suite is cached (one CFPrefs lookup per read) and picks up changes
+    /// made while we run, so toggling Stage Manager takes effect on the next scan.
+    static var isStageManagerEnabled: Bool {
+        windowManagerDefaults?.bool(forKey: "GloballyEnabled") ?? false
+    }
+
     /// Classification of a `CGWindowListCopyWindowInfo` entry for snapshot
     /// bucketing. `.normal` windows feed the id/z-order hint; `.nonNormalLayer`
     /// windows (Dock-level-and-above overlays plus the sub-normal desktop band)
@@ -139,14 +161,18 @@ enum WindowEnumerator {
         case excluded
     }
 
-    static func cgWindowBucket(layer: Int, alpha: Double, width: Double, height: Double) -> CGWindowBucket {
+    static func cgWindowBucket(layer: Int, alpha: Double, width: Double, height: Double, stageManager: Bool = false) -> CGWindowBucket {
         // Drop only non-switchable surfaces: Dock level (20) and above, plus the
         // sub-normal desktop band (< 0). Levels 1–19 — floating ("keep on top"),
         // modal panels, utility windows — are real user windows and stay. The
         // Teams notification phantom sits at level 20 (Dock), so it's still caught.
         if layer >= Self.dockWindowLevel || layer < 0 { return .nonNormalLayer }
         if alpha <= 0 { return .excluded }
-        if width < 100 || height < 100 { return .excluded }
+        // The size gate assumes anything this small is a helper surface, which is
+        // false under Stage Manager: it reports every off-stage window at its
+        // ~83×103 strip-tile size, so the gate would exclude real user windows
+        // from the CG hint and the on-screen set (#116).
+        if !stageManager, width < 100 || height < 100 { return .excluded }
         return .normal
     }
 
@@ -175,6 +201,8 @@ enum WindowEnumerator {
         var zOrder: [pid_t: [CGWindowID]] = [:]
         var nonNormalLayer: [pid_t: Set<CGWindowID>] = [:]
         var onscreen: [pid_t: Set<CGWindowID>] = [:]
+        // Read once for the whole snapshot, not per window.
+        let stageManager = isStageManagerEnabled
         for entry in cfArray {
             guard let ownerPID = entry[kCGWindowOwnerPID as String] as? pid_t else { continue }
             guard let widNum = entry[kCGWindowNumber as String] as? Int else { continue }
@@ -190,7 +218,7 @@ enum WindowEnumerator {
                 width = (bounds["Width"] as? Double) ?? 0
                 height = (bounds["Height"] as? Double) ?? 0
             }
-            switch cgWindowBucket(layer: layer, alpha: alpha, width: width, height: height) {
+            switch cgWindowBucket(layer: layer, alpha: alpha, width: width, height: height, stageManager: stageManager) {
             case .normal:
                 if ids[ownerPID, default: []].insert(wid).inserted {
                     zOrder[ownerPID, default: []].append(wid)
@@ -508,7 +536,12 @@ enum WindowEnumerator {
         // without a tab-shaped group — the common case pays nothing.
         var spaceless = [Bool](repeating: false, count: raws.count)
         var spaceOf = [UInt64?](repeating: nil, count: raws.count)
-        let spaceQueryIndices = tabSpaceQueryIndices(frames: frames, fromAXList: fromAXList, onscreen: onscreen)
+        // Under Stage Manager the near-frame rule is off (see `isStageManagerEnabled`),
+        // so skip the per-window Space IPCs that only feed it.
+        let stageManager = isStageManagerEnabled
+        let spaceQueryIndices = stageManager
+            ? []
+            : tabSpaceQueryIndices(frames: frames, fromAXList: fromAXList, onscreen: onscreen)
         if !spaceQueryIndices.isEmpty {
             let membership = PrivateAPI.spaceMembership(forWindows: spaceQueryIndices.map { raws[$0].cgWindowID })
             for i in spaceQueryIndices {
@@ -522,7 +555,8 @@ enum WindowEnumerator {
             onscreen: onscreen,
             spaceless: spaceless,
             spaceOf: spaceOf,
-            expand: expand
+            expand: expand,
+            stageManager: stageManager
         )
         for (i, raw) in raws.enumerated() where resolution.keep[i] {
             let siblings = resolution.siblingIndices[i] ?? []
@@ -633,13 +667,22 @@ enum WindowEnumerator {
     ///   their front window. Brute-only windows matching no AX-listed window
     ///   are kept (e.g. fullscreen windows the public list misses), preserving
     ///   prior behavior.
+    ///
+    /// `stageManager` disables the near-frame rule only: Stage Manager orders
+    /// every off-stage window out, so "ordered out near an ordered-in front" no
+    /// longer implies "tabbed away" and would fold the user's real windows out of
+    /// the switcher (#116 — TextEdit/browser windows cascade ~20–29pt apart, well
+    /// inside `tabFrameTolerance`). The exact-frame brute-only rule is untouched,
+    /// so ordinary native tab groups still collapse while Stage Manager is on;
+    /// only the #81 stale-frame shapes stay expanded until it is turned off.
     static func resolveTabStacks(
         frames: [CGRect?],
         fromAXList: [Bool],
         onscreen: [Bool],
         spaceless: [Bool],
         spaceOf: [UInt64?],
-        expand: Bool
+        expand: Bool,
+        stageManager: Bool = false
     ) -> TabResolution {
         let n = frames.count
         // Exact-frame front: the ordered-in AX-listed window (the visible front
@@ -662,7 +705,7 @@ enum WindowEnumerator {
             var front: Int?
             if !fromAXList[i], let exact = frontForFrame[frameKey(f)], exact != i {
                 front = exact
-            } else if !onscreen[i],
+            } else if !stageManager, !onscreen[i],
                       let near = nearFronts.first(where: { $0 != i && isNearTabFrame(f, frames[$0]!) }),
                       spaceless[i] || (spaceOf[i] != nil && spaceOf[i] == spaceOf[near]) {
                 front = near

--- a/BetterCmdTabTests/TabStackResolutionTests.swift
+++ b/BetterCmdTabTests/TabStackResolutionTests.swift
@@ -28,7 +28,8 @@ struct TabStackResolutionTests {
         onscreen: [Bool]? = nil,
         spaceless: [Bool]? = nil,
         spaceOf: [UInt64?]? = nil,
-        expand: Bool
+        expand: Bool,
+        stageManager: Bool = false
     ) -> WindowEnumerator.TabResolution {
         WindowEnumerator.resolveTabStacks(
             frames: frames,
@@ -36,8 +37,69 @@ struct TabStackResolutionTests {
             onscreen: onscreen ?? fromAXList,
             spaceless: spaceless ?? [Bool](repeating: false, count: frames.count),
             spaceOf: spaceOf ?? [UInt64?](repeating: nil, count: frames.count),
-            expand: expand
+            expand: expand,
+            stageManager: stageManager
         )
+    }
+
+    // MARK: - Stage Manager (#116)
+
+    /// Measured on macOS 26 with Stage Manager on ("show windows one at a
+    /// time"): seven TextEdit windows, identical 586×488, cascaded 15pt apart,
+    /// one on stage and the rest ordered out. Every off-stage window sits inside
+    /// `tabFrameTolerance` of the staged one, so the near-frame rule folds four
+    /// real windows away and the switcher shows 3 rows instead of 7.
+    private var stageManagerCascade: (frames: [CGRect?], onscreen: [Bool]) {
+        let frames: [CGRect?] = (0..<7).map {
+            CGRect(x: 400 + CGFloat($0) * 15, y: 200 + CGFloat($0) * 15, width: 586, height: 488)
+        }
+        // Index 1 is on stage; the rest report their strip tile and are ordered out.
+        return (frames, [false, true, false, false, false, false, false])
+    }
+
+    @Test("Stage Manager: cascaded windows are not folded as tab siblings")
+    func stageManagerKeepsCascadedWindows() {
+        let (frames, onscreen) = stageManagerCascade
+        let r = resolve(
+            frames: frames,
+            fromAXList: [Bool](repeating: true, count: 7),
+            onscreen: onscreen,
+            spaceOf: [UInt64?](repeating: 1, count: 7),
+            expand: false,
+            stageManager: true
+        )
+        #expect(r.keep == [Bool](repeating: true, count: 7))
+        #expect(r.siblingIndices.isEmpty)
+    }
+
+    /// Guards the flag itself: without it the same input loses four windows,
+    /// which is exactly the bug. Documents why the gate has to exist.
+    @Test("without the Stage Manager flag the same cascade loses four windows")
+    func cascadeWouldFoldWithoutStageManagerFlag() {
+        let (frames, onscreen) = stageManagerCascade
+        let r = resolve(
+            frames: frames,
+            fromAXList: [Bool](repeating: true, count: 7),
+            onscreen: onscreen,
+            spaceOf: [UInt64?](repeating: 1, count: 7),
+            expand: false,
+            stageManager: false
+        )
+        #expect(r.keep.filter { $0 }.count == 3)
+    }
+
+    @Test("Stage Manager still collapses ordinary native tab groups")
+    func stageManagerKeepsExactFrameTabCollapse() {
+        // Exact-frame brute-only rule is untouched: front tab + 2 background
+        // tabs at the identical group frame still fold into one row.
+        let r = resolve(
+            frames: [F, F, F],
+            fromAXList: [true, false, false],
+            expand: false,
+            stageManager: true
+        )
+        #expect(r.keep == [true, false, false])
+        #expect(r.siblingIndices[0] == [1, 2])
     }
 
     @Test("expand keeps every window as its own row and flags background tabs")

--- a/BetterCmdTabTests/WindowEnumeratorTests.swift
+++ b/BetterCmdTabTests/WindowEnumeratorTests.swift
@@ -66,4 +66,19 @@ struct WindowEnumeratorTests {
         // A bounds dict missing Width/Height yields 0, which the size gate excludes.
         #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 0, height: 0) == .excluded)
     }
+
+    @Test("Stage Manager: strip-tile sized windows stay normal (#116)")
+    func stageManagerKeepsStripTiles() {
+        // Measured on macOS 26: an off-stage window is reported at ~83×103.
+        // With Stage Manager off that is a junk surface; with it on it is a real
+        // user window and must stay in the CG hint / on-screen set.
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 83, height: 103) == .excluded)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 1.0, width: 83, height: 103, stageManager: true) == .normal)
+    }
+
+    @Test("Stage Manager does not re-admit invisible or overlay windows")
+    func stageManagerKeepsOtherGates() {
+        #expect(WindowEnumerator.cgWindowBucket(layer: 0, alpha: 0.0, width: 83, height: 103, stageManager: true) == .excluded)
+        #expect(WindowEnumerator.cgWindowBucket(layer: 20, alpha: 1.0, width: 83, height: 103, stageManager: true) == .nonNormalLayer)
+    }
 }


### PR DESCRIPTION
Fixes #116.

## Root cause

Stage Manager reports every **off-stage** window to WindowServer at its shrunken
strip-tile geometry, while the Accessibility API keeps reporting the window's
real frame. Measured on macOS 26 with 7 TextEdit windows:

| source | staged window | off-stage windows |
| --- | --- | --- |
| `CGWindowListCopyWindowInfo` | 586×488, on screen | **83×103** at the screen edge, ordered out |
| `AXPosition` / `AXSize` | 586×488 | **586×488** (the real frame) |

Layer stays 0 and alpha stays 1.0 — only the size changes. Two
WindowServer-derived heuristics silently stop holding because of that:

1. **`cgWindowBucket`** — the `width < 100 || height < 100` gate classifies the
   tiles as `.excluded`, so real windows fall out of `expectedCGWindowIDs`,
   `onscreenWids` and `cgZOrder`. `needsBruteScan` then sees full coverage and
   skips the brute-force AX scan; when it does run, `if !expectedCGWindowIDs.contains(wid) { continue }`
   rejects whatever it finds. Any window that only surfaces through the brute
   scan disappears.
2. **`resolveTabStacks`** (the near-frame rule from #81) — because CG no longer
   reports those windows as on screen, they all look "ordered out". The rule
   reads *ordered out + within 50pt of an ordered-in front + same Space* as a
   native background tab, and app windows cascade ~20–29pt apart (TextEdit: 29pt,
   browsers: ~22pt) — well inside `tabFrameTolerance`. Real windows get folded
   away as tab siblings.

**Reproduced on the shipped 26.7-beta.3:** 7 TextEdit windows, panel showed 4 rows.

### Why #122 didn't cover it

That fix guarded the phantom-window filter, which runs on every reveal — so it
correctly fixed step 6 of the report. The remaining loss happens inside
`WindowEnumerator.enumerate` and is baked into the catalog cache, which is why
the reporter sees it only after switching apps (step 7) and why it persists after
turning Stage Manager off until another app switch bumps the pid.

## The fix

One source of truth (`isStageManagerEnabled`, reading the system
`com.apple.WindowManager` / `GloballyEnabled` toggle — verified that a
long-running process observes the toggle changing), wired into both sites:

- the size gate is skipped while Stage Manager is on (alpha and window-level
  gates untouched, so invisible surfaces and Dock-level overlays are still dropped);
- the near-frame tab rule is skipped while Stage Manager is on. The exact-frame
  brute-only rule is untouched, so ordinary native tab groups still collapse —
  only the #81 stale-frame shapes (CotEditor, Sonoma) stay expanded until Stage
  Manager is turned off.

Perf side effect: with Stage Manager on, `tabSpaceQueryIndices` is skipped, which
drops the per-window `CGSCopySpacesForWindows` round-trips that only fed that rule.

## Tests

5 new cases built from the measured numbers, including one that pins the bug
itself (`keep.filter { $0 }.count == 3` without the flag) so it can't regress.
Full suite: **525 tests pass.**

## Not verified

The panel was not exercised against a build containing this change — the Debug
scheme uses a separate bundle ID (`…BetterCmdTab.debug`) and therefore needs its
own Accessibility grant, which can't be given programmatically. Evidence is the
live reproduction of the bug plus unit tests over the measured geometry. For an
end-to-end check: grant Accessibility to the Debug build and follow the steps in
the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
