### PR TITLE
feat: add per-app window title exclusions

### DIFF
--- a/BetterCmdTab/App/ConfigSchemaDocs.swift
+++ b/BetterCmdTab/App/ConfigSchemaDocs.swift
@@ -42,8 +42,9 @@ struct ConfigValues: Sendable, ExpressibleByArrayLiteral {
 /// Element schema of an array setting — a scalar (optionally constrained to a
 /// set of values) or an object with typed properties. The stored dictionaries
 /// (`appExceptions`, `scopedShortcutList`, `shortcutOverrides`) are plists of
-/// `[String: String]`, so their *values* are the string forms of the types the
-/// app parses back out — that's what these describe.
+/// property-list dictionaries. Most values are string forms of the types the
+/// app parses back out; `appExceptions.windowTitleContains` is a nested string
+/// array.
 struct ConfigItemSchema: Sendable {
     let type: String
     let values: ConfigValues?
@@ -348,6 +349,9 @@ enum ConfigSchemaDocs {
                     "ignore": ConfigSettingDoc(
                         "string", "Whether the switcher shortcut is passed through to this app instead of opening the panel.",
                         values: ConfigValues(IgnoreShortcutsMode.self, \.displayName)),
+                    "windowTitleContains": ConfigSettingDoc(
+                        "array", "Case-insensitive title fragments. Matching windows are hidden while the app's other windows remain available.",
+                        item: ConfigItemSchema("string", pattern: ".+")),
                 ],
                 required: ["bundleID"])),
         "excludedBundleIDs": ConfigSettingDoc(

--- a/BetterCmdTab/App/Preferences.swift
+++ b/BetterCmdTab/App/Preferences.swift
@@ -744,31 +744,64 @@ enum IgnoreShortcutsMode: String, CaseIterable, Sendable {
 
 /// A per-app entry in the switcher's Exceptions list, identified by bundle ID.
 /// Carries the hide-windows and ignore-shortcuts overrides shown in the
-/// Exceptions editor. Persisted as a `[String: String]` dictionary so both the
+/// Exceptions editor. Persisted as a property-list dictionary so both the
 /// main-actor `Preferences` and the off-main `CatalogFilter` can read it.
 struct AppException: Equatable, Sendable {
     var bundleID: String
     var hide: HideWindowsMode
     var ignore: IgnoreShortcutsMode
+    /// Case-insensitive fragments. A window whose title contains any fragment
+    /// is omitted while other windows from the same app remain available.
+    var windowTitleContains: [String]
 
-    init(bundleID: String, hide: HideWindowsMode = .dontHide, ignore: IgnoreShortcutsMode = .never) {
+    init(
+        bundleID: String,
+        hide: HideWindowsMode = .dontHide,
+        ignore: IgnoreShortcutsMode = .never,
+        windowTitleContains: [String] = []
+    ) {
         self.bundleID = bundleID
         self.hide = hide
         self.ignore = ignore
+        self.windowTitleContains = Self.cleanedTitleFragments(windowTitleContains)
     }
 
     /// Plist-friendly representation for UserDefaults.
-    var dictionary: [String: String] {
-        ["bundleID": bundleID, "hide": hide.rawValue, "ignore": ignore.rawValue]
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "bundleID": bundleID,
+            "hide": hide.rawValue,
+            "ignore": ignore.rawValue,
+        ]
+        if !windowTitleContains.isEmpty {
+            result["windowTitleContains"] = windowTitleContains
+        }
+        return result
     }
 
     /// Parse one stored dictionary. Missing/unknown modes fall back to the
     /// neutral default so a half-written entry never silently drops the app.
-    init?(dictionary: [String: String]) {
-        guard let bid = dictionary["bundleID"], !bid.isEmpty else { return nil }
+    init?(dictionary: [String: Any]) {
+        guard let bid = dictionary["bundleID"] as? String, !bid.isEmpty else { return nil }
         self.bundleID = bid
-        self.hide = dictionary["hide"].flatMap(HideWindowsMode.init) ?? .dontHide
-        self.ignore = dictionary["ignore"].flatMap(IgnoreShortcutsMode.init) ?? .never
+        self.hide = (dictionary["hide"] as? String).flatMap(HideWindowsMode.init) ?? .dontHide
+        self.ignore = (dictionary["ignore"] as? String).flatMap(IgnoreShortcutsMode.init) ?? .never
+        self.windowTitleContains = Self.cleanedTitleFragments(dictionary["windowTitleContains"] as? [String] ?? [])
+    }
+
+    /// Trim, discard empty fragments, and deduplicate case-insensitively while
+    /// preserving the user's order for settings/config round-trips.
+    static func cleanedTitleFragments(_ fragments: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        result.reserveCapacity(fragments.count)
+        for fragment in fragments {
+            let trimmed = fragment.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let key = trimmed.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+            if seen.insert(key).inserted { result.append(trimmed) }
+        }
+        return result
     }
 }
 
@@ -2367,7 +2400,7 @@ final class Preferences: ObservableObject {
         // entries, and seed Finder to "show only with open windows". Persisted
         // immediately because `CatalogFilter` reads the new key from UserDefaults
         // off-main and never sees the legacy key.
-        if let stored = defaults.array(forKey: Keys.appExceptions) as? [[String: String]] {
+        if let stored = defaults.array(forKey: Keys.appExceptions) as? [[String: Any]] {
             self.appExceptions = stored.compactMap(AppException.init(dictionary:))
         } else {
             var initial = (defaults.stringArray(forKey: Keys.legacyExcludedBundleIDs) ?? [])
@@ -2523,7 +2556,7 @@ final class Preferences: ObservableObject {
         gridMaxColumns = defaults.object(forKey: Keys.gridMaxColumns) as? Int ?? 0
         gridSingleRow = defaults.object(forKey: Keys.gridSingleRow) as? Bool ?? true
 
-        if let stored = defaults.array(forKey: Keys.appExceptions) as? [[String: String]] {
+        if let stored = defaults.array(forKey: Keys.appExceptions) as? [[String: Any]] {
             appExceptions = stored.compactMap(AppException.init(dictionary:))
         } else {
             appExceptions = []

--- a/BetterCmdTab/Catalog/CatalogFilter.swift
+++ b/BetterCmdTab/Catalog/CatalogFilter.swift
@@ -16,6 +16,9 @@ enum CatalogFilter {
         /// hide something are stored — a `.dontHide` exception is neutral and
         /// omitted, so an absent key means "apply the global toggles".
         let hideModes: [String: HideWindowsMode]
+        /// Pre-folded, non-empty title fragments keyed by bundle ID. Empty for
+        /// the common case, keeping the row-filter hot path allocation-free.
+        let excludedTitleFragments: [String: [String]]
         let pinned: [String]
         let showMinimized: Bool
         let showHidden: Bool
@@ -35,23 +38,28 @@ enum CatalogFilter {
 
         /// No filtering and no reordering — lets callers skip work entirely.
         var isIdentity: Bool {
-            hideModes.isEmpty && pinned.isEmpty && showMinimized && showHidden && showWindowless && spaceScope == .allSpaces && sortOrder == .mru
+            hideModes.isEmpty && excludedTitleFragments.isEmpty && pinned.isEmpty && showMinimized && showHidden && showWindowless && spaceScope == .allSpaces && sortOrder == .mru
         }
     }
 
     nonisolated static func config() -> Config {
         let defaults = UserDefaults.standard
         var hideModes: [String: HideWindowsMode] = [:]
-        if let raw = defaults.array(forKey: Preferences.Keys.appExceptions) as? [[String: String]] {
+        var excludedTitleFragments: [String: [String]] = [:]
+        if let raw = defaults.array(forKey: Preferences.Keys.appExceptions) as? [[String: Any]] {
             for entry in raw {
-                guard let bid = entry["bundleID"], !bid.isEmpty else { continue }
-                let mode = entry["hide"].flatMap(HideWindowsMode.init) ?? .dontHide
+                guard let bid = entry["bundleID"] as? String, !bid.isEmpty else { continue }
+                let mode = (entry["hide"] as? String).flatMap(HideWindowsMode.init) ?? .dontHide
                 if mode != .dontHide { hideModes[bid] = mode }
+                let fragments = AppException.cleanedTitleFragments(entry["windowTitleContains"] as? [String] ?? [])
+                    .map { $0.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil) }
+                if !fragments.isEmpty { excludedTitleFragments[bid] = fragments }
             }
         }
         let sortRaw = defaults.string(forKey: Preferences.Keys.sortOrder)
         return Config(
             hideModes: hideModes,
+            excludedTitleFragments: excludedTitleFragments,
             pinned: defaults.stringArray(forKey: Preferences.Keys.pinnedBundleIDs) ?? [],
             showMinimized: defaults.object(forKey: Preferences.Keys.showMinimizedWindows) as? Bool ?? true,
             showHidden: defaults.object(forKey: Preferences.Keys.showHiddenApps) as? Bool ?? true,
@@ -71,6 +79,7 @@ enum CatalogFilter {
     static func overlay(_ base: Config, _ ov: ShortcutOverride) -> Config {
         Config(
             hideModes: base.hideModes,
+            excludedTitleFragments: base.excludedTitleFragments,
             pinned: base.pinned,
             showMinimized: ov.showMinimized ?? base.showMinimized,
             showHidden: ov.showHidden ?? base.showHidden,
@@ -106,11 +115,12 @@ enum CatalogFilter {
         // never-shown helper windows the user can't reach (not a preference), so
         // they're removed even under an identity config that skips the rest.
         let phantomFiltered = filterPhantomWindows(rows, spaces)
-        if cfg.isIdentity { return phantomFiltered }
+        let titleFiltered = filterExcludedWindowTitles(phantomFiltered, cfg.excludedTitleFragments)
+        if cfg.isIdentity { return titleFiltered }
         // Flags rather than a filter: a rescued row has to slot back in at its
         // original index so MRU order survives. Only reached on a non-identity
         // config — the default reveal returned above.
-        var kept = phantomFiltered.map {
+        var kept = titleFiltered.map {
             includes(bundleID: $0.bundleIdentifier, isPlaceholder: $0.isPlaceholder, isMinimized: $0.isMinimized, appHidden: $0.isHidden, hasWindow: $0.window != nil, cfg)
         }
         // An app can lose *every* row to the minimized/hidden window drops while
@@ -121,16 +131,16 @@ enum CatalogFilter {
         // unreachable (#168). Re-admit one row per stranded app.
         if cfg.showWindowless, !cfg.showMinimized || !cfg.showHidden {
             for index in strandedAppIndices(
-                pids: phantomFiltered.map(\.pid),
+                pids: titleFiltered.map(\.pid),
                 kept: kept,
-                rescuable: phantomFiltered.map {
+                rescuable: titleFiltered.map {
                     admittedByAppRules(bundleID: $0.bundleIdentifier, hasWindow: $0.window != nil, cfg)
                 }
             ) {
                 kept[index] = true
             }
         }
-        var filtered = phantomFiltered.indices.compactMap { kept[$0] ? phantomFiltered[$0] : nil }
+        var filtered = titleFiltered.indices.compactMap { kept[$0] ? titleFiltered[$0] : nil }
         if cfg.sortOrder != .mru {
             filtered = applySortOrder(filtered, cfg.sortOrder, name: { $0.appName }, pid: { $0.pid })
         }
@@ -139,6 +149,25 @@ enum CatalogFilter {
             filtered = filterToAllowedSpaces(filtered, spaces)
         }
         return filtered
+    }
+
+    /// Apply app-scoped, case/diacritic-insensitive title exclusions. The
+    /// dictionary is empty for users without rules, so the common path returns
+    /// the original array without inspecting or folding any title.
+    static func filterExcludedWindowTitles(
+        _ rows: [SwitcherRow],
+        _ fragmentsByBundleID: [String: [String]]
+    ) -> [SwitcherRow] {
+        guard !fragmentsByBundleID.isEmpty else { return rows }
+        return rows.filter { row in
+            guard row.window != nil,
+                  !row.windowTitle.isEmpty,
+                  let bundleID = row.bundleIdentifier,
+                  let fragments = fragmentsByBundleID[bundleID],
+                  !fragments.isEmpty else { return true }
+            let title = row.windowTitle.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+            return !fragments.contains { title.contains($0) }
+        }
     }
 
     /// Whether this reveal needs any WindowServer Space resolution. A narrowing

--- a/BetterCmdTab/Localizable.xcstrings
+++ b/BetterCmdTab/Localizable.xcstrings
@@ -410,6 +410,40 @@
         }
       }
     },
+    "Add title fragments…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titelfragmente hinzufügen…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir fragmentos de título…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter des fragments de titre…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaj fragmenty tytułu…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加标题片段…"
+          }
+        }
+      }
+    },
     "All" : {
       "localizations" : {
         "de" : {
@@ -4594,6 +4628,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏所有应用以显示桌面。全系统生效。"
+          }
+        }
+      }
+    },
+    "Hide only windows whose title contains one of these phrases. Matching ignores capitalization and accents; the app's other windows remain available. Press Return or type a comma after each phrase." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blende nur Fenster aus, deren Titel einen dieser Ausdrücke enthält. Groß-/Kleinschreibung und Akzente werden beim Abgleich ignoriert; andere Fenster der App bleiben verfügbar. Drücke nach jedem Ausdruck die Eingabetaste oder gib ein Komma ein."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oculta solo las ventanas cuyo título contenga una de estas frases. La coincidencia ignora mayúsculas, minúsculas y acentos; las demás ventanas de la app siguen disponibles. Pulsa Retorno o escribe una coma después de cada frase."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquez uniquement les fenêtres dont le titre contient l’une de ces expressions. La correspondance ignore la casse et les accents ; les autres fenêtres de l’app restent disponibles. Appuyez sur Retour ou saisissez une virgule après chaque expression."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukrywaj tylko okna, których tytuł zawiera jeden z tych zwrotów. Dopasowanie ignoruje wielkość liter i znaki diakrytyczne; pozostałe okna aplikacji nadal są dostępne. Po każdym zwrocie naciśnij Return lub wpisz przecinek."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅隐藏标题中包含任一词组的窗口。匹配时忽略大小写和重音符号；该应用的其他窗口仍可使用。每个词组后按 Return 键或输入逗号。"
+          }
+        }
+      }
+    },
+    "Hide titles containing" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel ausblenden mit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar títulos que contengan"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer les titres contenant"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukryj tytuły zawierające"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏标题包含"
           }
         }
       }

--- a/BetterCmdTab/Settings/AppRuleRow.swift
+++ b/BetterCmdTab/Settings/AppRuleRow.swift
@@ -11,7 +11,7 @@ final class AppRuleRowView: NSView {
     let bundleID: String
 
     /// Fired after either popup changes, with the row's new modes.
-    var onChange: ((HideWindowsMode, IgnoreShortcutsMode) -> Void)?
+    var onChange: ((HideWindowsMode, IgnoreShortcutsMode, [String]) -> Void)?
     /// Fired when the remove button is clicked.
     var onRemove: (() -> Void)?
 
@@ -19,9 +19,11 @@ final class AppRuleRowView: NSView {
     private let shortcutOptions: [(mode: IgnoreShortcutsMode, title: String)]
     private var hide: HideWindowsMode
     private var ignore: IgnoreShortcutsMode
+    private var windowTitleContains: [String]
 
     private let showPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let shortcutPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let titleTokens = NSTokenField()
     private let iconView = NSImageView()
     private let nameLabel = NSTextField(labelWithString: "")
 
@@ -38,12 +40,14 @@ final class AppRuleRowView: NSView {
         icon: NSImage,
         hide: HideWindowsMode,
         ignore: IgnoreShortcutsMode,
+        windowTitleContains: [String],
         showOptions: [(mode: HideWindowsMode, title: String)],
         shortcutOptions: [(mode: IgnoreShortcutsMode, title: String)]
     ) {
         self.bundleID = bundleID
         self.hide = hide
         self.ignore = ignore
+        self.windowTitleContains = windowTitleContains
         self.showOptions = showOptions
         self.shortcutOptions = shortcutOptions
         super.init(frame: .zero)
@@ -72,6 +76,16 @@ final class AppRuleRowView: NSView {
         configure(shortcutPopup, titles: shortcutOptions.map(\.title), selected: shortcutOptions.firstIndex { $0.mode == ignore } ?? 0, action: #selector(shortcutChanged))
         shortcutPopup.toolTip = String(localized: "Pass ⌘Tab through to the app instead of opening the switcher — for apps with their own window switching (virtual machines, remote desktop, some games).")
 
+        titleTokens.controlSize = .small
+        titleTokens.font = .systemFont(ofSize: 11)
+        titleTokens.placeholderString = String(localized: "Add title fragments…")
+        titleTokens.objectValue = windowTitleContains
+        titleTokens.tokenizingCharacterSet = CharacterSet(charactersIn: ",\n")
+        titleTokens.target = self
+        titleTokens.action = #selector(titleTokensChanged)
+        titleTokens.translatesAutoresizingMaskIntoConstraints = false
+        titleTokens.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
         let removeButton = NSButton()
         removeButton.isBordered = false
         removeButton.bezelStyle = .accessoryBarAction
@@ -88,17 +102,26 @@ final class AppRuleRowView: NSView {
         let showGroup = captionedControl(String(localized: "Show"), info: Self.showInfo, showPopup)
         let shortcutGroup = captionedControl("⌘Tab", info: Self.shortcutInfo, shortcutPopup)
 
-        let stack = NSStackView(views: [iconView, nameLabel, NSView(), showGroup, shortcutGroup, removeButton])
-        stack.orientation = .horizontal
-        stack.alignment = .centerY
-        stack.spacing = 10
-        stack.setCustomSpacing(14, after: showGroup)
+        let top = NSStackView(views: [iconView, nameLabel, NSView(), showGroup, shortcutGroup, removeButton])
+        top.orientation = .horizontal
+        top.alignment = .centerY
+        top.spacing = 10
+        top.setCustomSpacing(14, after: showGroup)
+
+        let titleGroup = captionedControl(String(localized: "Hide titles containing"), info: Self.titleInfo, titleTokens)
+        let stack = NSStackView(views: [top, titleGroup])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
 
         NSLayoutConstraint.activate([
             iconView.widthAnchor.constraint(equalToConstant: 26),
             iconView.heightAnchor.constraint(equalToConstant: 26),
+            top.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            titleGroup.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            titleTokens.widthAnchor.constraint(greaterThanOrEqualToConstant: 180),
             stack.topAnchor.constraint(equalTo: topAnchor, constant: 3),
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3),
             stack.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -144,6 +167,8 @@ final class AppRuleRowView: NSView {
         String(localized: "Controls whether this app shows up in the switcher.\n\n• Always — always listed.\n• With open windows — listed only while it has at least one open window.\n• Never — never listed (hidden from the switcher).")
     private static let shortcutInfo =
         String(localized: "Lets the app keep ⌘Tab for itself: the chord is passed through to the app instead of opening the switcher. Useful for apps with their own window switching — virtual machines, remote desktop, some games.\n\n• Never — the switcher always opens.\n• Always — the app keeps ⌘Tab whenever it's focused.\n• In full screen — only while the app is in full screen.")
+    private static let titleInfo =
+        String(localized: "Hide only windows whose title contains one of these phrases. Matching ignores capitalization and accents; the app's other windows remain available. Press Return or type a comma after each phrase.")
 
     // MARK: - Actions
 
@@ -151,14 +176,30 @@ final class AppRuleRowView: NSView {
         let idx = showPopup.indexOfSelectedItem
         guard showOptions.indices.contains(idx) else { return }
         hide = showOptions[idx].mode
-        onChange?(hide, ignore)
+        notifyChange()
     }
 
     @objc private func shortcutChanged() {
         let idx = shortcutPopup.indexOfSelectedItem
         guard shortcutOptions.indices.contains(idx) else { return }
         ignore = shortcutOptions[idx].mode
-        onChange?(hide, ignore)
+        notifyChange()
+    }
+
+    @objc private func titleTokensChanged() {
+        let raw: [String]
+        if let tokens = titleTokens.objectValue as? [String] {
+            raw = tokens
+        } else {
+            raw = titleTokens.stringValue.components(separatedBy: titleTokens.tokenizingCharacterSet)
+        }
+        windowTitleContains = AppException.cleanedTitleFragments(raw)
+        titleTokens.objectValue = windowTitleContains
+        notifyChange()
+    }
+
+    private func notifyChange() {
+        onChange?(hide, ignore, windowTitleContains)
     }
 
     @objc private func removeClicked() {

--- a/BetterCmdTab/Settings/AppsSettingsViewController.swift
+++ b/BetterCmdTab/Settings/AppsSettingsViewController.swift
@@ -171,12 +171,18 @@ final class AppsSettingsViewController: SettingsTabViewController {
             icon: placeholderIcon,
             hide: exception.hide,
             ignore: exception.ignore,
+            windowTitleContains: exception.windowTitleContains,
             showOptions: showOptions,
             shortcutOptions: shortcutOptions
         )
         let bundleID = exception.bundleID
-        row.onChange = { [weak self] hide, ignore in
-            self?.updateRule(bundleID: bundleID, hide: hide, ignore: ignore)
+        row.onChange = { [weak self] hide, ignore, windowTitleContains in
+            self?.updateRule(
+                bundleID: bundleID,
+                hide: hide,
+                ignore: ignore,
+                windowTitleContains: windowTitleContains
+            )
         }
         row.onRemove = { [weak self] in
             self?.removeRule(bundleID: bundleID)
@@ -190,10 +196,16 @@ final class AppsSettingsViewController: SettingsTabViewController {
         return row
     }
 
-    private func updateRule(bundleID: String, hide: HideWindowsMode, ignore: IgnoreShortcutsMode) {
+    private func updateRule(
+        bundleID: String,
+        hide: HideWindowsMode,
+        ignore: IgnoreShortcutsMode,
+        windowTitleContains: [String]
+    ) {
         guard let idx = exceptions.firstIndex(where: { $0.bundleID == bundleID }) else { return }
         exceptions[idx].hide = hide
         exceptions[idx].ignore = ignore
+        exceptions[idx].windowTitleContains = AppException.cleanedTitleFragments(windowTitleContains)
         persist()
     }
 

--- a/BetterCmdTabTests/CatalogFilterTests.swift
+++ b/BetterCmdTabTests/CatalogFilterTests.swift
@@ -19,7 +19,7 @@ struct CatalogFilterTests {
         sinkMinimizedWindows: Bool = true
     ) -> CatalogFilter.Config {
         CatalogFilter.Config(
-            hideModes: hideModes, pinned: pinned,
+            hideModes: hideModes, excludedTitleFragments: [:], pinned: pinned,
             showMinimized: showMinimized, showHidden: showHidden, showWindowless: showWindowless,
             spaceScope: spaceScope, sortOrder: sortOrder, sinkHiddenApps: sinkHiddenApps,
             sinkMinimizedWindows: sinkMinimizedWindows)
@@ -74,6 +74,34 @@ struct CatalogFilterTests {
         let cfg = config(hideModes: ["com.x": .dontHide], showMinimized: false)
         #expect(!CatalogFilter.includes(bundleID: "com.x", isPlaceholder: false, isMinimized: true, appHidden: false, cfg))
         #expect(CatalogFilter.includes(bundleID: "com.x", isPlaceholder: false, isMinimized: false, appHidden: false, cfg))
+    }
+
+    @Test("window-title exclusions are app-scoped and case/diacritic insensitive")
+    func windowTitleExclusions() {
+        let app = NSRunningApplication.current
+        let ownBundleID = app.bundleIdentifier ?? ""
+        let rows = [
+            SwitcherRow(app: app, window: AXUIElementCreateSystemWide(), windowTitle: "Picture-in-Picture", isMinimized: false),
+            SwitcherRow(app: app, window: AXUIElementCreateSystemWide(), windowTitle: "RéSUMé — Draft", isMinimized: false),
+            SwitcherRow(app: app, window: AXUIElementCreateSystemWide(), windowTitle: "Main document", isMinimized: false),
+        ]
+        let filtered = CatalogFilter.filterExcludedWindowTitles(
+            rows,
+            [ownBundleID: ["picture-in-picture", "resume"]]
+        )
+        #expect(filtered.map(\.windowTitle) == ["Main document"])
+    }
+
+    @Test("title exclusions preserve windowless rows and other apps")
+    func windowTitleExclusionsStayScoped() {
+        let app = NSRunningApplication.current
+        let ownBundleID = app.bundleIdentifier ?? ""
+        let windowless = SwitcherRow(app: app, window: nil, windowTitle: "", isMinimized: false)
+        let titled = SwitcherRow(app: app, window: AXUIElementCreateSystemWide(), windowTitle: "Inspector", isMinimized: false)
+        #expect(CatalogFilter.filterExcludedWindowTitles([windowless, titled], ["com.other": ["inspector"]]).count == 2)
+        let filtered = CatalogFilter.filterExcludedWindowTitles([windowless, titled], [ownBundleID: ["inspector"]])
+        #expect(filtered.count == 1)
+        #expect(filtered[0].window == nil)
     }
 
     @Test("placeholders are always kept, even when hidden")

--- a/BetterCmdTabTests/PreferencesEnumTests.swift
+++ b/BetterCmdTabTests/PreferencesEnumTests.swift
@@ -285,12 +285,24 @@ struct PreferencesEnumTests {
 
     @Test("AppException round-trips through its stored dictionary")
     func appExceptionDictionary() {
-        let original = AppException(bundleID: "com.x", hide: .whenNoWindows, ignore: .whenFullscreen)
+        let original = AppException(
+            bundleID: "com.x",
+            hide: .whenNoWindows,
+            ignore: .whenFullscreen,
+            windowTitleContains: ["Picture-in-Picture", " Inspector ", "picture-in-picture"]
+        )
+        #expect(original.windowTitleContains == ["Picture-in-Picture", "Inspector"])
         #expect(AppException(dictionary: original.dictionary) == original)
 
         // Missing modes fall back to the neutral defaults.
         let partial = AppException(dictionary: ["bundleID": "com.y"])
         #expect(partial == AppException(bundleID: "com.y", hide: .dontHide, ignore: .never))
+
+        let malformedTitles = AppException(dictionary: [
+            "bundleID": "com.z",
+            "windowTitleContains": ["", "   ", "Résumé", "resume"],
+        ])
+        #expect(malformedTitles?.windowTitleContains == ["Résumé"])
 
         // No bundle ID → no exception.
         #expect(AppException(dictionary: ["hide": "always"]) == nil)

--- a/BetterCmdTabTests/SettingsPortabilityTests.swift
+++ b/BetterCmdTabTests/SettingsPortabilityTests.swift
@@ -846,6 +846,9 @@ struct SettingsPortabilityTests {
         #expect(rule["additionalProperties"] as? Bool == false)
         #expect(ruleProperties["hide"]?["enum"] as? [String] == HideWindowsMode.allCases.map(\.rawValue))
         #expect(ruleProperties["ignore"]?["enum"] as? [String] == IgnoreShortcutsMode.allCases.map(\.rawValue))
+        let titleFragments = try #require(ruleProperties["windowTitleContains"])
+        #expect(titleFragments["type"] as? String == "array")
+        #expect((titleFragments["items"] as? [String: Any])?["type"] as? String == "string")
 
         // Overrides are a plist [String: String]: every value is the *string*
         // form of the global setting, and unknown keys are carried through.

--- a/BetterCmdTabTests/ShortcutOverrideTests.swift
+++ b/BetterCmdTabTests/ShortcutOverrideTests.swift
@@ -169,6 +169,7 @@ struct ShortcutOverrideTests {
     ) -> CatalogFilter.Config {
         CatalogFilter.Config(
             hideModes: ["com.example.app": .always],
+            excludedTitleFragments: ["com.example.app": ["picture-in-picture"]],
             pinned: ["com.example.pin"],
             showMinimized: showMinimized,
             showHidden: true,
@@ -200,6 +201,7 @@ struct ShortcutOverrideTests {
         #expect(result.showMinimized == base.showMinimized)
         #expect(result.sortOrder == base.sortOrder)
         #expect(result.hideModes == base.hideModes)
+        #expect(result.excludedTitleFragments == base.excludedTitleFragments)
         #expect(result.pinned == base.pinned)
     }
 
@@ -230,7 +232,7 @@ struct ShortcutOverrideTests {
     @Test("overlaying an empty override preserves an identity config")
     func overlayKeepsIdentity() {
         let identity = CatalogFilter.Config(
-            hideModes: [:], pinned: [], showMinimized: true, showHidden: true, showWindowless: true,
+            hideModes: [:], excludedTitleFragments: [:], pinned: [], showMinimized: true, showHidden: true, showWindowless: true,
             spaceScope: .allSpaces, sortOrder: .mru, sinkHiddenApps: true, sinkMinimizedWindows: true)
         #expect(identity.isIdentity)
         #expect(CatalogFilter.overlay(identity, ShortcutOverride()).isIdentity)

--- a/docs/src/data/config-schema.json
+++ b/docs/src/data/config-schema.json
@@ -48,6 +48,14 @@
               "When fullscreen"
             ],
             "type" : "string"
+          },
+          "windowTitleContains" : {
+            "description" : "Case-insensitive title fragments. Matching windows are hidden while the app's other windows remain available.",
+            "items" : {
+              "pattern" : ".+",
+              "type" : "string"
+            },
+            "type" : "array"
           }
         },
         "required" : [


### PR DESCRIPTION
## Summary

- add a **Hide titles containing** field to each app rule
- hide matching windows without hiding other windows from the same app
- match title fragments case- and diacritic-insensitively
- include the new rule in saved preferences and the generated config schema

## Why

App rules can currently hide an entire app, but they cannot exclude one utility window such as Firefox Picture-in-Picture. This adds the narrower filter requested in #176.

## Testing

- ran the full `BetterCmdTab Debug` test suite with `xcodebuild`
- added tests for app scoping, case and diacritic handling, preference round-trips, and schema output

Closes #176