### PR TITLE
fix: full-screen window visibility and hover dot fixes

### DIFF
--- a/BetterCmdTab/Switcher/HoverActionBar.swift
+++ b/BetterCmdTab/Switcher/HoverActionBar.swift
@@ -182,20 +182,22 @@ final class HoverActionBar: NSView {
     }
 }
 
-/// A single circular traffic-light dot. The circle is custom-drawn; the
-/// glyph rides as a centered `NSImageView` so AppKit aligns the symbol's
-/// actual cap-height optical center to the dot center (manually computing
-/// `bounds.midX - gs.width/2` lands the bbox center, not the visual center
-/// — SF Symbols ship with asymmetric ascender/descender padding that
-/// shifted every glyph half a pixel off-center). Re-rendering the symbol on
-/// each resize keeps it sharp at every switcher scale.
+/// A single circular traffic-light dot. Circle and glyph are both custom-drawn:
+/// the symbol image is centered on the circle's own center, which an
+/// `NSImageView` could not do — Auto Layout gave the hosted view a non-square
+/// frame (17.5pt tall in a 21pt dot), so `.alignCenter` centered the glyph in
+/// that box and pushed `plus` visibly up and right. SF Symbol images are
+/// ink-centered in their own bounds (measured), so centering the image rect is
+/// exact. Re-rendering the symbol on each resize keeps it sharp at every
+/// switcher scale.
 @MainActor
 final class TrafficLightDot: NSView {
     let action: RowAction
 
     private let fillColor: NSColor
     private let symbolName: String
-    private let glyphView = NSImageView()
+    private var glyph: NSImage?
+    private var glyphHeight: CGFloat = 0
     var isHot = false { didSet { if oldValue != isHot { needsDisplay = true } } }
 
     init(action: RowAction, color: NSColor, symbol: String, tooltip: String) {
@@ -204,18 +206,6 @@ final class TrafficLightDot: NSView {
         self.symbolName = symbol
         super.init(frame: NSRect(x: 0, y: 0, width: HoverActionBar.baseDotSize, height: HoverActionBar.baseDotSize))
         toolTip = tooltip
-
-        glyphView.translatesAutoresizingMaskIntoConstraints = false
-        glyphView.imageScaling = .scaleProportionallyDown
-        glyphView.imageAlignment = .alignCenter
-        addSubview(glyphView)
-        NSLayoutConstraint.activate([
-            glyphView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            glyphView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            glyphView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.62),
-            glyphView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 0.62),
-        ])
-        rebuildGlyph(for: bounds.height)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
@@ -224,19 +214,17 @@ final class TrafficLightDot: NSView {
         NSSize(width: HoverActionBar.baseDotSize, height: HoverActionBar.baseDotSize)
     }
 
-    override func layout() {
-        super.layout()
-        rebuildGlyph(for: bounds.height)
-    }
-
     /// SF Symbol's point size is what determines stroke weight — set it from
     /// the live dot height so the glyph keeps its proportional weight at
     /// every panel scale, instead of staying glued to the base 8pt size.
+    /// Memoized on the height it was rendered for, so redraws (hover) are free.
     private func rebuildGlyph(for dotHeight: CGFloat) {
+        guard glyphHeight != dotHeight else { return }
+        glyphHeight = dotHeight
         let pointSize = max(6, round(dotHeight * 0.55))
         let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .bold)
             .applying(.init(paletteColors: [NSColor.black.withAlphaComponent(0.65)]))
-        glyphView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+        glyph = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
             .withSymbolConfiguration(cfg)
     }
 
@@ -251,5 +239,35 @@ final class TrafficLightDot: NSView {
         NSColor.black.withAlphaComponent(isHot ? 0.28 : 0.18).setStroke()
         path.lineWidth = isHot ? 0.75 : 0.5
         path.stroke()
+
+        rebuildGlyph(for: d)
+        guard let glyph, glyph.size.width > 0, glyph.size.height > 0 else { return }
+        glyph.draw(in: Self.glyphRect(
+            in: circle,
+            imageSize: glyph.size,
+            backingScale: window?.backingScaleFactor ?? 2
+        ))
+    }
+
+    /// Where the symbol is drawn inside `circle`: its own aspect, fitted to 62%
+    /// of the diameter (never upscaled), centered — then snapped to the backing
+    /// pixel grid. Without the snap the glyph lands on fractional pixels and
+    /// rasterizes asymmetrically: measured 1 backing pixel high-and-left on a
+    /// 14pt dot, which is exactly what made `plus` look off-center in its dot.
+    /// Size is rounded before the origin so the rect stays symmetric about the
+    /// circle's center. Pure, so it is unit-testable.
+    nonisolated static func glyphRect(in circle: NSRect, imageSize: NSSize, backingScale: CGFloat) -> NSRect {
+        let d = min(circle.width, circle.height)
+        let box = d * 0.62
+        let k = min(box / imageSize.width, box / imageSize.height, 1)
+        let s = max(1, backingScale)
+        let w = (imageSize.width * k * s).rounded() / s
+        let h = (imageSize.height * k * s).rounded() / s
+        return NSRect(
+            x: ((circle.midX - w / 2) * s).rounded() / s,
+            y: ((circle.midY - h / 2) * s).rounded() / s,
+            width: w,
+            height: h
+        )
     }
 }

--- a/BetterCmdTab/System/PrivateAPIs.swift
+++ b/BetterCmdTab/System/PrivateAPIs.swift
@@ -151,21 +151,50 @@ enum PrivateAPI {
 
     /// The Spaces currently on screen: each display's "Current Space" from
     /// `CGSCopyManagedDisplaySpaces` (#57 — the "visible Spaces" switcher
-    /// filter). One id per connected display; a single-monitor setup yields the
-    /// same id as `activeSpace()`. Empty when the private API is unavailable —
-    /// callers must treat that as "unknown" and degrade, same as a nil
-    /// `activeSpace()`. One CGS round-trip, no per-window IPC.
+    /// filter), *plus the Spaces grouped with it* (see `spaceGroup`). A
+    /// single-monitor setup with no full-screen app yields the same id as
+    /// `activeSpace()`. Empty when the private API is unavailable — callers must
+    /// treat that as "unknown" and degrade, same as a nil `activeSpace()`. One
+    /// CGS round-trip, no per-window IPC.
     static func visibleSpaces() -> Set<UInt64> {
         guard let mainConnection = mainConnectionFn,
               let copyDisplays = copyManagedDisplaySpacesFn,
               let cfDisplays = copyDisplays(mainConnection())?.takeRetainedValue() else { return [] }
         var spaces = Set<UInt64>()
         for display in (cfDisplays as NSArray).compactMap({ $0 as? [String: Any] }) {
-            if let current = display["Current Space"] as? [String: Any], let id = spaceId(current) {
-                spaces.insert(id)
+            guard let current = display["Current Space"] as? [String: Any], let id = spaceId(current) else { continue }
+            let ordered = ((display["Spaces"] as? [[String: Any]]) ?? []).compactMap { dict -> (id: UInt64, isDesktop: Bool)? in
+                guard let spaceId = spaceId(dict) else { return nil }
+                return (spaceId, ((dict["type"] as? NSNumber)?.intValue ?? 0) == 0)
             }
+            spaces.formUnion(spaceGroup(containing: id, orderedSpaces: ordered))
         }
         return spaces
+    }
+
+    /// The Spaces that share a display "place" with `current`: a desktop Space
+    /// and the full-screen/tiled Spaces created from it, which WindowServer
+    /// lists right after it in the display's ordered `Spaces` array.
+    ///
+    /// Going full screen must not empty the switcher: the desktop underneath is
+    /// no longer WindowServer-visible, so a literal per-display "Current Space"
+    /// hid every other window while a full-screen app was focused — and hid the
+    /// full-screen window itself while its desktop was focused. Grouping the two
+    /// makes "Visible Spaces" mean "this desktop, however it's being shown".
+    ///
+    /// Pure, so the grouping is unit-testable. Falls back to `[current]` when the
+    /// display's Space list is missing or doesn't contain it.
+    static func spaceGroup(containing current: UInt64, orderedSpaces: [(id: UInt64, isDesktop: Bool)]) -> Set<UInt64> {
+        var group: [UInt64] = []
+        for space in orderedSpaces {
+            if space.isDesktop {
+                if group.contains(current) { break }
+                group = [space.id]
+            } else {
+                group.append(space.id)
+            }
+        }
+        return group.contains(current) ? Set(group) : [current]
     }
 
     /// The CoreGraphics display id of the monitor whose menu bar is currently

--- a/BetterCmdTab/Windows/Activator.swift
+++ b/BetterCmdTab/Windows/Activator.swift
@@ -881,7 +881,13 @@ enum Activator {
 
     /// Zoom (green-button maximize) the row's window by pressing its AX zoom
     /// button. Apps without a zoom button (some dialogs/utilities) are no-ops.
+    ///
+    /// A full-screen window still exposes an `AXZoomButton` whose `AXPress`
+    /// reports success and does nothing, so the hover dot looked dead on exactly
+    /// the window the user wants to restore. Route that case through the
+    /// `AXFullScreen` write instead, which does leave full screen.
     static func zoomWindow(_ row: SwitcherRow) {
+        if row.isFullscreen { return toggleFullscreen(row) }
         guard let window = row.window, let app = row.app else { return }
         let apply: @Sendable () -> Void = {
             var buttonValue: AnyObject?

--- a/BetterCmdTab/Windows/WindowEnumerator.swift
+++ b/BetterCmdTab/Windows/WindowEnumerator.swift
@@ -521,8 +521,8 @@ enum WindowEnumerator {
         // #81) — a background tab left at its stale pre-merge frame
         // (CotEditor), or AX-listed on macOS builds that list every tab window
         // (Sonoma) — are caught by the near-frame rule: ordered out near an
-        // ordered-in front's frame and spaceless / on the front's own Space.
-        // Ordered-in windows and windows on another Space are never folded.
+        // ordered-in front's frame and reported spaceless. Ordered-in windows
+        // and windows that resolve to a Space are never folded (#148).
         // Collapse keeps the front tab and attaches the rest as `tabWindows`
         // for the `\` peek; expand emits one row per tab. No reliance on
         // `AXTabs` (which these apps don't expose).
@@ -531,11 +531,9 @@ enum WindowEnumerator {
         let fromAXList = raws.map(\.fromAXList)
         let onscreen = raws.map { onscreenWids.contains($0.cgWindowID) }
         // Space membership is one WindowServer IPC per window, so resolve it
-        // only for the windows the near-frame tab rule can act on (plus their
-        // on-screen fronts, for the same-Space comparison). Empty for apps
-        // without a tab-shaped group — the common case pays nothing.
+        // only for the windows the near-frame tab rule can act on. Empty for
+        // apps without a tab-shaped group — the common case pays nothing.
         var spaceless = [Bool](repeating: false, count: raws.count)
-        var spaceOf = [UInt64?](repeating: nil, count: raws.count)
         // Under Stage Manager the near-frame rule is off (see `isStageManagerEnabled`),
         // so skip the per-window Space IPCs that only feed it.
         let stageManager = isStageManagerEnabled
@@ -546,7 +544,6 @@ enum WindowEnumerator {
             let membership = PrivateAPI.spaceMembership(forWindows: spaceQueryIndices.map { raws[$0].cgWindowID })
             for i in spaceQueryIndices {
                 spaceless[i] = membership.spaceless.contains(raws[i].cgWindowID)
-                spaceOf[i] = membership.resolved[raws[i].cgWindowID]
             }
         }
         let resolution = resolveTabStacks(
@@ -554,7 +551,6 @@ enum WindowEnumerator {
             fromAXList: fromAXList,
             onscreen: onscreen,
             spaceless: spaceless,
-            spaceOf: spaceOf,
             expand: expand,
             stageManager: stageManager
         )
@@ -616,8 +612,7 @@ enum WindowEnumerator {
     /// windows sitting near an ordered-in AX-listed window's frame that the
     /// exact-frame brute rule alone can't classify (AX-listed ones — the
     /// Sonoma shape — and brute-only ones whose stale frame drifted off the
-    /// group's, the CotEditor shape), plus the ordered-in fronts themselves
-    /// (for the same-Space comparison). Empty — the common case — means the
+    /// group's, the CotEditor shape). Empty — the common case — means the
     /// caller skips the per-window `CGSCopySpacesForWindows` IPCs entirely.
     /// Pure, so the gate is unit-testable.
     static func tabSpaceQueryIndices(frames: [CGRect?], fromAXList: [Bool], onscreen: [Bool]) -> [Int] {
@@ -631,15 +626,13 @@ enum WindowEnumerator {
             if let f = frames[i] { axFrames.insert(frameKey(f)) }
         }
         var indices: [Int] = []
-        var neededFronts = Set<Int>()
         for i in 0..<n where !onscreen[i] {
             guard let f = frames[i] else { continue }
             if !fromAXList[i] && axFrames.contains(frameKey(f)) { continue }
-            guard let front = fronts.first(where: { isNearTabFrame(f, frames[$0]!) }) else { continue }
+            guard fronts.contains(where: { isNearTabFrame(f, frames[$0]!) }) else { continue }
             indices.append(i)
-            neededFronts.insert(front)
         }
-        return indices.isEmpty ? [] : indices + neededFronts.sorted()
+        return indices
     }
 
     /// Decide which windows to surface and which are native background tabs.
@@ -653,13 +646,15 @@ enum WindowEnumerator {
     ///   windows are both AX-listed, so issue #10 stays safe. Or:
     /// - it is ordered out (`onscreen[i] == false`) *near* an ordered-in
     ///   AX-listed front's frame (same size, origin within
-    ///   `tabFrameTolerance`), and WindowServer reports it spaceless or on the
-    ///   front's own Space. This catches the shapes the exact rule misses
-    ///   (issue #81): apps that leave a background tab's frame at its stale
-    ///   pre-merge cascade offset (CotEditor), and macOS builds that AX-list
-    ///   every tab window (Sonoma). Ordered-in windows (real overlapping
-    ///   windows, issue #10) and windows resolved to a *different* Space (a
-    ///   same-frame window on another desktop) are never folded.
+    ///   `tabFrameTolerance`) and WindowServer reports it *spaceless*. This
+    ///   catches the shapes the exact rule misses (issue #81): apps that leave
+    ///   a background tab's frame at its stale pre-merge cascade offset
+    ///   (CotEditor), and macOS builds that AX-list every tab window (Sonoma).
+    ///   Ordered-in windows (real overlapping windows, issue #10) and windows
+    ///   that resolve to *any* Space are never folded — a real window mid
+    ///   fullscreen-exit is briefly ordered out at a cascade-near frame while
+    ///   still resolving to the current Space, and folding it dropped it from
+    ///   the switcher until an unrelated event re-scanned the app (issue #148).
     ///
     /// - expand: every window is kept as its own row (one entry per tab);
     ///   background tabs are flagged `tabSibling` instead of folded.
@@ -680,7 +675,6 @@ enum WindowEnumerator {
         fromAXList: [Bool],
         onscreen: [Bool],
         spaceless: [Bool],
-        spaceOf: [UInt64?],
         expand: Bool,
         stageManager: Bool = false
     ) -> TabResolution {
@@ -705,9 +699,8 @@ enum WindowEnumerator {
             var front: Int?
             if !fromAXList[i], let exact = frontForFrame[frameKey(f)], exact != i {
                 front = exact
-            } else if !stageManager, !onscreen[i],
-                      let near = nearFronts.first(where: { $0 != i && isNearTabFrame(f, frames[$0]!) }),
-                      spaceless[i] || (spaceOf[i] != nil && spaceOf[i] == spaceOf[near]) {
+            } else if !stageManager, !onscreen[i], spaceless[i],
+                      let near = nearFronts.first(where: { $0 != i && isNearTabFrame(f, frames[$0]!) }) {
                 front = near
             }
             if let front {

--- a/BetterCmdTabTests/SpaceGroupTests.swift
+++ b/BetterCmdTabTests/SpaceGroupTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import BetterCmdTab
+
+/// A display's desktop Space and the full-screen Spaces created from it are one
+/// "place" for the Visible Spaces scope: going full screen must not hide the
+/// desktop's windows from the switcher, and a full-screen window must not
+/// disappear while its desktop is focused.
+@Suite("Space grouping")
+struct SpaceGroupTests {
+    /// [Desktop 1, full-screen] — the shape WindowServer reports for one
+    /// full-screen app on a single-desktop display.
+    private let oneDesktopWithFullscreen: [(id: UInt64, isDesktop: Bool)] = [(1, true), (87, false)]
+
+    @Test("full-screen Space groups with the desktop it was created from")
+    func fullscreenGroupsWithItsDesktop() {
+        #expect(PrivateAPI.spaceGroup(containing: 87, orderedSpaces: oneDesktopWithFullscreen) == [1, 87])
+        #expect(PrivateAPI.spaceGroup(containing: 1, orderedSpaces: oneDesktopWithFullscreen) == [1, 87])
+    }
+
+    @Test("another desktop's Spaces stay out of the group")
+    func otherDesktopsExcluded() {
+        // [Desktop 1, full screen from it, Desktop 2, full screen from Desktop 2]
+        let spaces: [(id: UInt64, isDesktop: Bool)] = [(1, true), (87, false), (2, true), (88, false)]
+        #expect(PrivateAPI.spaceGroup(containing: 1, orderedSpaces: spaces) == [1, 87])
+        #expect(PrivateAPI.spaceGroup(containing: 87, orderedSpaces: spaces) == [1, 87])
+        #expect(PrivateAPI.spaceGroup(containing: 2, orderedSpaces: spaces) == [2, 88])
+        #expect(PrivateAPI.spaceGroup(containing: 88, orderedSpaces: spaces) == [2, 88])
+    }
+
+    @Test("unknown or missing Space list falls back to the Space itself")
+    func fallsBackToCurrent() {
+        #expect(PrivateAPI.spaceGroup(containing: 5, orderedSpaces: []) == [5])
+        #expect(PrivateAPI.spaceGroup(containing: 5, orderedSpaces: oneDesktopWithFullscreen) == [5])
+    }
+}

--- a/BetterCmdTabTests/SwitcherMetricsTests.swift
+++ b/BetterCmdTabTests/SwitcherMetricsTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Testing
 @testable import BetterCmdTab
@@ -81,6 +82,35 @@ struct SwitcherMetricsTests {
         #expect(many.appNameWidth == expected)
         // The reserved column is added back to the row width vs the no-hover collapse.
         #expect(many.rowWidth == SwitcherMetrics.baseRowWidth - SwitcherMetrics.baseAppNameWidth + expected)
+    }
+
+    @Test("traffic-light glyph is centered on its dot and lands on the pixel grid")
+    func hoverDotGlyphCentering() {
+        // `plus` renders as a non-square image (13x12 at its 21pt dot size). The
+        // old NSImageView hosting centered it in a non-square layout box, which
+        // pushed the glyph visibly up and right inside the green circle.
+        for d in [CGFloat(14), 16, 17, 21, 28] {
+            let circle = NSRect(x: 0, y: 0, width: d, height: d).insetBy(dx: 0.5, dy: 0.5)
+            let r = TrafficLightDot.glyphRect(in: circle, imageSize: NSSize(width: 13, height: 12), backingScale: 2)
+            // Centered to within half a device pixel — exact whenever the
+            // fitted size is an even number of pixels, off by that half when
+            // it isn't (the grid snap wins there: it rasterizes symmetrically,
+            // a mathematically-centered fractional rect does not).
+            #expect(abs(r.midX - circle.midX) <= 0.25)
+            #expect(abs(r.midY - circle.midY) <= 0.25)
+            #expect(r.width <= circle.width * 0.62 + 0.5)
+            // On the backing grid: every edge is a whole device pixel.
+            for v in [r.minX, r.minY, r.width, r.height] {
+                #expect(abs((v * 2).rounded() - v * 2) < 0.001)
+            }
+        }
+    }
+
+    @Test("a glyph smaller than its box is never upscaled")
+    func hoverDotGlyphNoUpscale() {
+        let circle = NSRect(x: 0, y: 0, width: 40, height: 40)
+        let r = TrafficLightDot.glyphRect(in: circle, imageSize: NSSize(width: 9, height: 8), backingScale: 2)
+        #expect(r.size == NSSize(width: 9, height: 8))
     }
 
     @Test("preview label area collapses to 0 whenever the window title is hidden")

--- a/BetterCmdTabTests/TabStackResolutionTests.swift
+++ b/BetterCmdTabTests/TabStackResolutionTests.swift
@@ -27,7 +27,6 @@ struct TabStackResolutionTests {
         fromAXList: [Bool],
         onscreen: [Bool]? = nil,
         spaceless: [Bool]? = nil,
-        spaceOf: [UInt64?]? = nil,
         expand: Bool,
         stageManager: Bool = false
     ) -> WindowEnumerator.TabResolution {
@@ -36,7 +35,6 @@ struct TabStackResolutionTests {
             fromAXList: fromAXList,
             onscreen: onscreen ?? fromAXList,
             spaceless: spaceless ?? [Bool](repeating: false, count: frames.count),
-            spaceOf: spaceOf ?? [UInt64?](repeating: nil, count: frames.count),
             expand: expand,
             stageManager: stageManager
         )
@@ -64,7 +62,7 @@ struct TabStackResolutionTests {
             frames: frames,
             fromAXList: [Bool](repeating: true, count: 7),
             onscreen: onscreen,
-            spaceOf: [UInt64?](repeating: 1, count: 7),
+            spaceless: [Bool](repeating: true, count: 7),
             expand: false,
             stageManager: true
         )
@@ -81,7 +79,7 @@ struct TabStackResolutionTests {
             frames: frames,
             fromAXList: [Bool](repeating: true, count: 7),
             onscreen: onscreen,
-            spaceOf: [UInt64?](repeating: 1, count: 7),
+            spaceless: [Bool](repeating: true, count: 7),
             expand: false,
             stageManager: false
         )
@@ -174,43 +172,15 @@ struct TabStackResolutionTests {
         #expect(r.siblingIndices[0] == [1, 2])
     }
 
-    @Test("collapse folds an ordered-out tab resolved to the front's Space")
-    func collapseFoldsSameSpaceTab() {
-        // Variant: WindowServer maps the tabbed-away window to the group's own
-        // Space instead of reporting it spaceless.
+    @Test("a window mid fullscreen-exit is never folded (issue #148)")
+    func fullscreenExitWindowKept() {
+        // Measured on macOS 26: for ~50-100ms after leaving full screen the
+        // returning window is back in the AX list but still ordered out, at its
+        // restored frame — 29pt from a cascaded sibling, inside the tolerance —
+        // and WindowServer resolves it to the current Space. Folding it dropped
+        // it from the switcher until an unrelated event re-scanned the app.
         let r = resolve(
             frames: [F, Fstale],
-            fromAXList: [true, false],
-            onscreen: [true, false],
-            spaceOf: [2, 2],
-            expand: false
-        )
-        #expect(r.keep == [true, false])
-        #expect(r.siblingIndices[0] == [1])
-    }
-
-    @Test("an ordered-out window on a DIFFERENT Space is never folded")
-    func otherSpaceWindowKept() {
-        // Two same-frame windows on two desktops (e.g. both maximized): the
-        // off-Space one is ordered out but resolves to its own Space — a real
-        // window, not a tab.
-        let r = resolve(
-            frames: [F, F],
-            fromAXList: [true, true],
-            onscreen: [true, false],
-            spaceOf: [2, 3],
-            expand: false
-        )
-        #expect(r.keep == [true, true])
-        #expect(r.siblingIndices.isEmpty)
-    }
-
-    @Test("an ordered-out AX-listed window with unresolved Space is never folded")
-    func unresolvedSpaceWindowKept() {
-        // Sticky (All Desktops) or failed query: neither spaceless nor
-        // resolved — keep it, the fold only acts on positive signals.
-        let r = resolve(
-            frames: [F, F],
             fromAXList: [true, true],
             onscreen: [true, false],
             expand: false
@@ -368,24 +338,24 @@ struct TabStackResolutionTests {
         #expect(indices.isEmpty)
     }
 
-    @Test("Space query covers stale-frame brute candidates plus their front")
+    @Test("Space query covers stale-frame brute candidates only")
     func queryCoversStaleFrameCandidates() {
         let indices = WindowEnumerator.tabSpaceQueryIndices(
             frames: [F, Fstale, Fstale, G],
             fromAXList: [true, false, false, true],
             onscreen: [true, false, false, true]
         )
-        #expect(Set(indices) == [0, 1, 2])
+        #expect(indices == [1, 2])
     }
 
-    @Test("Space query covers ordered-out AX-listed candidates plus their front")
+    @Test("Space query covers ordered-out AX-listed candidates only")
     func queryCoversAXListedCandidates() {
         let indices = WindowEnumerator.tabSpaceQueryIndices(
             frames: [F, F, F, G],
             fromAXList: [true, true, true, true],
             onscreen: [true, false, false, true]
         )
-        #expect(Set(indices) == [0, 1, 2])
+        #expect(indices == [1, 2])
     }
 
     @Test("no Space query without an ordered-in front at the frame (hidden app)")


### PR DESCRIPTION
Four fixes around full screen and the hover action dots.

### Fixed
- A window returning from full screen no longer disappears from the switcher until the next unrelated re-scan (#148). The near-frame tab rule now folds only windows WindowServer reports *spaceless* — a real window always resolves to a Space, a background tab never does. Also removes the per-front Space IPCs the old same-Space comparison needed.
- Under **Visible Spaces**, a full-screen app no longer hides the windows of the desktop it came from, and a full-screen window no longer disappears while its desktop is focused. Each desktop is grouped with the full-screen Spaces WindowServer lists after it.
- Clicking the green hover dot on a full-screen window leaves full screen instead of doing nothing (its `AXZoomButton` press reports success and has no effect).
- The `plus` glyph is centered in its green dot — it was hosted in an `NSImageView` whose Auto Layout frame came out non-square, and landed a backing pixel off the grid on top of that.

### Testing
- `xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test` — 538 tests pass, including new cases for the Space grouping, the tab-fold rule, and the glyph rect.
- Verified live: windows list correctly from inside and outside a full-screen Space, and the hover dot round-trips a window in and out of full screen (confirmed via the app's own activator log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)