### PR TITLE
fix: stop direct-activation shortcuts dying after the first chord (#120)

### DIFF
--- a/BetterCmdTab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BetterCmdTab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rokartur/BetterShortcuts.git",
       "state" : {
-        "revision" : "1709519d34a08ef667f32d378ff74d59e551976b",
-        "version" : "0.3.4"
+        "revision" : "f978759561fe3a7defe5b1cc998f5ba872c99746",
+        "version" : "0.3.6"
       }
     },
     {


### PR DESCRIPTION
Bumps BetterShortcuts to **0.3.6**, fixing the hot key modifier guard added in 0.3.4 — which is what `26.7-beta.3` currently ships.

## The regression

0.3.4 validated a firing hot key against `GetCurrentEventKeyModifiers()`. That API reports the modifiers of the last event pulled from the **app's event queue**, and hot key events never refresh it — in a background `.accessory` app it freezes at whatever chord it happened to see first.

Measured in a standalone Carbon probe with two registrations (`⌃1`, `⌥2`), running both guards over the same events:

```
⌥2 first   old=FIRE       new=FIRE
⌃1 second  old=SWALLOWED  new=FIRE      ← legitimate press killed by 0.3.4
⌥2 third   old=FIRE       new=FIRE
```

On beta-3 that means the *second distinct* direct-activation chord you press stops working for the rest of the session.

## What 0.3.5 + 0.3.6 change

- Read `GetCurrentKeyModifiers()` — the live hardware state — instead of the frozen event-queue value.
- Reject only when a modifier the registration never asked for is held. A *missing* modifier no longer rejects: the handler runs a moment after the press, and the probe caught a run where the live state already read empty while the hot key was genuinely firing, which the old equality rule would have swallowed.
- Clear a stranded suppression on the next accepted press. Carbon doesn't guarantee a release for every press, so a rejected key-down could otherwise leave its ID behind and eat the key-up of a later legitimate press (`onKeyUp` clients only — nothing in this app attaches one today).
- Side-specific modifier bits stay out of the validated mask: `GetCurrentKeyModifiers()` reports the generic bit for either side, so a stray side bit is ignored rather than read as an extra modifier that would reject the press.

The guard itself stays — Carbon identifies a hot key only by registration ID, so a notification arriving with a foreign modifier held is still refused.

## Verification

- BetterShortcuts: 49 tests pass, including the `⌥`-held-while-`⌃`-registered case from #120 and a new "missing modifier still fires" case.
- BetterCmdTab: Debug build + full suite (538 tests) pass; Release build succeeds.

## This does not close #120

The same probe shows `RegisterEventHotKey` matching is exact on a stock Mac — a `⌃1` registration fired on neither `⌥1` nor `⌃⌥1`. Carbon does not alias modifiers, so the reported `⌥`-digit triggering a `⌃`-digit slot originates in the reporter's remap stack, and #120 stays open pending their answer. Worth recording: the original guard never reached them either — `26.7-beta.2` pins BetterShortcuts 0.3.3, and the 0.3.4 bump only landed in beta-3.

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)