### PR TITLE
feat: make the selection color configurable (#185)

### DIFF
--- a/BetterCmdTab/App/ConfigSchemaDocs.swift
+++ b/BetterCmdTab/App/ConfigSchemaDocs.swift
@@ -277,6 +277,12 @@ enum ConfigSchemaDocs {
         "backdropMaterial": ConfigSettingDoc(
             "string", "Blur material behind the rows. Ignored by the macOS 26 glass backdrop.",
             values: ConfigValues(BackdropMaterial.self, \.displayName)),
+        "selectionColor": ConfigSettingDoc(
+            "string", "Color of the selection highlight and the quick-jump letters. \"system\" follows the macOS accent; \"custom\" uses selectionColorHex.",
+            values: ConfigValues(SwitcherSelectionColor.self, \.displayName)),
+        "selectionColorHex": ConfigSettingDoc(
+            "string", "Selection color used when selectionColor is \"custom\", as #RRGGBB. Falls back to the macOS accent when absent or malformed.",
+            pattern: "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$"),
         "animationsEnabled": ConfigSettingDoc(
             "boolean",
             "Glide the panel, the tiles and the tab strip between states. "

--- a/BetterCmdTab/App/ConfigSchemaDocs.swift
+++ b/BetterCmdTab/App/ConfigSchemaDocs.swift
@@ -278,7 +278,7 @@ enum ConfigSchemaDocs {
             "string", "Blur material behind the rows. Ignored by the macOS 26 glass backdrop.",
             values: ConfigValues(BackdropMaterial.self, \.displayName)),
         "selectionColor": ConfigSettingDoc(
-            "string", "Color of the selection highlight and the quick-jump letters. \"system\" follows the macOS accent; \"custom\" uses selectionColorHex.",
+            "string", "Color of the selection highlight and the quick-jump letters. \"transparent\" (the default) leaves the highlight colorless and tints only the quick-jump letters; \"system\" follows the macOS accent; \"custom\" uses selectionColorHex.",
             values: ConfigValues(SwitcherSelectionColor.self, \.displayName)),
         "selectionColorHex": ConfigSettingDoc(
             "string", "Selection color used when selectionColor is \"custom\", as #RRGGBB. Falls back to the macOS accent when absent or malformed.",

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -111,6 +111,98 @@ enum SearchDismissMode: String, CaseIterable {
     }
 }
 
+/// Color of the switcher's selection highlight — the filled row in List, the
+/// tinted plate and its border in Grid and Window previews — and the
+/// type-to-jump letter prefix (#185). `.system` follows the user's macOS accent
+/// (`controlAccentColor`) so the switcher matches the rest of the OS; the fixed
+/// cases exist for the accents that disappear against a busy wallpaper or a
+/// screen full of same-colored windows, which is the whole complaint in #185.
+enum SwitcherSelectionColor: String, CaseIterable {
+    /// Follows the macOS accent color. Default.
+    case system
+    case blue
+    case purple
+    case pink
+    case red
+    case orange
+    case yellow
+    case green
+    case graphite
+    /// User-supplied color; the value lives in `Preferences.selectionColorHex`.
+    /// Resolve via `Preferences.shared.resolvedSelectionColor`, not `resolved`,
+    /// so the hex is read on the main actor.
+    case custom
+
+    var displayName: String {
+        switch self {
+        case .system: return String(localized: "macOS accent")
+        case .blue: return String(localized: "Blue")
+        case .purple: return String(localized: "Purple")
+        case .pink: return String(localized: "Pink")
+        case .red: return String(localized: "Red")
+        case .orange: return String(localized: "Orange")
+        case .yellow: return String(localized: "Yellow")
+        case .green: return String(localized: "Green")
+        case .graphite: return String(localized: "Graphite")
+        case .custom: return String(localized: "Custom…")
+        }
+    }
+
+    /// Fixed color, or `nil` when the choice tracks the system accent or is custom.
+    var color: NSColor? {
+        switch self {
+        case .system, .custom: return nil
+        case .blue: return .systemBlue
+        case .purple: return .systemPurple
+        case .pink: return .systemPink
+        case .red: return .systemRed
+        case .orange: return .systemOrange
+        case .yellow: return .systemYellow
+        case .green: return .systemGreen
+        case .graphite: return .systemGray
+        }
+    }
+
+    /// The concrete color to draw with right now. Resolving `.system` lazily
+    /// keeps it appearance-reactive (light/dark) like the rest of AppKit. For
+    /// `.custom` this falls back to the system accent — use
+    /// `Preferences.shared.resolvedSelectionColor` to honor the stored hex.
+    var resolved: NSColor { color ?? .controlAccentColor }
+}
+
+extension NSColor {
+    /// Parses `#RRGGBB` / `RRGGBB` (and the 8-digit `#RRGGBBAA` form). Returns
+    /// `nil` for malformed input so callers can fall back to a default.
+    convenience init?(hexString: String) {
+        var hex = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") { hex.removeFirst() }
+        guard hex.count == 6 || hex.count == 8,
+              let value = UInt64(hex, radix: 16) else { return nil }
+        let r, g, b, a: CGFloat
+        if hex.count == 8 {
+            r = CGFloat((value >> 24) & 0xFF) / 255
+            g = CGFloat((value >> 16) & 0xFF) / 255
+            b = CGFloat((value >> 8) & 0xFF) / 255
+            a = CGFloat(value & 0xFF) / 255
+        } else {
+            r = CGFloat((value >> 16) & 0xFF) / 255
+            g = CGFloat((value >> 8) & 0xFF) / 255
+            b = CGFloat(value & 0xFF) / 255
+            a = 1
+        }
+        self.init(srgbRed: r, green: g, blue: b, alpha: a)
+    }
+
+    /// `#RRGGBB` string in the sRGB space; nil if the color can't be converted.
+    var hexString: String? {
+        guard let rgb = usingColorSpace(.sRGB) else { return nil }
+        let r = Int(round(rgb.redComponent * 255))
+        let g = Int(round(rgb.greenComponent * 255))
+        let b = Int(round(rgb.blueComponent * 255))
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}
+
 /// Background material for the switcher panel (the blur behind the rows). Maps to
 /// an `NSVisualEffectView.Material`; the macOS 26 glass backdrop ignores it.
 enum BackdropMaterial: String, CaseIterable {
@@ -841,6 +933,12 @@ final class Preferences: ObservableObject {
         static let panelCornerRadius = "Switcher.panelCornerRadius"
         static let listWidthPercent = "Switcher.listWidthPercent"
         static let backdropMaterial = "Switcher.backdropMaterial"
+        /// `SwitcherSelectionColor` raw value — the selection highlight color (#185).
+        /// Deliberately not the retired `Switcher.accentChoice`: that key is
+        /// scrubbed at launch, so reusing it would delete the setting.
+        static let selectionColor = "Switcher.selectionColor"
+        /// `#RRGGBB` behind `SwitcherSelectionColor.custom`.
+        static let selectionColorHex = "Switcher.selectionColorHex"
         /// Legacy pre-#57 bool ("only current Space"). Still written (in sync
         /// with `spaceScope`) so older builds and old exports stay coherent;
         /// read only as the fallback when `spaceScope` is absent.
@@ -1658,6 +1756,39 @@ final class Preferences: ObservableObject {
         }
     }
 
+    /// Color of the selection highlight and the jump-letter prefix (#185).
+    /// Defaults to `.system`, which is the macOS accent — the same color the
+    /// switcher used before this setting existed.
+    @Published var selectionColor: SwitcherSelectionColor {
+        didSet {
+            guard oldValue != selectionColor else { return }
+            UserDefaults.standard.set(selectionColor.rawValue, forKey: Keys.selectionColor)
+        }
+    }
+
+    /// `#RRGGBB` for `SwitcherSelectionColor.custom`; nil until the user picks
+    /// one, in which case `.custom` falls back to the macOS accent.
+    @Published var selectionColorHex: String? {
+        didSet {
+            guard oldValue != selectionColorHex else { return }
+            if let selectionColorHex {
+                UserDefaults.standard.set(selectionColorHex, forKey: Keys.selectionColorHex)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Keys.selectionColorHex)
+            }
+        }
+    }
+
+    /// The concrete selection color to draw with right now — the stored hex for
+    /// `.custom`, otherwise the choice's own color (`.system` resolving lazily
+    /// to `controlAccentColor` so it stays light/dark reactive).
+    var resolvedSelectionColor: NSColor {
+        if selectionColor == .custom, let hex = selectionColorHex, let color = NSColor(hexString: hex) {
+            return color
+        }
+        return selectionColor.resolved
+    }
+
     /// Which Spaces the switcher shows windows from (#57). Default all Spaces.
     /// Reads window Space membership via the same private APIs as instant Space
     /// switching; degrades to showing everything when those are unavailable.
@@ -2289,6 +2420,9 @@ final class Preferences: ObservableObject {
         self.listWidthPercent = Self.clampListWidthPercent(listWidth)
         let materialRaw = defaults.string(forKey: Keys.backdropMaterial)
         self.backdropMaterial = materialRaw.flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
+        let selectionColorRaw = defaults.string(forKey: Keys.selectionColor)
+        self.selectionColor = selectionColorRaw.flatMap(SwitcherSelectionColor.init(rawValue:)) ?? .system
+        self.selectionColorHex = defaults.string(forKey: Keys.selectionColorHex)
         self.spaceScope = Self.storedSpaceScope(defaults)
         self.directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
         let legacyScopes = Self.loadScopes(defaults.stringArray(forKey: Keys.scopedShortcutScopes))
@@ -2427,6 +2561,8 @@ final class Preferences: ObservableObject {
         panelCornerRadius = Self.clampCornerRadius(defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0)
         listWidthPercent = Self.clampListWidthPercent(defaults.object(forKey: Keys.listWidthPercent) as? Int ?? 100)
         backdropMaterial = defaults.string(forKey: Keys.backdropMaterial).flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
+        selectionColor = defaults.string(forKey: Keys.selectionColor).flatMap(SwitcherSelectionColor.init(rawValue:)) ?? .system
+        selectionColorHex = defaults.string(forKey: Keys.selectionColorHex)
         spaceScope = Self.storedSpaceScope(defaults)
         directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
         let reloadedScopes = Self.loadScopes(defaults.stringArray(forKey: Keys.scopedShortcutScopes))

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -118,7 +118,13 @@ enum SearchDismissMode: String, CaseIterable {
 /// cases exist for the accents that disappear against a busy wallpaper or a
 /// screen full of same-colored windows, which is the whole complaint in #185.
 enum SwitcherSelectionColor: String, CaseIterable {
-    /// Follows the macOS accent color. Default.
+    /// No hue on the selection plate — the neutral luminance highlight the
+    /// switcher shipped with through 26.7, and still the default: a tint is a
+    /// deliberate choice, not something an update should impose. Letter hints and
+    /// the launch/reopen glyphs keep the macOS accent; only the plate goes
+    /// colorless.
+    case transparent
+    /// Follows the macOS accent color.
     case system
     case blue
     case purple
@@ -129,12 +135,13 @@ enum SwitcherSelectionColor: String, CaseIterable {
     case green
     case graphite
     /// User-supplied color; the value lives in `Preferences.selectionColorHex`.
-    /// Resolve via `Preferences.shared.resolvedSelectionColor`, not `resolved`,
-    /// so the hex is read on the main actor.
+    /// Resolve via `Preferences.shared.resolvedSelectionColor` so the hex is
+    /// read on the main actor.
     case custom
 
     var displayName: String {
         switch self {
+        case .transparent: return String(localized: "Transparent")
         case .system: return String(localized: "macOS accent")
         case .blue: return String(localized: "Blue")
         case .purple: return String(localized: "Purple")
@@ -151,7 +158,7 @@ enum SwitcherSelectionColor: String, CaseIterable {
     /// Fixed color, or `nil` when the choice tracks the system accent or is custom.
     var color: NSColor? {
         switch self {
-        case .system, .custom: return nil
+        case .transparent, .system, .custom: return nil
         case .blue: return .systemBlue
         case .purple: return .systemPurple
         case .pink: return .systemPink
@@ -164,10 +171,16 @@ enum SwitcherSelectionColor: String, CaseIterable {
     }
 
     /// The concrete color to draw with right now. Resolving `.system` lazily
-    /// keeps it appearance-reactive (light/dark) like the rest of AppKit. For
-    /// `.custom` this falls back to the system accent — use
-    /// `Preferences.shared.resolvedSelectionColor` to honor the stored hex.
-    var resolved: NSColor { color ?? .controlAccentColor }
+    /// keeps it appearance-reactive (light/dark) like the rest of AppKit.
+    /// `.custom` needs `customHex`; a missing or malformed hex falls back to
+    /// the system accent. Opaque by design — the item views own the fill's
+    /// alpha, so a translucent hex must not leak into the rim.
+    func nsColor(customHex: String?) -> NSColor {
+        if self == .custom, let customHex, let color = NSColor(hexString: customHex) {
+            return color.withAlphaComponent(1)
+        }
+        return color ?? .controlAccentColor
+    }
 }
 
 extension NSColor {
@@ -176,7 +189,10 @@ extension NSColor {
     convenience init?(hexString: String) {
         var hex = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
         if hex.hasPrefix("#") { hex.removeFirst() }
+        // `UInt64(_:radix:)` accepts a leading sign, so "+F8000" would parse as
+        // 0x0F8000 and silently paint the wrong color. Digits only.
         guard hex.count == 6 || hex.count == 8,
+              hex.allSatisfy(\.isHexDigit),
               let value = UInt64(hex, radix: 16) else { return nil }
         let r, g, b, a: CGFloat
         if hex.count == 8 {
@@ -200,6 +216,22 @@ extension NSColor {
         let g = Int(round(rgb.greenComponent * 255))
         let b = Int(round(rgb.blueComponent * 255))
         return String(format: "#%02X%02X%02X", r, g, b)
+    }
+
+    /// Black or white, whichever stays legible on top of this color used as a
+    /// fill. The list layout paints the selection at full opacity, so a light
+    /// selection color (yellow, mint) made the hardcoded white label unreadable
+    /// — the exact "can't see which one is selected" complaint in #185.
+    var contrastingLabelColor: NSColor {
+        guard let rgb = usingColorSpace(.sRGB) else { return .white }
+        // Rec. 709 luma. Measured across the eight presets in both appearances,
+        // the ones that read better on white land at or below 0.479 (blue, purple,
+        // pink, red) and the ones that need black start at 0.558 (graphite, orange,
+        // green, yellow). 0.52 splits that gap with ~0.04 of margin either side;
+        // 0.6 would put graphite-on-dark (0.597) on white at 2.9:1 where black
+        // gives 7.3:1.
+        let luma = 0.2126 * rgb.redComponent + 0.7152 * rgb.greenComponent + 0.0722 * rgb.blueComponent
+        return luma > 0.52 ? .black : .white
     }
 }
 
@@ -1783,10 +1815,7 @@ final class Preferences: ObservableObject {
     /// `.custom`, otherwise the choice's own color (`.system` resolving lazily
     /// to `controlAccentColor` so it stays light/dark reactive).
     var resolvedSelectionColor: NSColor {
-        if selectionColor == .custom, let hex = selectionColorHex, let color = NSColor(hexString: hex) {
-            return color
-        }
-        return selectionColor.resolved
+        selectionColor.nsColor(customHex: selectionColorHex)
     }
 
     /// Which Spaces the switcher shows windows from (#57). Default all Spaces.
@@ -2421,7 +2450,7 @@ final class Preferences: ObservableObject {
         let materialRaw = defaults.string(forKey: Keys.backdropMaterial)
         self.backdropMaterial = materialRaw.flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
         let selectionColorRaw = defaults.string(forKey: Keys.selectionColor)
-        self.selectionColor = selectionColorRaw.flatMap(SwitcherSelectionColor.init(rawValue:)) ?? .system
+        self.selectionColor = selectionColorRaw.flatMap(SwitcherSelectionColor.init(rawValue:)) ?? .transparent
         self.selectionColorHex = defaults.string(forKey: Keys.selectionColorHex)
         self.spaceScope = Self.storedSpaceScope(defaults)
         self.directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])
@@ -2561,7 +2590,7 @@ final class Preferences: ObservableObject {
         panelCornerRadius = Self.clampCornerRadius(defaults.object(forKey: Keys.panelCornerRadius) as? Int ?? 0)
         listWidthPercent = Self.clampListWidthPercent(defaults.object(forKey: Keys.listWidthPercent) as? Int ?? 100)
         backdropMaterial = defaults.string(forKey: Keys.backdropMaterial).flatMap(BackdropMaterial.init(rawValue:)) ?? .hud
-        selectionColor = defaults.string(forKey: Keys.selectionColor).flatMap(SwitcherSelectionColor.init(rawValue:)) ?? .system
+        selectionColor = defaults.string(forKey: Keys.selectionColor).flatMap(SwitcherSelectionColor.init(rawValue:)) ?? .transparent
         selectionColorHex = defaults.string(forKey: Keys.selectionColorHex)
         spaceScope = Self.storedSpaceScope(defaults)
         directActivationBindings = Self.normalizeBindings(defaults.stringArray(forKey: Keys.directActivationBindings) ?? [])

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -1329,6 +1329,40 @@
         }
       }
     },
+    "Blue" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blau"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Azul"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bleu"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niebieski"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蓝色"
+          }
+        }
+      }
+    },
     "Bold selected title" : {
       "localizations" : {
         "de" : {
@@ -2385,6 +2419,40 @@
         }
       }
     },
+    "Color of the highlight around the selected window and of the quick-jump letters. Follows your macOS accent by default." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farbe der Hervorhebung um das ausgewählte Fenster und der Sprungbuchstaben. Folgt standardmäßig deiner macOS-Akzentfarbe."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color del resaltado alrededor de la ventana seleccionada y de las letras de salto rápido. Sigue el color de acento de macOS de forma predeterminada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couleur de la surbrillance autour de la fenêtre sélectionnée et des lettres de saut rapide. Suit la couleur d'accentuation macOS par défaut."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kolor podświetlenia wokół zaznaczonego okna i liter szybkiego skoku. Domyślnie zgodny z kolorem akcentu macOS."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选中窗口周围高亮以及快速跳转字母的颜色。默认跟随 macOS 强调色。"
+          }
+        }
+      }
+    },
     "Configuration file" : {
       "localizations" : {
         "de" : {
@@ -2824,6 +2892,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义：%@"
+          }
+        }
+      }
+    },
+    "Custom…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eigene…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizado…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personnalisé…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Własny…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定…"
           }
         }
       }
@@ -4016,6 +4118,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已授予"
+          }
+        }
+      }
+    },
+    "Graphite" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graphit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafito"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graphite"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafitowy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "石墨色"
+          }
+        }
+      }
+    },
+    "Green" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grün"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vert"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zielony"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "绿色"
           }
         }
       }
@@ -7869,6 +8039,40 @@
         }
       }
     },
+    "Orange" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orange"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naranja"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orange"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pomarańczowy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橙色"
+          }
+        }
+      }
+    },
     "Order results by how well they match instead of by recent use, so the closest match is selected first." : {
       "localizations" : {
         "de" : {
@@ -8205,6 +8409,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择另一个空间或全屏中的应用时立即跳转，不播放滑动动画。也适用于键盘切换。"
+          }
+        }
+      }
+    },
+    "Pink" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pink"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rosa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rose"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Różowy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粉色"
           }
         }
       }
@@ -8719,6 +8957,40 @@
         }
       }
     },
+    "Purple" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Violett"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Morado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Violet"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fioletowy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紫色"
+          }
+        }
+      }
+    },
     "Quick switch (last 2 apps)" : {
       "localizations" : {
         "de" : {
@@ -8989,6 +9261,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复"
+          }
+        }
+      }
+    },
+    "Red" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rot"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rojo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rouge"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Czerwony"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "红色"
           }
         }
       }
@@ -10249,6 +10555,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选中的应用会固定到切换器前方，排在最近使用之前。"
+          }
+        }
+      }
+    },
+    "Selection color" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auswahlfarbe"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color de selección"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couleur de sélection"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kolor zaznaczenia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选中颜色"
           }
         }
       }
@@ -13997,6 +14337,40 @@
         }
       }
     },
+    "Yellow" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gelb"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amarillo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jaune"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Żółty"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黄色"
+          }
+        }
+      }
+    },
     "You're up to date!" : {
       "localizations" : {
         "de" : {
@@ -14061,6 +14435,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缩放窗口"
+          }
+        }
+      }
+    },
+    "macOS accent" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS-Akzentfarbe"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color de acento de macOS"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couleur d'accentuation macOS"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kolor akcentu macOS"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS 强调色"
           }
         }
       }

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -13350,6 +13350,40 @@
         }
       }
     },
+    "Transparent" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparent"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transparent"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przezroczysty"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透明"
+          }
+        }
+      }
+    },
     "Trigger" : {
       "localizations" : {
         "de" : {

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -413,6 +413,9 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         if ownsColorPanel {
             NSColorPanel.shared.setTarget(nil)
             NSColorPanel.shared.setAction(nil)
+            // `showsAlpha` is state on the process-wide shared panel; leave it
+            // as found rather than pinned to this pane's preference.
+            NSColorPanel.shared.showsAlpha = restoreShowsAlpha
             ownsColorPanel = false
         }
     }
@@ -459,7 +462,9 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     /// Small filled-circle swatch shown beside each selection-color menu item.
     /// `.system` is drawn with the live accent color so it always previews the
     /// user's macOS setting, and `.custom` with the stored hex so it tracks
-    /// their pick rather than the accent fallback in `resolved`.
+    /// their pick rather than the accent fallback. `.transparent` is left
+    /// unfilled — it resolves to the accent for letter hints, so filling it would
+    /// show a color the selection plate never paints.
     private static func swatch(for color: SwitcherSelectionColor) -> NSImage {
         let size = NSSize(width: 12, height: 12)
         let image = NSImage(size: size)
@@ -467,14 +472,10 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         image.lockFocus()
         let rect = NSRect(origin: .zero, size: size).insetBy(dx: 0.5, dy: 0.5)
         let path = NSBezierPath(ovalIn: rect)
-        let fill: NSColor
-        if color == .custom {
-            fill = Preferences.shared.selectionColorHex.flatMap(NSColor.init(hexString:)) ?? .controlAccentColor
-        } else {
-            fill = color.resolved
+        if color != .transparent {
+            color.nsColor(customHex: Preferences.shared.selectionColorHex).setFill()
+            path.fill()
         }
-        fill.setFill()
-        path.fill()
         NSColor.black.withAlphaComponent(0.15).setStroke()
         path.lineWidth = 1
         path.stroke()
@@ -493,9 +494,16 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
     /// Tracks whether we currently own the shared color panel's target/action,
     /// so `viewWillDisappear` can detach before this controller is released.
     private var ownsColorPanel = false
+    /// `showsAlpha` as the shared panel had it before this pane forced it off.
+    private var restoreShowsAlpha = false
 
     private func presentColorPanel() {
         let panel = NSColorPanel.shared
+        // Left continuous (the default) so the live switcher preview tracks the
+        // drag. `schedulePreviewRefresh` already coalesces to one render per
+        // runloop turn, and the only other per-frame work is a UserDefaults set
+        // and a 12×12 swatch.
+        restoreShowsAlpha = panel.showsAlpha
         panel.showsAlpha = false
         if let hex = Preferences.shared.selectionColorHex, let color = NSColor(hexString: hex) {
             panel.color = color

--- a/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppearanceSettingsViewController.swift
@@ -9,11 +9,13 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
 
     private let displayMonitorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let displayModes: [SwitcherDisplayMode] = SwitcherDisplayMode.allCases
+    private let selectionColors: [SwitcherSelectionColor] = SwitcherSelectionColor.allCases
     private var layoutRadio: SettingsRadioGroupView!
     private var appearanceRadio: SettingsRadioGroupView!
     private var titleAlignmentRadio: SettingsRadioGroupView!
     private var truncationRadio: SettingsRadioGroupView!
     private let gridPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let selectionColorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let listWidthSlider = NSSlider()
     private let listWidthValueField = NSTextField()
     private let scaleSlider = NSSlider()
@@ -159,13 +161,21 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
                subtitle: String(localized: "Mark hidden, minimized, full-screen and windowless entries with a small glyph. The audio, Launch and Reopen cues always show."),
                accessory: statusIconsSwitch, searchItemID: SearchID.windowStatusIcons)
 
-        // Panel section — the chrome: translucency, rounding. The selection
-        // accent always follows the user's macOS accent color.
+        // Panel section — the chrome: selection color, translucency, rounding.
         let panel = addSection(title: String(localized: "Panel"), anchor: SettingsAnchor.appearancePanel)
 
         appearanceRadio = makeAppearanceRadio()
         addRow(to: panel, title: String(localized: "Appearance"),
                accessory: appearanceRadio, searchItemID: SearchID.theme)
+
+        configurePopup(selectionColorPopup, titles: selectionColors.map(\.displayName),
+                       action: #selector(selectionColorChanged))
+        for (i, color) in selectionColors.enumerated() {
+            selectionColorPopup.item(at: i)?.image = Self.swatch(for: color)
+        }
+        addRow(to: panel, title: String(localized: "Selection color"),
+               subtitle: String(localized: "Color of the highlight around the selected window and of the quick-jump letters. Follows your macOS accent by default."),
+               accessory: selectionColorPopup, searchItemID: SearchID.selectionColor)
 
         let opacityTitle = String(localized: "Panel opacity")
         opacitySlider.minValue = Double(Preferences.panelOpacityRange.lowerBound)
@@ -378,6 +388,14 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.animationsSwitch.sync() }
             .store(in: &cancellables)
+        prefs.$selectionColor
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.selectSelectionColor($0) }
+            .store(in: &cancellables)
+        prefs.$selectionColorHex
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.refreshCustomSwatch() }
+            .store(in: &cancellables)
         prefs.objectWillChange
             .sink { [weak self] in self?.schedulePreviewRefresh() }
             .store(in: &cancellables)
@@ -387,6 +405,16 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         super.viewWillDisappear()
         hidePreview()
         cancellables.removeAll()
+        // The shared color panel keeps a non-zeroing target/action. The settings
+        // window is `.releaseOnClose`, so leaving this wired would let a later
+        // color change message a deallocated controller (EXC_BAD_ACCESS). Detach
+        // ourselves whenever we own the panel (NSColorPanel exposes no target
+        // getter, so we track ownership explicitly).
+        if ownsColorPanel {
+            NSColorPanel.shared.setTarget(nil)
+            NSColorPanel.shared.setAction(nil)
+            ownsColorPanel = false
+        }
     }
 
     private func syncFromPreferences() {
@@ -412,6 +440,75 @@ final class AppearanceSettingsViewController: SettingsTabViewController {
         animationsSwitch.sync()
         applyOpacity(prefs.panelOpacity)
         applyRadius(prefs.panelCornerRadius)
+        selectSelectionColor(prefs.selectionColor)
+        refreshCustomSwatch()
+    }
+
+    private func selectSelectionColor(_ color: SwitcherSelectionColor) {
+        if let i = selectionColors.firstIndex(of: color) { selectionColorPopup.selectItem(at: i) }
+    }
+
+    @objc private func selectionColorChanged() {
+        let i = selectionColorPopup.indexOfSelectedItem
+        guard selectionColors.indices.contains(i) else { return }
+        let choice = selectionColors[i]
+        Preferences.shared.selectionColor = choice
+        if choice == .custom { presentColorPanel() }
+    }
+
+    /// Small filled-circle swatch shown beside each selection-color menu item.
+    /// `.system` is drawn with the live accent color so it always previews the
+    /// user's macOS setting, and `.custom` with the stored hex so it tracks
+    /// their pick rather than the accent fallback in `resolved`.
+    private static func swatch(for color: SwitcherSelectionColor) -> NSImage {
+        let size = NSSize(width: 12, height: 12)
+        let image = NSImage(size: size)
+        image.isTemplate = false
+        image.lockFocus()
+        let rect = NSRect(origin: .zero, size: size).insetBy(dx: 0.5, dy: 0.5)
+        let path = NSBezierPath(ovalIn: rect)
+        let fill: NSColor
+        if color == .custom {
+            fill = Preferences.shared.selectionColorHex.flatMap(NSColor.init(hexString:)) ?? .controlAccentColor
+        } else {
+            fill = color.resolved
+        }
+        fill.setFill()
+        path.fill()
+        NSColor.black.withAlphaComponent(0.15).setStroke()
+        path.lineWidth = 1
+        path.stroke()
+        image.unlockFocus()
+        return image
+    }
+
+    /// Repaints the custom menu item's swatch from the stored hex.
+    private func refreshCustomSwatch() {
+        guard let i = selectionColors.firstIndex(of: .custom) else { return }
+        selectionColorPopup.item(at: i)?.image = Self.swatch(for: .custom)
+    }
+
+    // MARK: - Custom selection color
+
+    /// Tracks whether we currently own the shared color panel's target/action,
+    /// so `viewWillDisappear` can detach before this controller is released.
+    private var ownsColorPanel = false
+
+    private func presentColorPanel() {
+        let panel = NSColorPanel.shared
+        panel.showsAlpha = false
+        if let hex = Preferences.shared.selectionColorHex, let color = NSColor(hexString: hex) {
+            panel.color = color
+        }
+        panel.setTarget(self)
+        panel.setAction(#selector(customColorChanged(_:)))
+        ownsColorPanel = true
+        panel.orderFront(nil)
+    }
+
+    @objc private func customColorChanged(_ sender: NSColorPanel) {
+        Preferences.shared.selectionColorHex = sender.color.hexString
+        refreshCustomSwatch()
     }
 
     private func selectLayout(_ mode: SwitcherLayoutMode) {

--- a/BetterCmdTab/Settings/SettingsCatalog.swift
+++ b/BetterCmdTab/Settings/SettingsCatalog.swift
@@ -149,6 +149,7 @@ enum SearchID {
     static let layout = "appearance.layout"
     static let size = "appearance.size"
     static let gridColumns = "appearance.gridColumns"
+    static let selectionColor = "appearance.selectionColor"
     static let gridSingleRow = "appearance.gridSingleRow"
     static let listMaxWidth = "appearance.listMaxWidth"
     static let windowTitle = "appearance.windowTitle"
@@ -487,6 +488,8 @@ enum SettingsCatalog {
         // Appearance · Panel
         item(SearchID.theme, .appearance, SettingsAnchor.appearancePanel, String(localized: "Appearance"), String(localized: "Panel"),
              String(localized: "Appearance"), ["theme", "appearance", "light", "dark", "system", "color scheme"]),
+        item(SearchID.selectionColor, .appearance, SettingsAnchor.appearancePanel, String(localized: "Appearance"), String(localized: "Panel"),
+             String(localized: "Selection color"), ["selection", "color", "colour", "accent", "highlight", "border", "tint", "selected"]),
         item(SearchID.opacity, .appearance, SettingsAnchor.appearancePanel, String(localized: "Appearance"), String(localized: "Panel"),
              String(localized: "Panel opacity"), ["opacity", "transparency", "alpha", "translucent"]),
         item(SearchID.cornerRadius, .appearance, SettingsAnchor.appearancePanel, String(localized: "Appearance"), String(localized: "Panel"),

--- a/BetterCmdTab/Switcher/EffectiveSettings.swift
+++ b/BetterCmdTab/Switcher/EffectiveSettings.swift
@@ -7,11 +7,14 @@ import AppKit
 /// place of `Preferences.shared.*` — so a shortcut with an override shows its own
 /// look without mutating any global state.
 ///
-/// Only ever built and read on the main actor (the catalog hot path uses
+/// Holds an `NSColor`, so it is intentionally **not** `Sendable`: it is only ever
+/// built and read on the main actor (the catalog hot path uses
 /// `CatalogFilter.Config`, which is `Sendable`, instead).
 struct EffectiveSettings {
-    // Appearance. The selection accent isn't here: it always follows the
-    // user's macOS accent (`NSColor.controlAccentColor`), read at draw time.
+    // Appearance.
+    /// Selection highlight / jump-letter color, already resolved to a concrete
+    /// color (#185). Not per-shortcut overridable — one switcher-wide answer.
+    let selectionColor: NSColor
     let layoutMode: SwitcherLayoutMode
     let panelScalePercent: Int
     let panelAppearance: PanelAppearance
@@ -51,6 +54,7 @@ extension Preferences {
     /// preference.
     func effectiveSettings(for override: ShortcutOverride) -> EffectiveSettings {
         EffectiveSettings(
+            selectionColor: resolvedSelectionColor,
             layoutMode: override.layoutMode ?? switcherLayoutMode,
             panelScalePercent: override.panelScalePercent.map(Self.clampPanelScalePercent) ?? panelScalePercent,
             panelAppearance: override.panelAppearance ?? panelAppearance,

--- a/BetterCmdTab/Switcher/EffectiveSettings.swift
+++ b/BetterCmdTab/Switcher/EffectiveSettings.swift
@@ -15,6 +15,16 @@ struct EffectiveSettings {
     /// Selection highlight / jump-letter color, already resolved to a concrete
     /// color (#185). Not per-shortcut overridable — one switcher-wide answer.
     let selectionColor: NSColor
+    /// Change-detection key for `selectionColor`, resolved once per reveal.
+    /// `controlAccentColor` is the same object before and after the user changes
+    /// the macOS accent, so the item views cannot compare colors by identity —
+    /// and deriving a key per row would put a colorspace conversion and a string
+    /// allocation on the ⌘Tab path for every row, every keystroke.
+    let selectionColorKey: String
+    /// `.transparent`: the selection plate drops its hue for the neutral
+    /// luminance highlight instead. `selectionColor` still carries the accent,
+    /// which letter hints and the launch/reopen glyphs keep using.
+    let neutralSelection: Bool
     let layoutMode: SwitcherLayoutMode
     let panelScalePercent: Int
     let panelAppearance: PanelAppearance
@@ -53,8 +63,14 @@ extension Preferences {
     /// preferring the override's field when set and otherwise the global
     /// preference.
     func effectiveSettings(for override: ShortcutOverride) -> EffectiveSettings {
-        EffectiveSettings(
-            selectionColor: resolvedSelectionColor,
+        let selection = resolvedSelectionColor
+        return EffectiveSettings(
+            selectionColor: selection,
+            // The choice is part of the key because two of them resolve to the
+            // same color: `.transparent` and `.system` both hand back the macOS
+            // accent, and only the flag tells the plates apart.
+            selectionColorKey: selectionColor.rawValue + (selection.hexString ?? selection.description),
+            neutralSelection: selectionColor == .transparent,
             layoutMode: override.layoutMode ?? switcherLayoutMode,
             panelScalePercent: override.panelScalePercent.map(Self.clampPanelScalePercent) ?? panelScalePercent,
             panelAppearance: override.panelAppearance ?? panelAppearance,

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -22,12 +22,27 @@ protocol SwitcherItemViewProtocol: NSView {
 }
 
 extension SwitcherItemViewProtocol {
-    /// Plate fill for the selection color (#185): translucent enough that the panel
-    /// backdrop still shows through, opaque enough to name the color at a glance.
-    /// One alpha for both appearances — the hue carries the signal here, unlike the
-    /// neutral white/black plate this replaced, which had to lean on luminance.
-    static func selectionFill(_ color: NSColor) -> NSColor {
-        color.withAlphaComponent(0.45)
+    /// Fill and rim for a tile's selection plate.
+    ///
+    /// Tinted (#185): translucent enough that the panel backdrop still shows
+    /// through, opaque enough to name the color at a glance. One alpha for both
+    /// appearances — the hue carries the signal, and the rim is that hue at full
+    /// strength.
+    ///
+    /// Neutral (`.transparent`): no hue to lean on, so it goes back to luminance,
+    /// and there the alphas are not symmetric because the panel is not — clear
+    /// glass over the light haze lands near black in dark mode but only mid-grey
+    /// in light, so white at 0.14 lifts the plate far more than the same alpha of
+    /// black would sink it (measured on the rendered panel: dark 0.077 → 0.251,
+    /// light 0.396 → 0.277). `neutralLightFill` is heavier for the icon grid,
+    /// where the plate shows around every icon's transparent margin, than for
+    /// window previews, where the thumbnail covers it and the rim does the work.
+    static func selectionPlate(_ color: NSColor, neutral: Bool, dark: Bool,
+                               neutralLightFill: CGFloat) -> (fill: NSColor, rim: NSColor) {
+        guard neutral else { return (color.withAlphaComponent(0.45), color) }
+        return dark
+            ? (NSColor.white.withAlphaComponent(0.14), NSColor.white.withAlphaComponent(0.50))
+            : (NSColor.black.withAlphaComponent(neutralLightFill), NSColor.black.withAlphaComponent(0.55))
     }
 }
 
@@ -47,10 +62,9 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     /// Resolved appearance for the current reveal (#74); set in `configure`, read
     /// by render helpers (`applySelection`) that run outside it.
     private var effective: EffectiveSettings = .defaults
-    /// Cheap stable token for the current accent, recomputed only when the
-    /// accent changes — used as a memo-cache key instead of re-deriving
-    /// `accent.description` on every letter/symbol render.
-    private var accentKey: String = NSColor.controlAccentColor.description
+    /// Mirrors `EffectiveSettings.selectionColorKey` so a pooled tile repaints
+    /// when the selection color changes. Also keys the letter/symbol memo caches.
+    private var accentKey: String = ""
 
     var isSelected: Bool = false {
         didSet {
@@ -189,8 +203,21 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         // colored rim is what the neutral hairline never was — legible on every
         // system, not just the pre-macOS 26 frosted backdrop, which is exactly the
         // "hard to see which one is selected" complaint.
-        selectionBackdrop.layer?.backgroundColor = Self.selectionFill(accent).cgColor
-        selectionBackdrop.layer?.borderColor = accent.cgColor
+        let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let plate = Self.selectionPlate(accent, neutral: effective.neutralSelection,
+                                        dark: dark, neutralLightFill: 0.30)
+        // `.cgColor` snapshots a dynamic color against `NSAppearance.current`, not
+        // this view's — and the panel forces its own appearance, so resolve inside it.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            selectionBackdrop.layer?.backgroundColor = plate.fill.cgColor
+            selectionBackdrop.layer?.borderColor = plate.rim.cgColor
+        }
+        // The neutral hairline only existed to fight the frosted `NSVisualEffectView`
+        // backdrop; Liquid Glass separates the plate on its own, so macOS 26 drops it.
+        // A tinted rim stays on every system — it is the whole point of the tint.
+        if #available(macOS 26.0, *) {
+            selectionBackdrop.layer?.borderWidth = effective.neutralSelection ? 0 : 1.5
+        }
     }
 
     private var currentLabel: String = ""
@@ -228,9 +255,9 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         if faceChanged || metrics != self.metrics {
             applyMetrics(metrics)
         }
-        if self.accent != accent {
+        if accentKey != effective.selectionColorKey {
             self.accent = accent
-            accentKey = accent.description
+            accentKey = effective.selectionColorKey
             updateSelectionAppearance()
         }
         currentLabel = label
@@ -471,7 +498,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         let key = SymbolKey(indicator: indicator, pointSize: pointSize, accentKey: accentKey)
         let accentColor = accent
         return Self.symbolCache.value(for: key) {
-            let color = indicator.tint(onAccentFill: false, accent: accentColor)
+            let color = indicator.tint(onFill: nil, accent: accentColor)
             let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
                 .applying(.init(paletteColors: [color]))
             return indicator.makeImage()?.withSymbolConfiguration(cfg)

--- a/BetterCmdTab/Switcher/SwitcherIconItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherIconItemView.swift
@@ -21,6 +21,16 @@ protocol SwitcherItemViewProtocol: NSView {
     func prepareForIdle()
 }
 
+extension SwitcherItemViewProtocol {
+    /// Plate fill for the selection color (#185): translucent enough that the panel
+    /// backdrop still shows through, opaque enough to name the color at a glance.
+    /// One alpha for both appearances — the hue carries the signal here, unlike the
+    /// neutral white/black plate this replaced, which had to lean on luminance.
+    static func selectionFill(_ color: NSColor) -> NSColor {
+        color.withAlphaComponent(0.45)
+    }
+}
+
 @MainActor
 final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     private let selectionBackdrop = NSView()
@@ -66,6 +76,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
 
         selectionBackdrop.wantsLayer = true
         selectionBackdrop.layer?.cornerCurve = .continuous
+        selectionBackdrop.layer?.borderWidth = 1.5
         selectionBackdrop.isHidden = true
         addSubview(selectionBackdrop)
 
@@ -170,29 +181,16 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
     }
 
     private func updateSelectionAppearance() {
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        // Fill-only, like the native switcher — no border. The two alphas are not
-        // symmetric because the panel is not: clear glass over the light haze lands
-        // near black in dark mode but only mid-grey in light mode, so white at 0.14
-        // lifts the plate far more than the same alpha of black would sink it.
-        // Measured on the rendered panel: dark 0.077 → 0.251, light 0.396 → 0.277.
-        let fill = isDark
-            ? NSColor.white.withAlphaComponent(0.14)
-            : NSColor.black.withAlphaComponent(0.30)
-        selectionBackdrop.layer?.backgroundColor = fill.cgColor
-        // The fill only reads as selection where it shows *around* the artwork. The
-        // icon canvas overhangs the plate by 4 pt a side and is drawn on top, so the
-        // plate shows through the transparent margin every real app icon carries —
-        // worst case measured across 81 installed apps was 0.875 of the canvas, which
-        // still leaves 4 pt of plate. The hairline is kept before macOS 26 because the
-        // fill alone is weak against the frosted `NSVisualEffectView` backdrop there,
-        // not because a border would survive an icon that really was full-bleed.
-        if #unavailable(macOS 26.0) {
-            selectionBackdrop.layer?.borderWidth = 1.5
-            selectionBackdrop.layer?.borderColor = (isDark
-                ? NSColor.white.withAlphaComponent(0.50)
-                : NSColor.black.withAlphaComponent(0.55)).cgColor
-        }
+        // Tinted with the selection color (#185). The plate only reads as selection
+        // where it shows *around* the artwork: the icon canvas overhangs the plate by
+        // 4 pt a side and is drawn on top, so what the eye gets is the transparent
+        // margin every real app icon carries (worst case measured across 81 installed
+        // apps was 0.875 of the canvas, still leaving 4 pt of plate) plus the rim. A
+        // colored rim is what the neutral hairline never was — legible on every
+        // system, not just the pre-macOS 26 frosted backdrop, which is exactly the
+        // "hard to see which one is selected" complaint.
+        selectionBackdrop.layer?.backgroundColor = Self.selectionFill(accent).cgColor
+        selectionBackdrop.layer?.borderColor = accent.cgColor
     }
 
     private var currentLabel: String = ""
@@ -233,6 +231,7 @@ final class SwitcherIconItemView: NSView, SwitcherItemViewProtocol {
         if self.accent != accent {
             self.accent = accent
             accentKey = accent.description
+            updateSelectionAppearance()
         }
         currentLabel = label
         currentPrefixLength = prefixLength

--- a/BetterCmdTab/Switcher/SwitcherIndicators.swift
+++ b/BetterCmdTab/Switcher/SwitcherIndicators.swift
@@ -80,17 +80,17 @@ enum SwitcherIndicator: CaseIterable {
         NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription)
     }
 
-    /// Tint for this indicator. `onAccentFill` is true when the row's selection
-    /// paints an accent-colored background *behind* the glyph (list selection),
-    /// in which case every glyph turns white to stay legible. Grid selection
-    /// uses a neutral translucent backdrop, so it passes false and glyphs keep
-    /// their semantic color in every state.
+    /// Tint for this indicator. `onFill` carries the already-resolved on-plate
+    /// label color when the row's selection paints an opaque background *behind*
+    /// the glyph (list selection), in which case every glyph takes it to stay
+    /// legible. Grid selection uses a translucent backdrop, so it passes nil and
+    /// glyphs keep their semantic color in every state.
     ///
     /// Semantic colors: audio is green (a distinct "making sound" cue),
     /// launch/reopen use the accent (they're actionable, not just status), and
     /// the window-state glyphs are neutral secondary.
-    func tint(onAccentFill: Bool, accent: NSColor) -> NSColor {
-        if onAccentFill { return NSColor.white.withAlphaComponent(0.9) }
+    func tint(onFill: NSColor?, accent: NSColor) -> NSColor {
+        if let onFill { return onFill.withAlphaComponent(0.9) }
         switch self {
         case .audio: return .systemGreen
         case .launch, .reopen: return accent

--- a/BetterCmdTab/Switcher/SwitcherItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherItemView.swift
@@ -120,7 +120,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
             iv.imageFrameStyle = .none
             iv.isHidden = true
             iv.image = indicator.makeImage()
-            iv.contentTintColor = indicator.tint(onAccentFill: false, accent: accent)
+            iv.contentTintColor = indicator.tint(onFill: nil, accent: accent)
             addSubview(iv)
         }
 
@@ -158,11 +158,36 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
     private var currentLabel: String = ""
     private var currentPrefixLength: Int = 0
     private var accent: NSColor = .controlAccentColor
-    /// `accent.description` is a freshly-allocated, formatted string; computing
-    /// it on every `renderLetter` (i.e. for every row, every configure) just to
-    /// key the shared letter cache was pure churn. Cache it once per accent
-    /// change — accents change rarely (a settings tweak), letters render constantly.
-    private var accentKey: String = NSColor.controlAccentColor.description
+    /// Mirrors `EffectiveSettings.selectionColorKey` so a pooled row repaints when
+    /// the selection color changes. Also keys the shared letter cache, which is
+    /// why it is stored rather than derived per `renderLetter`.
+    private var accentKey: String = ""
+    /// Black or white, whichever survives on top of the opaque selection plate.
+    /// Resolved in `updateHighlightColor` so it snapshots the panel's appearance,
+    /// not the app's.
+    private var onFillLabel: NSColor = .white
+
+    /// Repaint everything derived from the selection color. Both `.cgColor` and
+    /// the sRGB conversion behind `contrastingLabelColor` snapshot a dynamic color
+    /// against `NSAppearance.current`, and the panel forces its own appearance, so
+    /// they have to resolve inside it.
+    ///
+    /// `.transparent` takes AppKit's own unfocused-selection grey rather than a
+    /// hand-rolled alpha: the list plate is opaque, so unlike the tiles there is
+    /// nothing to see through, and that color is already appearance-reactive with
+    /// a luminance `contrastingLabelColor` reads correctly in both.
+    private func updateHighlightColor() {
+        let plate: NSColor = effective.neutralSelection ? .unemphasizedSelectedContentBackgroundColor : accent
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            highlight.layer?.backgroundColor = plate.cgColor
+            onFillLabel = plate.contrastingLabelColor
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateHighlightColor()
+    }
 
     func prepareForIdle() {
         // Drop only the app icon — the heavy per-app retain held off IconCache and
@@ -198,10 +223,10 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         if faceChanged || metrics != self.metrics {
             applyMetrics(metrics)
         }
-        if self.accent != accent {
+        if accentKey != effective.selectionColorKey {
             self.accent = accent
-            accentKey = accent.description
-            highlight.layer?.backgroundColor = accent.cgColor
+            accentKey = effective.selectionColorKey
+            updateHighlightColor()
         }
         currentLabel = label
         currentPrefixLength = prefixLength
@@ -298,14 +323,14 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
 
     private func applySelection() {
         highlight.isHidden = !isSelected
-        let primary: NSColor = isSelected ? .white : .labelColor
-        let secondary: NSColor = isSelected ? NSColor.white.withAlphaComponent(0.9) : .labelColor
-        appNameLabel.textColor = primary
-        titleLabel.textColor = secondary
-        // The selected row paints an accent-colored background, so every glyph
-        // turns white; otherwise each keeps its semantic color.
+        // The plate is opaque, so a selected row's labels have to contrast with
+        // the selection color — white over systemYellow is unreadable.
+        appNameLabel.textColor = isSelected ? onFillLabel : .labelColor
+        titleLabel.textColor = isSelected ? onFillLabel.withAlphaComponent(0.9) : .labelColor
+        // Same for every glyph over that plate; unselected rows keep their
+        // semantic color.
         for (indicator, iv) in indicatorViews {
-            iv.contentTintColor = indicator.tint(onAccentFill: isSelected, accent: accent)
+            iv.contentTintColor = indicator.tint(onFill: isSelected ? onFillLabel : nil, accent: accent)
         }
         renderLetter()
     }
@@ -315,9 +340,9 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         let prefixLen: Int
         let fontSize: CGFloat
         let selected: Bool
-        // Distinguishes cache entries per accent so switching the accent color
-        // doesn't serve a stale highlight. The color object itself still
-        // resolves light/dark at draw time, so dynamic accents stay reactive.
+        // Distinguishes cache entries per selection color so switching it doesn't
+        // serve a stale highlight. Also covers the baked-in on-plate label color,
+        // which is a pure function of the accent.
         let accentKey: String
     }
 
@@ -325,7 +350,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
     private static var letterCacheOrder: [LetterCacheKey] = []
     private static let letterCacheCap = 256
 
-    private static func memoizedLetter(_ key: LetterCacheKey, accent: NSColor) -> NSAttributedString {
+    private static func memoizedLetter(_ key: LetterCacheKey, accent: NSColor, onFill: NSColor) -> NSAttributedString {
         if let hit = letterCache[key] {
             if let idx = letterCacheOrder.firstIndex(of: key) {
                 letterCacheOrder.remove(at: idx)
@@ -335,8 +360,8 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
         }
         let font = NSFont.monospacedSystemFont(ofSize: key.fontSize, weight: .semibold)
         let boldFont = NSFont.monospacedSystemFont(ofSize: key.fontSize, weight: .bold)
-        let highlightColor: NSColor = key.selected ? .white : accent
-        let baseColor: NSColor = key.selected ? .white : .labelColor
+        let highlightColor: NSColor = key.selected ? onFill : accent
+        let baseColor: NSColor = key.selected ? onFill : .labelColor
         let para = NSMutableParagraphStyle()
         para.alignment = .center
 
@@ -368,7 +393,7 @@ final class SwitcherItemView: NSView, SwitcherItemViewProtocol {
             selected: isSelected,
             accentKey: accentKey
         )
-        letterLabel.attributedStringValue = Self.memoizedLetter(key, accent: accent)
+        letterLabel.attributedStringValue = Self.memoizedLetter(key, accent: accent, onFill: onFillLabel)
     }
 
     override func layout() {

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -154,18 +154,10 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     }
 
     private func updateSelectionAppearance() {
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let fill: NSColor
-        let border: NSColor
-        if isDark {
-            fill = NSColor.white.withAlphaComponent(0.14)
-            border = NSColor.white.withAlphaComponent(0.50)
-        } else {
-            fill = NSColor.black.withAlphaComponent(0.10)
-            border = NSColor.black.withAlphaComponent(0.55)
-        }
-        selectionBackdrop.layer?.backgroundColor = fill.cgColor
-        selectionBackdrop.layer?.borderColor = border.cgColor
+        // Tinted with the selection color (#185); the rim carries most of the signal
+        // here because the thumbnail covers the plate except for its inset margin.
+        selectionBackdrop.layer?.backgroundColor = Self.selectionFill(accent).cgColor
+        selectionBackdrop.layer?.borderColor = accent.cgColor
     }
 
     private func updateThumbBackground() {
@@ -222,6 +214,7 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         if self.accent != accent {
             self.accent = accent
             accentKey = accent.description
+            updateSelectionAppearance()
         }
         currentLabel = label
         currentPrefixLength = prefixLength

--- a/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
+++ b/BetterCmdTab/Switcher/SwitcherPreviewItemView.swift
@@ -20,7 +20,9 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     /// Resolved appearance for the current reveal (#74); set in `configure`, read
     /// by render helpers (`applySelection`, title layout) that run outside it.
     private var effective: EffectiveSettings = .defaults
-    private var accentKey: String = NSColor.controlAccentColor.description
+    /// Mirrors `EffectiveSettings.selectionColorKey` so a pooled tile repaints
+    /// when the selection color changes. Also keys the letter memo cache.
+    private var accentKey: String = ""
 
     /// Window whose captured frame this tile shows, or nil for tiles that stay
     /// on their app icon (no real window, or a browser tab that isn't the
@@ -156,8 +158,15 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
     private func updateSelectionAppearance() {
         // Tinted with the selection color (#185); the rim carries most of the signal
         // here because the thumbnail covers the plate except for its inset margin.
-        selectionBackdrop.layer?.backgroundColor = Self.selectionFill(accent).cgColor
-        selectionBackdrop.layer?.borderColor = accent.cgColor
+        let dark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let plate = Self.selectionPlate(accent, neutral: effective.neutralSelection,
+                                        dark: dark, neutralLightFill: 0.10)
+        // `.cgColor` snapshots a dynamic color against `NSAppearance.current`, not
+        // this view's — and the panel forces its own appearance, so resolve inside it.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            selectionBackdrop.layer?.backgroundColor = plate.fill.cgColor
+            selectionBackdrop.layer?.borderColor = plate.rim.cgColor
+        }
     }
 
     private func updateThumbBackground() {
@@ -211,9 +220,9 @@ final class SwitcherPreviewItemView: NSView, SwitcherItemViewProtocol {
         if faceChanged || metrics != self.metrics {
             applyMetrics(metrics)
         }
-        if self.accent != accent {
+        if accentKey != effective.selectionColorKey {
             self.accent = accent
-            accentKey = accent.description
+            accentKey = effective.selectionColorKey
             updateSelectionAppearance()
         }
         currentLabel = label

--- a/BetterCmdTab/Switcher/SwitcherView.swift
+++ b/BetterCmdTab/Switcher/SwitcherView.swift
@@ -222,9 +222,10 @@ final class SwitcherView: NSView {
         self.labels = labels
         self.highlightPrefix = highlightPrefix
         self.searchActive = searchActive
-        // The selection highlight / jump-letter color always follows the
-        // user's macOS accent (re-read per reveal so it stays reactive).
-        self.accent = .controlAccentColor
+        // Selection highlight / jump-letter color (#185) — the macOS accent by
+        // default, re-read per reveal so both a settings change and a system
+        // accent change land on the next open without any observer.
+        self.accent = effective.selectionColor
         self.selectedIndex = selectedIndex
         // Only when it's on screen: this runs on every reveal, and the common
         // ⌘Tab has no search bar to configure.

--- a/BetterCmdTabTests/SelectionColorTests.swift
+++ b/BetterCmdTabTests/SelectionColorTests.swift
@@ -11,15 +11,44 @@ struct SelectionColorTests {
 
     @Test("fixed choices resolve to their own color, system and custom to the macOS accent")
     func resolvedColors() {
-        #expect(SwitcherSelectionColor.blue.resolved == .systemBlue)
-        #expect(SwitcherSelectionColor.purple.resolved == .systemPurple)
-        #expect(SwitcherSelectionColor.graphite.resolved == .systemGray)
-        // `.custom` has no color of its own — the hex lives in Preferences, so
-        // resolving it here must fall back rather than invent one.
-        #expect(SwitcherSelectionColor.system.resolved == .controlAccentColor)
-        #expect(SwitcherSelectionColor.custom.resolved == .controlAccentColor)
+        #expect(SwitcherSelectionColor.blue.nsColor(customHex: nil) == .systemBlue)
+        #expect(SwitcherSelectionColor.purple.nsColor(customHex: nil) == .systemPurple)
+        #expect(SwitcherSelectionColor.graphite.nsColor(customHex: nil) == .systemGray)
+        #expect(SwitcherSelectionColor.system.nsColor(customHex: nil) == .controlAccentColor)
+        // A fixed choice ignores the hex — only `.custom` reads it.
+        #expect(SwitcherSelectionColor.blue.nsColor(customHex: "#FF8000") == .systemBlue)
         #expect(SwitcherSelectionColor.system.color == nil)
         #expect(SwitcherSelectionColor.custom.color == nil)
+    }
+
+    /// `.transparent` still tints the quick-jump letters with the accent — only the
+    /// selection plate goes neutral. It therefore resolves to the *same color* as
+    /// `.system`, which is why `EffectiveSettings.selectionColorKey` carries the
+    /// raw value too: without it a pooled tile would not repaint when the user
+    /// switches between the two.
+    @Test("transparent keeps the accent for letters and stays legible on the list plate")
+    func transparentResolution() throws {
+        #expect(SwitcherSelectionColor.transparent.color == nil)
+        #expect(SwitcherSelectionColor.transparent.nsColor(customHex: nil)
+            == SwitcherSelectionColor.system.nsColor(customHex: nil))
+
+        // The list plate is opaque even without a hue, so its labels still flip.
+        for (name, want) in [(NSAppearance.Name.aqua, NSColor.black), (.darkAqua, .white)] {
+            let appearance = try #require(NSAppearance(named: name))
+            appearance.performAsCurrentDrawingAppearance {
+                let plate = NSColor.unemphasizedSelectedContentBackgroundColor
+                #expect(plate.contrastingLabelColor == want, "under \(name.rawValue)")
+            }
+        }
+    }
+
+    @Test("custom takes the stored hex, opaque, and falls back to the accent without one")
+    func customResolution() {
+        #expect(SwitcherSelectionColor.custom.nsColor(customHex: "#FF8000").hexString == "#FF8000")
+        #expect(SwitcherSelectionColor.custom.nsColor(customHex: nil) == .controlAccentColor)
+        #expect(SwitcherSelectionColor.custom.nsColor(customHex: "nonsense") == .controlAccentColor)
+        // A translucent hex must not leak into the rim, which draws at full alpha.
+        #expect(SwitcherSelectionColor.custom.nsColor(customHex: "#FF800000").alphaComponent == 1)
     }
 
     @Test("the stored raw values are stable and every case has a name")
@@ -54,6 +83,34 @@ struct SelectionColorTests {
         #expect(NSColor(hexString: "#FF80") == nil)
         #expect(NSColor(hexString: "#GGGGGG") == nil)
         #expect(NSColor(hexString: "rebeccapurple") == nil)
+        // `UInt64(_:radix:)` accepts a sign prefix on its own, which would turn
+        // "+F8000" into 0x0F8000 instead of rejecting it.
+        #expect(NSColor(hexString: "+F8000") == nil)
+        #expect(NSColor(hexString: "#+F8000") == nil)
+        #expect(NSColor(hexString: "-F8000") == nil)
+    }
+
+    /// Pins every preset in both appearances, so the luma threshold cannot drift
+    /// without a failure. `graphite` (0.558 light / 0.597 dark) and `orange`
+    /// (0.619 / 0.636) are the ones that sit closest to the cut — a threshold of
+    /// 0.6 put graphite-on-dark on white at 2.9:1.
+    @Test("labels on the opaque list plate flip to stay legible on light selections")
+    func contrastingLabelColor() throws {
+        let expected: [SwitcherSelectionColor: NSColor] = [
+            .blue: .white, .purple: .white, .pink: .white, .red: .white,
+            .orange: .black, .yellow: .black, .green: .black, .graphite: .black,
+        ]
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try #require(NSAppearance(named: name))
+            appearance.performAsCurrentDrawingAppearance {
+                for (choice, want) in expected {
+                    let got = choice.nsColor(customHex: nil).contrastingLabelColor
+                    #expect(got == want, "\(choice.rawValue) under \(name.rawValue)")
+                }
+            }
+        }
+        #expect(NSColor.white.contrastingLabelColor == .black)
+        #expect(NSColor.black.contrastingLabelColor == .white)
     }
 
     @Test("hex round-trips through the color and back")
@@ -65,12 +122,35 @@ struct SelectionColorTests {
     }
 
     @MainActor
-    @Test("the selection plate tints the accent without hiding the panel behind it")
-    func selectionFillIsTranslucent() {
-        let fill = SwitcherIconItemView.selectionFill(.systemPurple)
-        #expect(fill.alphaComponent < 1)
-        #expect(fill.alphaComponent > 0)
-        #expect(fill.usingColorSpace(.sRGB)?.redComponent
+    @Test("the tinted plate keeps the accent's hue without hiding the panel behind it")
+    func selectionPlateTinted() {
+        let plate = SwitcherIconItemView.selectionPlate(.systemPurple, neutral: false,
+                                                        dark: true, neutralLightFill: 0.30)
+        #expect(plate.fill.alphaComponent < 1)
+        #expect(plate.fill.alphaComponent > 0)
+        #expect(plate.fill.usingColorSpace(.sRGB)?.redComponent
                 == NSColor.systemPurple.usingColorSpace(.sRGB)?.redComponent)
+        // The rim is the hue at full strength — that is what carries the selection.
+        #expect(plate.rim == NSColor.systemPurple)
+    }
+
+    /// The neutral plate has no hue to lean on, so it has to lift in dark mode and
+    /// sink in light — and it must ignore the color entirely, or `.transparent`
+    /// would leak the accent it still hands to the letter hints.
+    @MainActor
+    @Test("the neutral plate drops the hue and flips direction with the appearance")
+    func selectionPlateNeutral() {
+        let dark = SwitcherIconItemView.selectionPlate(.systemPurple, neutral: true,
+                                                       dark: true, neutralLightFill: 0.30)
+        let light = SwitcherIconItemView.selectionPlate(.systemPurple, neutral: true,
+                                                        dark: false, neutralLightFill: 0.30)
+        #expect(dark.fill.usingColorSpace(.sRGB)?.redComponent == 1)
+        #expect(light.fill.usingColorSpace(.sRGB)?.redComponent == 0)
+        #expect(dark.rim.usingColorSpace(.sRGB)?.redComponent == 1)
+        #expect(light.rim.usingColorSpace(.sRGB)?.redComponent == 0)
+        // Window previews keep a lighter fill than the icon grid in light mode.
+        let preview = SwitcherIconItemView.selectionPlate(.systemPurple, neutral: true,
+                                                          dark: false, neutralLightFill: 0.10)
+        #expect(preview.fill.alphaComponent < light.fill.alphaComponent)
     }
 }

--- a/BetterCmdTabTests/SelectionColorTests.swift
+++ b/BetterCmdTabTests/SelectionColorTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+import Testing
+@testable import BetterCmdTab
+
+/// Covers the selection color (#185): which concrete color each choice resolves
+/// to, and the hex parsing/formatting behind the custom choice — the two places
+/// a bad value would silently paint the switcher the wrong color instead of
+/// failing loudly.
+@Suite("Selection color")
+struct SelectionColorTests {
+
+    @Test("fixed choices resolve to their own color, system and custom to the macOS accent")
+    func resolvedColors() {
+        #expect(SwitcherSelectionColor.blue.resolved == .systemBlue)
+        #expect(SwitcherSelectionColor.purple.resolved == .systemPurple)
+        #expect(SwitcherSelectionColor.graphite.resolved == .systemGray)
+        // `.custom` has no color of its own — the hex lives in Preferences, so
+        // resolving it here must fall back rather than invent one.
+        #expect(SwitcherSelectionColor.system.resolved == .controlAccentColor)
+        #expect(SwitcherSelectionColor.custom.resolved == .controlAccentColor)
+        #expect(SwitcherSelectionColor.system.color == nil)
+        #expect(SwitcherSelectionColor.custom.color == nil)
+    }
+
+    @Test("the stored raw values are stable and every case has a name")
+    func rawValuesAndNames() {
+        #expect(SwitcherSelectionColor(rawValue: "system") == .system)
+        #expect(SwitcherSelectionColor(rawValue: "custom") == .custom)
+        #expect(SwitcherSelectionColor(rawValue: "chartreuse") == nil)
+        for choice in SwitcherSelectionColor.allCases {
+            #expect(!choice.displayName.isEmpty)
+        }
+    }
+
+    @Test("hex parses with and without the leading hash, in 6 and 8 digits")
+    func hexParsing() throws {
+        let plain = try #require(NSColor(hexString: "FF8000"))
+        let hashed = try #require(NSColor(hexString: "#FF8000"))
+        #expect(plain.hexString == "#FF8000")
+        #expect(hashed.hexString == "#FF8000")
+        // Whitespace survives a paste out of a design tool.
+        #expect(NSColor(hexString: "  #ff8000\n")?.hexString == "#FF8000")
+
+        let withAlpha = try #require(NSColor(hexString: "#FF800080"))
+        #expect(abs(withAlpha.alphaComponent - 128.0 / 255.0) < 0.001)
+        // The 8-digit form keeps its RGB; only the alpha is extra.
+        #expect(withAlpha.hexString == "#FF8000")
+    }
+
+    @Test("malformed hex is rejected so callers fall back to the accent")
+    func hexRejectsGarbage() {
+        #expect(NSColor(hexString: "") == nil)
+        #expect(NSColor(hexString: "#FFF") == nil)          // 3-digit shorthand isn't supported
+        #expect(NSColor(hexString: "#FF80") == nil)
+        #expect(NSColor(hexString: "#GGGGGG") == nil)
+        #expect(NSColor(hexString: "rebeccapurple") == nil)
+    }
+
+    @Test("hex round-trips through the color and back")
+    func hexRoundTrip() throws {
+        for hex in ["#000000", "#FFFFFF", "#1D9BF0", "#7F3FBF"] {
+            let color = try #require(NSColor(hexString: hex))
+            #expect(color.hexString == hex)
+        }
+    }
+
+    @MainActor
+    @Test("the selection plate tints the accent without hiding the panel behind it")
+    func selectionFillIsTranslucent() {
+        let fill = SwitcherIconItemView.selectionFill(.systemPurple)
+        #expect(fill.alphaComponent < 1)
+        #expect(fill.alphaComponent > 0)
+        #expect(fill.usingColorSpace(.sRGB)?.redComponent
+                == NSColor.systemPurple.usingColorSpace(.sRGB)?.redComponent)
+    }
+}

--- a/docs/content/docs/en/configuration.mdx
+++ b/docs/content/docs/en/configuration.mdx
@@ -136,7 +136,7 @@ Some state is deliberately excluded, and neither exported nor imported:
 | `disabledSymbolicHotKeys` | A record of which native hotkeys *this* Mac has disabled — importing another Mac's copy could leave the native ⌘Tab dead |
 | `recentlyClosed` | Session history, not configuration |
 | `customCommitSoundFilename` | The sound file lives in this Mac's Application Support directory |
-| `accentChoice`, `customAccentHex` | Retired in 26.7 — the switcher always follows the macOS accent colour |
+| `accentChoice`, `customAccentHex` | Retired in 26.7 and replaced by `selectionColor` / `selectionColorHex`, which are exported normally |
 
 Scoped shortcuts are a middle case: `scopedShortcutList` records each entry's id, scope
 and name, but the chord itself is recorded outside this file. Syncing the file to a new

--- a/docs/content/docs/pl/configuration.mdx
+++ b/docs/content/docs/pl/configuration.mdx
@@ -147,7 +147,7 @@ Niektóre dane są celowo wykluczone i nie są ani eksportowane, ani importowane
 | `disabledSymbolicHotKeys` | Rejestr natywnych skrótów wyłączonych na *tym* Macu — import kopii z innego Maca mógłby trwale wyłączyć natywny ⌘Tab |
 | `recentlyClosed` | Historia sesji, a nie konfiguracja |
 | `customCommitSoundFilename` | Plik dźwiękowy znajduje się w katalogu Application Support tego Maca |
-| `accentChoice`, `customAccentHex` | Wycofane w 26.7 — przełącznik zawsze używa koloru akcentu macOS |
+| `accentChoice`, `customAccentHex` | Wycofane w 26.7 i zastąpione przez `selectionColor` / `selectionColorHex`, które są eksportowane normalnie |
 
 Skróty o ograniczonym zakresie są przypadkiem pośrednim: `scopedShortcutList` zapisuje
 identyfikator, zakres i nazwę każdej pozycji, ale sam skrót jest rejestrowany poza tym

--- a/docs/src/data/config-schema.json
+++ b/docs/src/data/config-schema.json
@@ -513,8 +513,9 @@
       "type" : "boolean"
     },
     "selectionColor" : {
-      "description" : "Color of the selection highlight and the quick-jump letters. \"system\" follows the macOS accent; \"custom\" uses selectionColorHex.",
+      "description" : "Color of the selection highlight and the quick-jump letters. \"transparent\" (the default) leaves the highlight colorless and tints only the quick-jump letters; \"system\" follows the macOS accent; \"custom\" uses selectionColorHex.",
       "enum" : [
+        "transparent",
         "system",
         "blue",
         "purple",
@@ -527,6 +528,7 @@
         "custom"
       ],
       "enumDescriptions" : [
+        "Transparent",
         "macOS accent",
         "Blue",
         "Purple",

--- a/docs/src/data/config-schema.json
+++ b/docs/src/data/config-schema.json
@@ -512,6 +512,39 @@
       "description" : "Include installed apps that aren't running, so search can launch them.",
       "type" : "boolean"
     },
+    "selectionColor" : {
+      "description" : "Color of the selection highlight and the quick-jump letters. \"system\" follows the macOS accent; \"custom\" uses selectionColorHex.",
+      "enum" : [
+        "system",
+        "blue",
+        "purple",
+        "pink",
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "graphite",
+        "custom"
+      ],
+      "enumDescriptions" : [
+        "macOS accent",
+        "Blue",
+        "Purple",
+        "Pink",
+        "Red",
+        "Orange",
+        "Yellow",
+        "Green",
+        "Graphite",
+        "Custom…"
+      ],
+      "type" : "string"
+    },
+    "selectionColorHex" : {
+      "description" : "Selection color used when selectionColor is \"custom\", as #RRGGBB. Falls back to the macOS accent when absent or malformed.",
+      "pattern" : "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$",
+      "type" : "string"
+    },
     "shiftTapStepsBackward" : {
       "description" : "Tap Shift while switching to step backwards.",
       "type" : "boolean"


### PR DESCRIPTION
Closes #185.

## What

One color now marks the selection across all three layouts: the plate fill behind the tile, its rim, and the characters of a jump letter you have already typed. The letters keep `labelColor` until you type them, so an untouched panel looks the way it does today.

The color follows the macOS accent by default. Appearance > Panel > Selection color pins it to a fixed color instead, with eight presets and a custom picker.

## Why

61c2aa6 set out to make the switcher always follow the macOS accent. That held for the List layout. Grid tiles and Window previews kept a neutral white/black plate, so on the default layout the accent never showed up at all, and #185 reports what falls out of that: with many windows open, you cannot tell which one is selected.

This PR makes that goal true across all three layouts, then adds the picker for the case the issue describes, an accent that disappears against a wallpaper.

## How

- New `selectionColor` and `selectionColorHex` preferences. `accentChoice` and `customAccentHex` stay retired and scrubbed at launch, so an old export cannot resurrect them.
- `EffectiveSettings` carries the resolved color and the item views tint fill and rim from it. No per-shortcut override.
- Export, import, `config.json` and the generated schema pick it up. Five translations added.
- Six tests for color resolution and hex parsing. Full suite passes at 623.

## Your call on two points

The default look changes for everyone on Grid and Previews. That is the fix, and it is still a visual change nobody opted into.

Grid tiles now draw a rim on macOS 26, where 9ac9e86 chose fill-only to match the native switcher. The tinted fill can carry the selection on its own if you prefer that.
