### PR TITLE
fix: keep a scoped panel alive while stepped by repeat chord press

### DIFF
--- a/BetterCmdTab/Switcher/SwitcherController.swift
+++ b/BetterCmdTab/Switcher/SwitcherController.swift
@@ -1965,7 +1965,12 @@ final class SwitcherController: SwitcherViewDelegate {
         guard phase == .idle else {
             if case .scoped(let activeId) = activeTarget, activeId == id,
                phase == .visible, !tabDrillActive {
-                advanceLinearVisible(by: 1, wrap: true)
+                // Through `handle`, not `advanceLinearVisible` directly (identical
+                // step at `.visible`): the chokepoint stamps `lastVisibleActivity`,
+                // so a user stepping *only* by repeat chord press isn't read as an
+                // abandoned panel and force-closed after 4s under Secure Event
+                // Input (issue #16's ceiling).
+                handle(.nextApp)
             }
             return
         }


### PR DESCRIPTION
A scoped profile chord (e.g. an ⌥Tab profile) steps its own panel from
the Carbon hotkey handler — the chord never reaches the panel as a
keyDown, so `openScoped` advances the selection itself. That path bypassed
`handle`, the chokepoint where `noteSteeringActivity` stamps
`lastVisibleActivity`.

Under Secure Event Input — or inside the 8s latch window after it clears —
`visibleReleaseBackstopFired` force-closes a `.visible` panel that has gone
`visibleStrandCeiling` (4s) without steering. A user holding ⌥ and tapping
Tab to browse an ⌥Tab profile therefore looked abandoned and had the panel
pulled out from under them mid-decision, despite steering it the only way
that chord can.

Route the repeat step through `handle(.nextApp)`. At `.visible` that
resolves to the same `advanceLinearVisible(by: 1, wrap: true)`, so the
stepping behavior is byte-for-byte what it was, and the stamp can no longer
be missed. The `!tabDrillActive` guard stays, so a repeat press while
drilled still doesn't step the app list under the strip.

Follow-up to the scoped release-to-commit work in #130 (`0c2c643`,
`55e2f44`). No behavior change outside a scoped session under secure input.

## Testing

`xcodebuild -scheme "BetterCmdTab Debug" -destination 'platform=macOS' test`
— 540 tests in 63 suites pass. No new pure logic to cover: the change
re-routes an existing call through an existing chokepoint, and the
force-close gate (`shouldForceCloseStrandedVisible`) is already tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)