### PR TITLE
fix: exclude spaceless windows from narrowed Space scopes

### DIFF
--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -357,6 +357,19 @@ enum CatalogFilter {
         guard !spaces.allowedSpaces.isEmpty, !spaces.spaceByWindow.isEmpty else { return rows }
         var dropOffsets = Set<Int>()
         for (offset, row) in rows.enumerated() where row.cgWindowID != 0 {
+            // A confirmed-spaceless NSWindow has no desktop membership at all.
+            // Native AppKit background tabs have exactly this shape while
+            // tabbed away. Under a narrowed Space scope, never let an ordinary
+            // spaceless row leak into the switcher: activating it can cause
+            // macOS to materialize it on the currently visible Space.
+            //
+            // Explicit expanded-tab rows remain eligible because the user asked
+            // to surface native tabs individually.
+            if spaces.confirmedSpaceless.contains(row.cgWindowID), !row.isTabSibling {
+                dropOffsets.insert(offset)
+                continue
+            }
+
             if let space = spaces.spaceByWindow[row.cgWindowID], !spaces.allowedSpaces.contains(space) {
                 dropOffsets.insert(offset)
             }

--- a/BetterCmdTabTests/SpacelessSpaceFilterTests.swift
+++ b/BetterCmdTabTests/SpacelessSpaceFilterTests.swift
@@ -1,0 +1,54 @@
+import AppKit
+import CoreGraphics
+import Testing
+@testable import BetterCmdTab
+
+@Suite("Spaceless Space filtering")
+struct SpacelessSpaceFilterTests {
+
+    private func row(
+        _ wid: CGWindowID,
+        tabSibling: Bool = false
+    ) -> SwitcherRow {
+        SwitcherRow(
+            app: .current,
+            window: nil,
+            windowTitle: "",
+            isMinimized: false,
+            cgWindowID: wid,
+            isTabSibling: tabSibling
+        )
+    }
+
+    @Test("narrowed Space scope drops ordinary spaceless rows but keeps explicit tab siblings")
+    func dropsOrdinarySpacelessRows() {
+        let active: UInt64 = 100
+
+        let rows: [SwitcherRow] = [
+            row(10),
+            row(20),
+            row(30, tabSibling: true),
+        ]
+
+        let spaceByWindow: [CGWindowID: UInt64] = [
+            10: active,
+        ]
+
+        let spaceless: Set<CGWindowID> = [
+            20,
+            30,
+        ]
+
+        let resolution = CatalogFilter.SpaceResolution(
+            spaceByWindow: spaceByWindow,
+            confirmedSpaceless: spaceless,
+            onScreen: [10],
+            allowedSpaces: [active]
+        )
+
+        let kept = CatalogFilter.filterToAllowedSpaces(rows, resolution)
+        let keptIDs = kept.map { $0.cgWindowID }
+
+        #expect(keptIDs == [10, 30])
+    }
+}


### PR DESCRIPTION
## Summary

Prevent confirmed-spaceless windows from appearing as ordinary switcher rows when the Space scope is narrowed to Current Space or Visible Spaces.

Native AppKit background tabs (e.g. TextEdit / Preview) can remain real NSWindows while tabbed away, but WindowServer reports them as belonging to no Space. Previously, `filterToAllowedSpaces` kept these rows because it only rejected windows positively resolved to another Space.

If one of these background-tab windows is then selected by BetterCmdTab, activating it can cause macOS to materialize it on the currently visible Space.

The filter now drops confirmed-spaceless ordinary rows under a narrowed Space scope.

`isTabSibling` rows are deliberately exempt so "Expand native tabs as windows" continues to work as requested.

## Reproduction

1. Create native TextEdit tab groups on different Spaces.
2. Set BetterCmdTab to:
   - Show windows from: Current Space
   - Expand native tabs as windows: Off
3. Switch repeatedly between apps / Spaces with BetterCmdTab.
4. A tabbed-away TextEdit window can unexpectedly appear on the current Space.

## Testing

Manual A/B isolation:

- resolver change only: bug still reproduced
- resolver + activation guard: bug still reproduced
- resolver + activation guard + Space filter: fixed
- resolver + Space filter: fixed
- Space filter only: fixed

Regression test:

- without the fix: `[10, 20, 30]` is retained, incorrectly keeping the ordinary spaceless row
- with the fix: `[10, 30]`, while the explicit native-tab sibling remains available
